### PR TITLE
Fix metrics examples

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           version: v3.6.3
       - name: Build deps
         run: |
-          make deps
+          make build-deps
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.2.1
         with:

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,17 @@
 CHARTS := $(shell dirname `find . -name Chart.yaml`)
 
-.PHONY: deps
-deps:
+.PHONY: update-deps
+update-deps:
+	@for chart in $(CHARTS); do \
+		helm dependency update $$chart; \
+	done
+
+.PHONY: build-deps
+build-deps:
 	helm repo add grafana https://grafana.github.io/helm-charts
 	helm repo add fluent https://fluent.github.io/helm-charts
 	helm repo add otel https://open-telemetry.github.io/opentelemetry-helm-charts
 	helm repo update
 	@for chart in $(CHARTS); do \
-		helm dependency update --skip-refresh $$chart; \
+		helm dependency build --skip-refresh $$chart; \
 	done

--- a/Makefile
+++ b/Makefile
@@ -7,5 +7,5 @@ deps:
 	helm repo add otel https://open-telemetry.github.io/opentelemetry-helm-charts
 	helm repo update
 	@for chart in $(CHARTS); do \
-		helm dependency build --skip-refresh $$chart; \
+		helm dependency update --skip-refresh $$chart; \
 	done

--- a/charts/stack/Chart.lock
+++ b/charts/stack/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 0.1.1
 - name: events
   repository: file://../internal/events
-  version: 0.1.3
-digest: sha256:0e6884b5635a64d4a88b14f237de1bd34643c4475fd79207ddf379fc52122003
-generated: "2023-05-04T13:10:02.025368-07:00"
+  version: 0.1.4
+digest: sha256:813c50f5a49a0461c74d1e5a314be608c2aca1e1c844be4664d991fba1acac88
+generated: "2023-06-06T17:32:53.775948-07:00"

--- a/examples/stack/values-l.yaml
+++ b/examples/stack/values-l.yaml
@@ -20,11 +20,12 @@ logs:
       mem_buf_limit: 20MB
 
 metrics:
-  agent:
-    resources:
-      limits:
-        cpu: 500m
-        memory: 4Gi
-      requests:
-        cpu: 500m
-        memory: 4Gi
+  grafana-agent:
+    agent:
+      resources:
+        limits:
+          cpu: 500m
+          memory: 4Gi
+        requests:
+          cpu: 500m
+          memory: 4Gi

--- a/examples/stack/values-m.yaml
+++ b/examples/stack/values-m.yaml
@@ -20,11 +20,12 @@ logs:
       mem_buf_limit: 10MB
 
 metrics:
-  agent:
-    resources:
-      limits:
-        cpu: 250m
-        memory: 2Gi
-      requests:
-        cpu: 250m
-        memory: 2Gi
+  grafana-agent:
+    agent:
+      resources:
+        limits:
+          cpu: 250m
+          memory: 2Gi
+        requests:
+          cpu: 250m
+          memory: 2Gi

--- a/examples/stack/values-xl.yaml
+++ b/examples/stack/values-xl.yaml
@@ -20,28 +20,29 @@ logs:
       mem_buf_limit: 30MB
 
 metrics:
-  controller:
-    type: daemonset
-    updateStrategy:
-      type: RollingUpdate
-      rollingUpdate:
-        maxUnavailable: "20%"
-    tolerations:
-      - operator: Exists
-    affinity:
-      nodeAffinity:
-        requiredDuringSchedulingIgnoredDuringExecution:
-          nodeSelectorTerms:
-            - matchExpressions:
-                - {key: observeinc.com/unschedulable, operator: DoesNotExist}
-                - {key: eks.amazonaws.com/compute-type, operator: NotIn, values: [fargate]}
-                - {key: kubernetes.io/os, operator: NotIn, values: [windows]}
+  grafana-agent:
+    controller:
+      type: daemonset
+      updateStrategy:
+        type: RollingUpdate
+        rollingUpdate:
+          maxUnavailable: "20%"
+      tolerations:
+        - operator: Exists
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - {key: observeinc.com/unschedulable, operator: DoesNotExist}
+                  - {key: eks.amazonaws.com/compute-type, operator: NotIn, values: [fargate]}
+                  - {key: kubernetes.io/os, operator: NotIn, values: [windows]}
 
-  agent:
-    resources:
-      limits:
-        cpu: 200m
-        memory: 1Gi
-      requests:
-        cpu: 200m
-        memory: 1Gi
+    agent:
+      resources:
+        limits:
+          cpu: 200m
+          memory: 1Gi
+        requests:
+          cpu: 200m
+          memory: 1Gi

--- a/examples/stack/values-xs.yaml
+++ b/examples/stack/values-xs.yaml
@@ -20,11 +20,12 @@ logs:
       mem_buf_limit: 5MB
 
 metrics:
-  agent:
-    resources:
-      limits:
-        cpu: 50m
-        memory: 256Mi
-      requests:
-        cpu: 50m
-        memory: 256Mi
+  grafana-agent:
+    agent:
+      resources:
+        limits:
+          cpu: 50m
+          memory: 256Mi
+        requests:
+          cpu: 50m
+          memory: 256Mi


### PR DESCRIPTION
The stack example files did not correctly set grafana-agent values. Fix by namespacing them correctly.

This change also updates the stack chart lock file, which was not correctly updated in the previous change. The command used to accomplish this was also added to the Makefile.