### PR TITLE
Add `host_filter: "true"` to default metrics values. 

### DIFF
--- a/charts/internal/metrics/values.yaml
+++ b/charts/internal/metrics/values.yaml
@@ -17,7 +17,7 @@ grafana-agent:
       scrape_timeout: 10s
       scrape_body_size_limit: 50MB
       scrape_cadvisor_action: keep
-      host_filter: "true"
+      host_filter: "false"
       # the following metrics are exported with 0 values in default cadvisor installs
       # see
       # - https://github.com/kubernetes/kubernetes/issues/60279

--- a/charts/internal/metrics/values.yaml
+++ b/charts/internal/metrics/values.yaml
@@ -17,6 +17,7 @@ grafana-agent:
       scrape_timeout: 10s
       scrape_body_size_limit: 50MB
       scrape_cadvisor_action: keep
+      host_filter: "true"
       # the following metrics are exported with 0 values in default cadvisor installs
       # see
       # - https://github.com/kubernetes/kubernetes/issues/60279

--- a/examples/stack/values-xl.yaml
+++ b/examples/stack/values-xl.yaml
@@ -21,6 +21,8 @@ logs:
 
 metrics:
   grafana-agent:
+    prom_config:
+      host_filter: "true"
     controller:
       type: daemonset
       updateStrategy:
@@ -39,8 +41,6 @@ metrics:
                   - {key: kubernetes.io/os, operator: NotIn, values: [windows]}
 
     agent:
-      prom_config:
-        host_filter: "true"
       resources:
         limits:
           cpu: 200m

--- a/examples/stack/values-xl.yaml
+++ b/examples/stack/values-xl.yaml
@@ -39,6 +39,8 @@ metrics:
                   - {key: kubernetes.io/os, operator: NotIn, values: [windows]}
 
     agent:
+      prom_config:
+        host_filter: "true"
       resources:
         limits:
           cpu: 200m


### PR DESCRIPTION
Chart renders with an empty value without this.

Further in the values, the configmap passed to grafana references a `Values.prom_config.host_filter` which is never initialized.

In our environment this was resulting in memory spikes for the grafana agent that cause an OOM crash loop. Adding this value in as a default appears to stop this, and brings things in line with the previously-used kustomize definition.