### PR TITLE
fix(all): prevent comment from being incorrectly rendered in endpoint

### DIFF
--- a/charts/internal/endpoint/Chart.yaml
+++ b/charts/internal/endpoint/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: endpoint
 description: Observe collection endpoint utility functions
 type: library
-version: 0.1.2
+version: 0.1.3

--- a/charts/internal/endpoint/templates/_address.tpl
+++ b/charts/internal/endpoint/templates/_address.tpl
@@ -67,10 +67,10 @@
 
 # If a collection endpoint is provided, use that.
 # Otherwise, generate the endpoint using the legacy values.
+# Re-constructing the parsed URL eliminates any path that was included in the value.
 {{- define "observe.collectionEndpoint" -}}
     {{- if .Values.global.observe.collectionEndpoint -}}
         {{- with urlParse .Values.global.observe.collectionEndpoint -}}
-            # re-constructing the URL this way eliminates any path that was included in the value
             {{- printf "%s://%s" .scheme .host -}}
         {{- end -}}
     {{- else -}}

--- a/charts/internal/events/Chart.lock
+++ b/charts/internal/events/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: endpoint
   repository: file://../endpoint
-  version: 0.1.2
-digest: sha256:ff77e47a389aa3d61d1146ceea444e418462225bd65a35bfbcce39b463af3dd3
-generated: "2023-07-07T12:18:10.567932-07:00"
+  version: 0.1.3
+digest: sha256:9953e693e6627c73836353ca5b415595dcd72d64cc87afdf31a25db17f0f2194
+generated: "2023-07-11T11:35:41.2535-07:00"

--- a/charts/internal/events/Chart.yaml
+++ b/charts/internal/events/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: events
 description: Observe kubernetes event collection
 type: application
-version: 0.1.7
+version: 0.1.8
 appVersion: v0.9.1
 dependencies:
   - name: endpoint
-    version: 0.1.2
+    version: 0.1.3
     repository: file://../endpoint

--- a/charts/internal/logs/Chart.lock
+++ b/charts/internal/logs/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 0.25.0
 - name: endpoint
   repository: file://../endpoint
-  version: 0.1.2
-digest: sha256:cdc629f4e124e2440388569a1b3cfffe14efc2f93f1e43b05bc1169433a20ae0
-generated: "2023-07-07T12:18:08.747797-07:00"
+  version: 0.1.3
+digest: sha256:53c32af7f65d7683aed0aa325738388ab0be6379c25b6a0d90724e520050f54b
+generated: "2023-07-11T11:35:39.457678-07:00"

--- a/charts/internal/logs/Chart.yaml
+++ b/charts/internal/logs/Chart.yaml
@@ -2,11 +2,11 @@ apiVersion: v2
 name: logs
 description: Observe logs collection
 type: application
-version: 0.1.4
+version: 0.1.5
 dependencies:
   - name: fluent-bit
     version: 0.25.0
     repository: https://fluent.github.io/helm-charts
   - name: endpoint
-    version: 0.1.2
+    version: 0.1.3
     repository: file://../endpoint

--- a/charts/internal/metrics/Chart.lock
+++ b/charts/internal/metrics/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 0.10.0
 - name: endpoint
   repository: file://../endpoint
-  version: 0.1.2
-digest: sha256:d6925c4fb9532fd3d96c81d12ab6b7572a166e22f327eec6e8b79053fd380de1
-generated: "2023-07-07T12:18:07.067398-07:00"
+  version: 0.1.3
+digest: sha256:e835dfde169a0bc3a9982b32b43da0e44902f1229bc3e5319abd5c4ef5343327
+generated: "2023-07-11T11:35:27.773065-07:00"

--- a/charts/internal/metrics/Chart.yaml
+++ b/charts/internal/metrics/Chart.yaml
@@ -2,11 +2,11 @@ apiVersion: v2
 name: metrics
 description: Observe metrics collection
 type: application
-version: 0.1.4
+version: 0.1.5
 dependencies:
   - name: grafana-agent
     version: 0.10.0
     repository: https://grafana.github.io/helm-charts
   - name: endpoint
-    version: 0.1.2
+    version: 0.1.3
     repository: file://../endpoint

--- a/charts/stack/Chart.lock
+++ b/charts/stack/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: logs
   repository: file://../internal/logs
-  version: 0.1.4
+  version: 0.1.5
 - name: metrics
   repository: file://../internal/metrics
-  version: 0.1.4
+  version: 0.1.5
 - name: events
   repository: file://../internal/events
-  version: 0.1.7
-digest: sha256:095acdb8e79fd5771e5d90c6eff663bae7616f3a2a95ef911c930aab5465747d
-generated: "2023-07-07T12:25:53.518721-07:00"
+  version: 0.1.8
+digest: sha256:89b0033dc26382e68c4ad9406e1973f6b2b6e6e53a419e934e1e5e3b5b81f16c
+generated: "2023-07-11T11:35:42.035217-07:00"

--- a/charts/stack/Chart.yaml
+++ b/charts/stack/Chart.yaml
@@ -2,17 +2,17 @@ apiVersion: v2
 name: stack
 description: Observe Kubernetes agent stack
 type: application
-version: 0.1.9
+version: 0.1.10
 dependencies:
   - name: logs
-    version: 0.1.4
+    version: 0.1.5
     repository: file://../internal/logs
     condition: logs.enabled
   - name: metrics
-    version: 0.1.4
+    version: 0.1.5
     repository: file://../internal/metrics
     condition: metrics.enabled
   - name: events
-    version: 0.1.7
+    version: 0.1.8
     repository: file://../internal/events
     condition: events.enabled

--- a/charts/traces/Chart.lock
+++ b/charts/traces/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 0.61.2
 - name: endpoint
   repository: file://../internal/endpoint
-  version: 0.1.2
-digest: sha256:53e75278fa52afbd6db689b9a1bff03e15a29b32f59dc04f968910e649020398
-generated: "2023-07-07T12:18:05.353687-07:00"
+  version: 0.1.3
+digest: sha256:2b5170dba4f067ca472a3b965d7c85b2b66ed2f3d3cd74eab092bdcdf16a531d
+generated: "2023-07-11T11:35:25.995729-07:00"

--- a/charts/traces/Chart.yaml
+++ b/charts/traces/Chart.yaml
@@ -2,11 +2,11 @@ apiVersion: v2
 name: traces
 description: Observe OpenTelemetry trace collection
 type: application
-version: 0.1.8
+version: 0.1.9
 dependencies:
   - name: opentelemetry-collector
     version: 0.61.2
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
   - name: endpoint
-    version: 0.1.2
+    version: 0.1.3
     repository: file://../internal/endpoint


### PR DESCRIPTION
This type of comment is not safe to use in the context of these template functions. It can be included in generated endpoints and cause invalid config.

Fixes OB-20629
Fixes #23  