### PR TITLE
feat: use observe endpoint to auto-configure scheme/host/port/customerID 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Observe Helm Charts
 
-This repository contains Helm charts for installing the telemetry agents required for Observe Kubernetes apps.
+This repository contains Helm charts for installing the telemetry agents required for Observe apps on Kubernetes.
 
 Contents:
 * stack: Installs several agents required for the Kubernetes Observe app
@@ -19,19 +19,23 @@ helm repo update
 ```
 
 ## Required Values
-You must set `global.observe.customer`. To have Helm create a Kubernetes secret containing your
-datastream token, you must also set `observe.token.value`. Otherwise, you must set `observe.token.create`
-to `false`, and manually create the secrets (see [Managing Secrets Manually](#managing-secrets-manually)).
+You must set `global.observe.collectionEndpoint`, which is provided when configuring a connection in
+Observe. To have Helm create a Kubernetes secret containing your datastream token, you must also set
+`observe.token.value`. Otherwise, you must set `observe.token.create` to `false`, and manually create
+the secrets (see [Managing Secrets Manually](#managing-secrets-manually)).
 
 These values can be set in a custom values file:
 
 ```yaml
 global:
   observe:
-    customer: "123456789012"
+    # A unique URL associated with your customer ID, provided in the new connection installation instructions.
+    collectionEndpoint: "https://123456789012.collect.observeinc.com"
 
 observe:
   token:
+    # The Datastream token. This will typically be unique to each chart being installed, or each release of
+    # of a chart.
     value: <datastream token>
 ```
 
@@ -73,8 +77,8 @@ helm install --namespace=observe --create-namespace \
 
 # installing by setting values on the command line
 helm install --namespace=observe --create-namespace \
-  --set-json 'global.observe.customerID="123456789012"' \
-  --set-json 'observe.token.value="..."' \
+  --set global.observe.collectionEndpoint="..." \
+  --set observe.token.value="..." \
   observe-stack observe/stack
 ```
 
@@ -86,8 +90,8 @@ helm install --namespace=observe --create-namespace \
 
 # installing by setting values on the command line
 helm install --namespace=observe --create-namespace \
-  --set-json 'global.observe.customer="123456789012"' \
-  --set-json 'observe.token.value="..."' \
+  --set global.observe.collectionEndpoint="..." \
+  --set observe.token.value="..." \
   observe-stack observe/traces
 ```
 
@@ -102,11 +106,11 @@ Then, ensure a secret exists in the observe namespace with the correct name:
 ## Stack
 
 ```bash
-kubectl -n observe create secret generic credentials --from-literal='OBSERVE_TOKEN=<datastream token>'
+kubectl -n observe create secret generic credentials --from-literal='OBSERVE_TOKEN=<kubernetes datastream token>'
 ```
 
 ## Traces
 
 ```bash
-kubectl -n observe create secret generic otel-credentials --from-literal='OBSERVE_TOKEN=<datastream token>'
+kubectl -n observe create secret generic otel-credentials --from-literal='OBSERVE_TOKEN=<opentelemetry datastream token>'
 ```

--- a/charts/internal/endpoint/Chart.yaml
+++ b/charts/internal/endpoint/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: endpoint
+description: Observe collection endpoint utility functions
+type: library
+version: 0.1.0

--- a/charts/internal/endpoint/templates/_address.tpl
+++ b/charts/internal/endpoint/templates/_address.tpl
@@ -1,0 +1,87 @@
+# If a collection endpoint is provided, use that.
+# Otherwise, generate the endpoint using the legacy values.
+{{- define "observe.collectionEndpoint" -}}{{- with .Values.global.observe -}}
+    {{- if .collectionEndpoint -}}
+        {{- .collectionEndpoint -}}
+    {{- else -}}
+        {{- $noEndpoint := "One of global.observe.collectionEndpoint or global.observe.customer must be defined" -}}
+        {{- printf "%s://%s.%s:%s" .collectorScheme (required $noEndpoint .customer | toString) .collectorHost (.collectorPort | toString) -}}
+    {{- end -}}
+{{- end -}}{{- end -}}
+
+# Same as "observe.collectionEndpoint", but with the token provided as part of the URL.
+{{- define "observe.collectionEndpointWithToken" -}}{{- with .Values.global.observe -}}
+    {{- if .collectionEndpoint -}}
+        {{- with urlParse .collectionEndpoint -}}
+            {{- printf "%s://$(OBSERVE_TOKEN)@%s" .scheme .host -}}
+        {{- end -}}
+    {{- else -}}
+        {{- $noEndpoint := "One of global.observe.collectionEndpoint or global.observe.customer must be defined" -}}
+        {{- printf "%s://$(OBSERVE_TOKEN)@%s.%s:%s" .collectorScheme (required $noEndpoint .customer | toString) .collectorHost (.collectorPort | toString) -}}
+    {{- end -}}
+{{- end -}}{{- end -}}
+
+# If a collection endpoint is provided, parse the scheme from that.
+# Otherwise, fall back to legacy collectorScheme value.
+{{- define "observe.collectorScheme" -}}{{- with .Values.global.observe -}}
+    {{- if .collectionEndpoint -}}
+        {{- with urlParse .collectionEndpoint -}}
+            {{- .scheme -}}
+        {{- end -}}
+    {{- else -}}
+        {{- .collectorScheme -}}
+    {{- end -}}
+{{- end -}}{{- end -}}
+
+# If a collection endpoint is provided, parse the host from that and split the host from the port.
+# Otherwise, fall back to legacy collectorHost value.
+{{- define "observe.collectorHost" -}}{{- with .Values.global.observe -}}
+    {{- if .collectionEndpoint -}}
+        {{- with urlParse .collectionEndpoint -}}
+            {{- (split ":" .host)._0 -}}
+        {{- end -}}
+    {{- else -}}
+        {{- $noEndpoint := "One of global.observe.collectionEndpoint or global.observe.customer must be defined" -}}
+        {{- required $noEndpoint .customer | toString -}}.{{- .collectorHost -}}
+    {{- end -}}
+{{- end -}}{{- end -}}
+
+# If a collection endpoint is provided, look for a provided port and otherwise try to guess
+# based on the scheme.
+# If an endpoint is not provided, fall back to legacy collectorPort.
+{{- define "observe.collectorPort" -}}{{- with .Values.global.observe -}}
+    {{- if .collectionEndpoint -}}
+        {{- with urlParse .collectionEndpoint -}}
+            {{- $parsedPort := (split ":" .host)._1 | toString -}}
+            {{- if ne $parsedPort "" -}}
+                {{- $parsedPort -}}
+            {{- else -}}
+                {{- if eq .scheme "https" -}}
+                    443
+                {{- else -}}
+                    80
+                {{- end -}}
+            {{- end -}}
+        {{- end -}}
+    {{- else -}}
+        {{- .collectorPort | toString -}}
+    {{- end -}}
+{{- end -}}{{- end -}}
+
+# Return true if the scheme is "https", as parsed from the collection endpoint.
+# If a collection endpoint is not provided, look at the legacy collectorScheme value.
+{{- define "observe.useTLS" -}}{{- with .Values.global.observe -}}
+    {{- if .collectionEndpoint -}}
+       {{- if eq "https" (urlParse .collectionEndpoint).scheme -}}
+            true
+        {{- else -}}
+            false
+        {{- end -}}
+    {{- else -}}
+        {{- if eq "https" .collectorScheme -}}
+            true
+        {{- else -}}
+            false
+        {{- end -}}
+    {{- end -}}
+{{- end -}}{{- end -}}

--- a/charts/internal/endpoint/values.yaml
+++ b/charts/internal/endpoint/values.yaml
@@ -1,0 +1,9 @@
+global:
+  observe:
+    collectionEndpoint:
+
+    # Legacy configuration values, only used if collectionEndpoint is not set
+    customer:
+    collectorScheme: "https"
+    collectorHost: "collect.observeinc.com"
+    collectorPort: "443"

--- a/charts/internal/events/Chart.lock
+++ b/charts/internal/events/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: endpoint
+  repository: file://../endpoint
+  version: 0.1.0
+digest: sha256:cd947c4e8b402a1958572a4e1cf640ada4cb9e7461ff53e747d3d9a6929a317c
+generated: "2023-06-26T19:46:21.167463-07:00"

--- a/charts/internal/events/Chart.yaml
+++ b/charts/internal/events/Chart.yaml
@@ -2,5 +2,9 @@ apiVersion: v2
 name: events
 description: Observe kubernetes event collection
 type: application
-version: 0.1.4
+version: 0.1.5
 appVersion: v0.9.1
+dependencies:
+  - name: endpoint
+    version: 0.1.0
+    repository: file://../endpoint

--- a/charts/internal/events/templates/deployment.yaml
+++ b/charts/internal/events/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: {{ include "kube-events.serviceAccountName" . }}
       initContainers:
         - name: kube-cluster-info
-          image: {{ .Values.image.kube_cluster_info.repository }}:{{ default .Chart.AppVersion .Values.image.kube_cluster_info_tag }}
+          image: {{ .Values.image.kube_cluster_info.repository }}:{{ default .Chart.AppVersion .Values.image.kube_cluster_info.tag }}
           env:
             - name: NAMESPACE
               valueFrom:
@@ -35,11 +35,11 @@ spec:
                   fieldPath: metadata.namespace
       containers:
         - name: kube-state-events
-          image: {{ .Values.image.kube_state_events.repository }}:{{ default .Chart.AppVersion .Values.image.kube_state_events_tag }}
+          image: {{ .Values.image.kube_state_events.repository }}:{{ default .Chart.AppVersion .Values.image.kube_state_events.tag }}
           args:
             - -healthz-addr=:5171
             - -metrics-addr=:9090
-            - -o={{.Values.global.observe.collectorScheme}}://$(OBSERVE_TOKEN)@{{.Values.global.observe.customer}}.{{.Values.global.observe.collectorHost}}:{{.Values.global.observe.collectorPort}}/v1/http/kubernetes/events?clusterUid=$(OBSERVE_CLUSTER)
+            - -o={{ include "observe.collectionEndpointWithToken" . }}/v1/http/kubernetes/events?clusterUid=$(OBSERVE_CLUSTER)
             - v1
             - apps/v1
             - autoscaling/v1

--- a/charts/internal/events/values.yaml
+++ b/charts/internal/events/values.yaml
@@ -1,10 +1,3 @@
-global:
-  observe:
-    customer: ""
-    collectorScheme: https
-    collectorHost: collect.observeinc.com
-    collectorPort: 443
-
 image:
   kube_cluster_info:
     repository: observeinc/kube-cluster-info

--- a/charts/internal/logs/Chart.lock
+++ b/charts/internal/logs/Chart.lock
@@ -2,5 +2,8 @@ dependencies:
 - name: fluent-bit
   repository: https://fluent.github.io/helm-charts
   version: 0.25.0
-digest: sha256:b1fb614f3fe47886c997ab9f3fd952ad2558b0007c292553d66f9b7500262d52
-generated: "2023-05-04T13:10:01.042218-07:00"
+- name: endpoint
+  repository: file://../endpoint
+  version: 0.1.0
+digest: sha256:08783ef863ff5a341c98443c760335248f8c78064e10e85ae4125aa380baaa6d
+generated: "2023-06-26T19:04:22.627488-07:00"

--- a/charts/internal/logs/Chart.yaml
+++ b/charts/internal/logs/Chart.yaml
@@ -2,8 +2,11 @@ apiVersion: v2
 name: logs
 description: Observe logs collection
 type: application
-version: 0.1.1
+version: 0.1.2
 dependencies:
   - name: fluent-bit
     version: 0.25.0
     repository: https://fluent.github.io/helm-charts
+  - name: endpoint
+    version: 0.1.0
+    repository: file://../endpoint

--- a/charts/internal/logs/values.yaml
+++ b/charts/internal/logs/values.yaml
@@ -1,10 +1,3 @@
-global:
-  observe:
-    customer: ""
-    collectorScheme: https
-    collectorHost: collect.observeinc.com
-    collectorPort: 443
-
 fluent-bit:
   nameOverride: logs
   env:
@@ -65,7 +58,6 @@ fluent-bit:
     grep_match_tag: "nothing"
     grep_exclude: "nomatch ^$"
     inotify_watcher: true
-    tls: on
 
     service: |
       [SERVICE]
@@ -155,9 +147,9 @@ fluent-bit:
           Name                http
           Match               k8slogs*
           Alias               k8slogs
-          Host                {{.Values.global.observe.customer}}.{{.Values.global.observe.collectorHost}}
-          Port                {{.Values.global.observe.collectorPort}}
-          TLS                 {{.Values.config.tls}}
+          Host                {{ include "observe.collectorHost" . }}
+          Port                {{ include "observe.collectorPort" . }}
+          TLS                 {{ include "observe.useTLS" . }}
           URI                 /v1/http/kubernetes/logs?clusterUid=${OBSERVE_CLUSTER}
           Format              msgpack
           Header              X-Observe-Decoder fluent
@@ -169,9 +161,9 @@ fluent-bit:
           Name                http
           Match               k8snode*
           Alias               k8snode
-          Host                {{.Values.global.observe.customer}}.{{.Values.global.observe.collectorHost}}
-          Port                {{.Values.global.observe.collectorPort}}
-          TLS                 {{.Values.config.tls}}
+          Host                {{ include "observe.collectorHost" . }}
+          Port                {{ include "observe.collectorPort" . }}
+          TLS                 {{ include "observe.useTLS" . }}
           URI                 /v1/http/kubernetes/node?clusterUid=${OBSERVE_CLUSTER}
           Format              msgpack
           Header              X-Observe-Decoder fluent

--- a/charts/internal/metrics/Chart.lock
+++ b/charts/internal/metrics/Chart.lock
@@ -2,5 +2,8 @@ dependencies:
 - name: grafana-agent
   repository: https://grafana.github.io/helm-charts
   version: 0.10.0
-digest: sha256:2b0cb5416af2fc07fa414013411eab01137fba56a770b4bd5da71ee385db08e7
-generated: "2023-05-04T13:10:00.116563-07:00"
+- name: endpoint
+  repository: file://../endpoint
+  version: 0.1.0
+digest: sha256:1d2739ad0e7a038ccbbec39b53067cf8eb61d9f43ce0979977412efb57467d3e
+generated: "2023-06-26T19:46:16.732076-07:00"

--- a/charts/internal/metrics/Chart.yaml
+++ b/charts/internal/metrics/Chart.yaml
@@ -2,8 +2,11 @@ apiVersion: v2
 name: metrics
 description: Observe metrics collection
 type: application
-version: 0.1.1
+version: 0.1.2
 dependencies:
   - name: grafana-agent
     version: 0.10.0
     repository: https://grafana.github.io/helm-charts
+  - name: endpoint
+    version: 0.1.0
+    repository: file://../endpoint

--- a/charts/internal/metrics/values.yaml
+++ b/charts/internal/metrics/values.yaml
@@ -1,10 +1,3 @@
-global:
-  observe:
-    customer: ""
-    collectorScheme: https
-    collectorHost: collect.observeinc.com
-    collectorPort: 443
-
 grafana-agent:
   nameOverride: metrics
   prom_config:
@@ -113,7 +106,7 @@ grafana-agent:
               wal_truncate_frequency: {{.Values.prom_config.wal_truncate_frequency}}
               remote_flush_deadline: {{.Values.prom_config.remote_flush_deadline}}
               remote_write:
-                - url: {{.Values.global.observe.collectorScheme}}://{{.Values.global.observe.customer}}.{{.Values.global.observe.collectorHost}}:{{.Values.global.observe.collectorPort}}/v1/prometheus
+                - url: {{ include "observe.collectionEndpoint" . }}/v1/prometheus
                   authorization:
                     credentials: ${OBSERVE_TOKEN}
                   remote_timeout: {{.Values.prom_config.remote_timeout}}

--- a/charts/stack/Chart.lock
+++ b/charts/stack/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: logs
   repository: file://../internal/logs
-  version: 0.1.1
+  version: 0.1.2
 - name: metrics
   repository: file://../internal/metrics
-  version: 0.1.1
+  version: 0.1.2
 - name: events
   repository: file://../internal/events
-  version: 0.1.4
-digest: sha256:813c50f5a49a0461c74d1e5a314be608c2aca1e1c844be4664d991fba1acac88
-generated: "2023-06-06T17:32:53.775948-07:00"
+  version: 0.1.5
+digest: sha256:bdcf08f3ba67afc501b3827ca4fd94a6bb404ac66b8447f468e950249ac08a45
+generated: "2023-06-26T20:12:49.392708-07:00"

--- a/charts/stack/Chart.yaml
+++ b/charts/stack/Chart.yaml
@@ -2,17 +2,17 @@ apiVersion: v2
 name: stack
 description: Observe Kubernetes agent stack
 type: application
-version: 0.1.6
+version: 0.1.7
 dependencies:
   - name: logs
-    version: 0.1.1
+    version: 0.1.2
     repository: file://../internal/logs
     condition: logs.enabled
   - name: metrics
-    version: 0.1.1
+    version: 0.1.2
     repository: file://../internal/metrics
     condition: metrics.enabled
   - name: events
-    version: 0.1.4
+    version: 0.1.5
     repository: file://../internal/events
     condition: events.enabled

--- a/charts/stack/values.yaml
+++ b/charts/stack/values.yaml
@@ -1,10 +1,3 @@
-global:
-  observe:
-    customer: ""
-    collectorScheme: https
-    collectorHost: collect.observeinc.com
-    collectorPort: 443
-
 observe:
   token:
     create: true

--- a/charts/traces/Chart.yaml
+++ b/charts/traces/Chart.yaml
@@ -2,8 +2,11 @@ apiVersion: v2
 name: traces
 description: Observe OpenTelemetry trace collection
 type: application
-version: 0.1.4
+version: 0.1.5
 dependencies:
   - name: opentelemetry-collector
     version: 0.49.1
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
+  - name: endpoint
+    version: 0.1.0
+    repository: file://../endpoint

--- a/charts/traces/values.yaml
+++ b/charts/traces/values.yaml
@@ -1,10 +1,3 @@
-global:
-  observe:
-    customer: ""
-    collectorScheme: https
-    collectorHost: collect.observeinc.com
-    collectorPort: 443
-
 observe:
   token:
     create: true
@@ -101,7 +94,7 @@ opentelemetry-collector:
       logging:
         loglevel: info
       otlphttp:
-        endpoint: "{{.Values.global.observe.collectorScheme}}://{{.Values.global.observe.customer}}.{{.Values.global.observe.collectorHost}}:{{.Values.global.observe.collectorPort}}/v1/otel"
+        endpoint: '{{ include "observe.collectionEndpoint" . }}/v1/otel'
         headers:
           authorization: "Bearer ${OBSERVE_TOKEN}"
         sending_queue:
@@ -110,7 +103,7 @@ opentelemetry-collector:
         retry_on_failure:
           enabled: true
       prometheusremotewrite:
-        endpoint: "{{.Values.global.observe.collectorScheme}}://{{.Values.global.observe.customer}}.{{.Values.global.observe.collectorHost}}:{{.Values.global.observe.collectorPort}}/v1/prometheus"
+        endpoint: '{{ include "observe.collectionEndpoint" . }}/v1/prometheus'
         headers:
           authorization: "Bearer ${OBSERVE_TOKEN}"
     extensions:


### PR DESCRIPTION
Rather than generating collector URLs using a provided scheme, customer, host, and port, also allow the entire ~~address~~ endpoint (minus the URL path, which changes per agent) to be provided as a single value. If this value is provided, it overrides the others. This change also adds enforcement that if the full address is not provided, then the customer ID must be provided or the template generation will fail with a descriptive error.

This is required for (still WIP) acceptance tests, which configure the agents to use a local collector whose hostname does not follow the usual pattern (customerID.collect.observeinc.com).