### PR TITLE
fix(traces): enable service by default for daemonset

### DIFF
--- a/charts/internal/endpoint/Chart.yaml
+++ b/charts/internal/endpoint/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: endpoint
 description: Observe collection endpoint utility functions
 type: library
-version: 0.1.0
+version: 0.1.1

--- a/charts/internal/endpoint/values.yaml
+++ b/charts/internal/endpoint/values.yaml
@@ -1,9 +1,0 @@
-global:
-  observe:
-    collectionEndpoint:
-
-    # Legacy configuration values, only used if collectionEndpoint is not set
-    customer:
-    collectorScheme: "https"
-    collectorHost: "collect.observeinc.com"
-    collectorPort: "443"

--- a/charts/internal/events/Chart.yaml
+++ b/charts/internal/events/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: events
 description: Observe kubernetes event collection
 type: application
-version: 0.1.5
+version: 0.1.6
 appVersion: v0.9.1
 dependencies:
   - name: endpoint
-    version: 0.1.0
+    version: 0.1.1
     repository: file://../endpoint

--- a/charts/internal/logs/Chart.yaml
+++ b/charts/internal/logs/Chart.yaml
@@ -2,11 +2,11 @@ apiVersion: v2
 name: logs
 description: Observe logs collection
 type: application
-version: 0.1.2
+version: 0.1.3
 dependencies:
   - name: fluent-bit
     version: 0.25.0
     repository: https://fluent.github.io/helm-charts
   - name: endpoint
-    version: 0.1.0
+    version: 0.1.1
     repository: file://../endpoint

--- a/charts/internal/metrics/Chart.yaml
+++ b/charts/internal/metrics/Chart.yaml
@@ -2,11 +2,11 @@ apiVersion: v2
 name: metrics
 description: Observe metrics collection
 type: application
-version: 0.1.2
+version: 0.1.3
 dependencies:
   - name: grafana-agent
     version: 0.10.0
     repository: https://grafana.github.io/helm-charts
   - name: endpoint
-    version: 0.1.0
+    version: 0.1.1
     repository: file://../endpoint

--- a/charts/stack/Chart.yaml
+++ b/charts/stack/Chart.yaml
@@ -2,17 +2,17 @@ apiVersion: v2
 name: stack
 description: Observe Kubernetes agent stack
 type: application
-version: 0.1.7
+version: 0.1.8
 dependencies:
   - name: logs
-    version: 0.1.2
+    version: 0.1.3
     repository: file://../internal/logs
     condition: logs.enabled
   - name: metrics
-    version: 0.1.2
+    version: 0.1.3
     repository: file://../internal/metrics
     condition: metrics.enabled
   - name: events
-    version: 0.1.5
+    version: 0.1.6
     repository: file://../internal/events
     condition: events.enabled

--- a/charts/traces/Chart.lock
+++ b/charts/traces/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: opentelemetry-collector
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
-  version: 0.49.1
+  version: 0.61.2
 - name: endpoint
   repository: file://../internal/endpoint
   version: 0.1.0
-digest: sha256:c326e9555cc8bfff1e91e7de2644eee0b85e7f8b9314cdb4219ea10dd13a5dab
-generated: "2023-06-26T20:56:26.475251-07:00"
+digest: sha256:30f3000dc2f7f9315f2157eb05225d62b10dc3a97b4422b655e4fa034941f930
+generated: "2023-07-05T10:44:45.908564-07:00"

--- a/charts/traces/Chart.yaml
+++ b/charts/traces/Chart.yaml
@@ -2,11 +2,11 @@ apiVersion: v2
 name: traces
 description: Observe OpenTelemetry trace collection
 type: application
-version: 0.1.5
+version: 0.1.7
 dependencies:
   - name: opentelemetry-collector
-    version: 0.49.1
+    version: 0.61.2
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
   - name: endpoint
-    version: 0.1.0
+    version: 0.1.1
     repository: file://../internal/endpoint

--- a/charts/traces/values.yaml
+++ b/charts/traces/values.yaml
@@ -7,7 +7,9 @@ opentelemetry-collector:
   nameOverride: traces
   image:
     tag: "0.62.1"
-  mode: daemonset # daemonset or deployment
+  mode: "daemonset" # daemonset or deployment
+  service:
+    enabled: true
   command:
     extraArgs: ["--set=service.telemetry.metrics.address=:58888"]
   resources:


### PR DESCRIPTION
We disable the hostPorts by default, so without a service the pods are not reachable for writing traces. 

Setting service to "enabled" for daemonsets was not supported in our current otel-collector chart version, so this also means bumping the otel-collector chart version to the latest.

This change also fixes several edge cases in the endpoint internal chart, where incorrect endpoints were generated if collectionEndpoint was not provided.