### PR TITLE
fix: remove trailing slash from base collection endpoint

### DIFF
--- a/charts/internal/endpoint/Chart.yaml
+++ b/charts/internal/endpoint/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: endpoint
 description: Observe collection endpoint utility functions
 type: library
-version: 0.1.1
+version: 0.1.2

--- a/charts/internal/endpoint/templates/_address.tpl
+++ b/charts/internal/endpoint/templates/_address.tpl
@@ -69,7 +69,10 @@
 # Otherwise, generate the endpoint using the legacy values.
 {{- define "observe.collectionEndpoint" -}}
     {{- if .Values.global.observe.collectionEndpoint -}}
-        {{- .Values.global.observe.collectionEndpoint -}}
+        {{- with urlParse .Values.global.observe.collectionEndpoint -}}
+            # re-constructing the URL this way eliminates any path that was included in the value
+            {{- printf "%s://%s" .scheme .host -}}
+        {{- end -}}
     {{- else -}}
         {{- printf "%s://%s:%s" (include "observe.collectorScheme" .) (include "observe.collectorHost" .) (include "observe.collectorPort" .) -}}
     {{- end -}}

--- a/charts/internal/events/Chart.lock
+++ b/charts/internal/events/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: endpoint
   repository: file://../endpoint
-  version: 0.1.1
-digest: sha256:740a1e7f4e620210f48dd666ec5e456401995b9b887470f7821d078c3dcbdcbd
-generated: "2023-07-05T14:07:30.410904-07:00"
+  version: 0.1.2
+digest: sha256:ff77e47a389aa3d61d1146ceea444e418462225bd65a35bfbcce39b463af3dd3
+generated: "2023-07-07T12:18:10.567932-07:00"

--- a/charts/internal/events/Chart.yaml
+++ b/charts/internal/events/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: events
 description: Observe kubernetes event collection
 type: application
-version: 0.1.6
+version: 0.1.7
 appVersion: v0.9.1
 dependencies:
   - name: endpoint
-    version: 0.1.1
+    version: 0.1.2
     repository: file://../endpoint

--- a/charts/internal/logs/Chart.lock
+++ b/charts/internal/logs/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 0.25.0
 - name: endpoint
   repository: file://../endpoint
-  version: 0.1.1
-digest: sha256:b877112cf3dd842ac9979ca51d37ca36999a6bb3c782b4842e87b9aa45d06a34
-generated: "2023-07-05T14:07:28.407762-07:00"
+  version: 0.1.2
+digest: sha256:cdc629f4e124e2440388569a1b3cfffe14efc2f93f1e43b05bc1169433a20ae0
+generated: "2023-07-07T12:18:08.747797-07:00"

--- a/charts/internal/logs/Chart.yaml
+++ b/charts/internal/logs/Chart.yaml
@@ -2,11 +2,11 @@ apiVersion: v2
 name: logs
 description: Observe logs collection
 type: application
-version: 0.1.3
+version: 0.1.4
 dependencies:
   - name: fluent-bit
     version: 0.25.0
     repository: https://fluent.github.io/helm-charts
   - name: endpoint
-    version: 0.1.1
+    version: 0.1.2
     repository: file://../endpoint

--- a/charts/internal/metrics/Chart.lock
+++ b/charts/internal/metrics/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 0.10.0
 - name: endpoint
   repository: file://../endpoint
-  version: 0.1.1
-digest: sha256:4d47e2a6bed77c641410a0419a0ae32a4dd452ab9ecdd040ae93f006eb971492
-generated: "2023-07-05T14:07:26.30612-07:00"
+  version: 0.1.2
+digest: sha256:d6925c4fb9532fd3d96c81d12ab6b7572a166e22f327eec6e8b79053fd380de1
+generated: "2023-07-07T12:18:07.067398-07:00"

--- a/charts/internal/metrics/Chart.yaml
+++ b/charts/internal/metrics/Chart.yaml
@@ -2,11 +2,11 @@ apiVersion: v2
 name: metrics
 description: Observe metrics collection
 type: application
-version: 0.1.3
+version: 0.1.4
 dependencies:
   - name: grafana-agent
     version: 0.10.0
     repository: https://grafana.github.io/helm-charts
   - name: endpoint
-    version: 0.1.1
+    version: 0.1.2
     repository: file://../endpoint

--- a/charts/stack/Chart.lock
+++ b/charts/stack/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: logs
   repository: file://../internal/logs
-  version: 0.1.3
+  version: 0.1.4
 - name: metrics
   repository: file://../internal/metrics
-  version: 0.1.3
+  version: 0.1.4
 - name: events
   repository: file://../internal/events
-  version: 0.1.6
-digest: sha256:7076f17add8182be137307914e4f2bf56862532da90b56cc434131b7d0deeb69
-generated: "2023-07-05T14:07:31.271817-07:00"
+  version: 0.1.7
+digest: sha256:095acdb8e79fd5771e5d90c6eff663bae7616f3a2a95ef911c930aab5465747d
+generated: "2023-07-07T12:25:53.518721-07:00"

--- a/charts/stack/Chart.yaml
+++ b/charts/stack/Chart.yaml
@@ -2,17 +2,17 @@ apiVersion: v2
 name: stack
 description: Observe Kubernetes agent stack
 type: application
-version: 0.1.8
+version: 0.1.9
 dependencies:
   - name: logs
-    version: 0.1.3
+    version: 0.1.4
     repository: file://../internal/logs
     condition: logs.enabled
   - name: metrics
-    version: 0.1.3
+    version: 0.1.4
     repository: file://../internal/metrics
     condition: metrics.enabled
   - name: events
-    version: 0.1.6
+    version: 0.1.7
     repository: file://../internal/events
     condition: events.enabled

--- a/charts/traces/Chart.lock
+++ b/charts/traces/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 0.61.2
 - name: endpoint
   repository: file://../internal/endpoint
-  version: 0.1.1
-digest: sha256:ea76419abdaa19bc41a02bdc1d4ad31413dce242da67a15a240dc11a3b95373a
-generated: "2023-07-05T14:07:24.066684-07:00"
+  version: 0.1.2
+digest: sha256:53e75278fa52afbd6db689b9a1bff03e15a29b32f59dc04f968910e649020398
+generated: "2023-07-07T12:18:05.353687-07:00"

--- a/charts/traces/Chart.yaml
+++ b/charts/traces/Chart.yaml
@@ -2,11 +2,11 @@ apiVersion: v2
 name: traces
 description: Observe OpenTelemetry trace collection
 type: application
-version: 0.1.7
+version: 0.1.8
 dependencies:
   - name: opentelemetry-collector
     version: 0.61.2
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
   - name: endpoint
-    version: 0.1.1
+    version: 0.1.2
     repository: file://../internal/endpoint


### PR DESCRIPTION
OB-20505 describes an issue wherein requests with duplicate slashes in the URL, such as `https://130594569014.collect.observeinc.com//v1/prometheus`, result in an error "Method GET is not allowed", despite the method actually being POST. While this appears to be a bug in the collector, we can also mitigate the issue here by ensuring that all generated URLs have redundant `/`s stripped.