### PR TITLE
chore: making event chart more flexible

### DIFF
--- a/charts/internal/events/Chart.yaml
+++ b/charts/internal/events/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: events
 description: Observe kubernetes event collection
 type: application
-version: 0.1.8
+version: 0.1.9
 appVersion: v0.9.1
 dependencies:
   - name: endpoint

--- a/charts/internal/events/templates/deployment.yaml
+++ b/charts/internal/events/templates/deployment.yaml
@@ -75,9 +75,11 @@ spec:
             {{- range .Values.extraEnv }}
             - {{- toYaml . | nindent 14 }}
             {{- end }}
+          {{- if .Values.useCredentialsSecret.enabled }}
           envFrom:
             - secretRef:
-                name: credentials
+                name: {{ .Values.useCredentialsSecret.secretName }}
+          {{- end}}
           readinessProbe:
             httpGet:
               path: /healthz

--- a/charts/internal/events/templates/deployment.yaml
+++ b/charts/internal/events/templates/deployment.yaml
@@ -72,6 +72,9 @@ spec:
                 configMapKeyRef:
                   name: cluster-info
                   key: id
+            {{- range .Values.extraEnv }}
+            - {{- toYaml . | nindent 14 }}
+            {{- end }}
           envFrom:
             - secretRef:
                 name: credentials

--- a/charts/internal/events/templates/deployment.yaml
+++ b/charts/internal/events/templates/deployment.yaml
@@ -17,6 +17,10 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534
+      {{- with .Values.tolerations }}
+      tolerations:
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/charts/internal/events/templates/deployment.yaml
+++ b/charts/internal/events/templates/deployment.yaml
@@ -32,6 +32,7 @@ spec:
       initContainers:
         - name: kube-cluster-info
           image: {{ .Values.image.kube_cluster_info.repository }}:{{ default .Chart.AppVersion .Values.image.kube_cluster_info.tag }}
+          imagePullPolicy: {{ .Values.image.kube_cluster_info.imagePullPolicy | default "IfNotPresent" }}
           env:
             - name: NAMESPACE
               valueFrom:
@@ -40,6 +41,17 @@ spec:
       containers:
         - name: kube-state-events
           image: {{ .Values.image.kube_state_events.repository }}:{{ default .Chart.AppVersion .Values.image.kube_state_events.tag }}
+          imagePullPolicy: {{ .Values.image.kube_state_events.imagePullPolicy | default "IfNotPresent" }}
+          {{- if .Values.image.kube_state_events.command }}
+          command: {{- range .Values.image.kube_state_events.command }}
+          - {{ . }}
+          {{- end }}
+          {{- end }}
+          {{- if .Values.image.kube_state_events.args }}
+          args: {{- range .Values.image.kube_state_events.args }}
+          - {{ . }}
+          {{- end }}
+          {{- else }}
           args:
             - -healthz-addr=:5171
             - -metrics-addr=:9090
@@ -49,6 +61,7 @@ spec:
             - autoscaling/v1
             - batch/v1
             - networking.k8s.io/v1
+          {{- end}}
           ports:
             - containerPort: 5171
             - containerPort: 9090

--- a/charts/internal/events/values.yaml
+++ b/charts/internal/events/values.yaml
@@ -35,3 +35,7 @@ resources:
 tolerations: {}
 
 extraEnv: []
+
+useCredentialsSecret:
+  enabled: true
+  secretName: credentials

--- a/charts/internal/events/values.yaml
+++ b/charts/internal/events/values.yaml
@@ -33,3 +33,5 @@ resources:
     memory: 256Mi
 
 tolerations: {}
+
+extraEnv: []

--- a/charts/internal/events/values.yaml
+++ b/charts/internal/events/values.yaml
@@ -1,13 +1,20 @@
+global:
+  observe:
+    customer: "123456789012"
+
 image:
   kube_cluster_info:
     repository: observeinc/kube-cluster-info
     # Overrides the image tag whose default is {{ .Chart.AppVersion }}
     tag: ""
+    imagePullPolicy:
   kube_state_events:
     repository: observeinc/kube-state-events
     # Overrides the image tag whose default is {{ .Chart.AppVersion }}
     tag: ""
-  pullPolicy: Always
+    imagePullPolicy:
+    command: []
+    args: []
 
 rbac:
   create: true

--- a/charts/internal/events/values.yaml
+++ b/charts/internal/events/values.yaml
@@ -24,3 +24,5 @@ resources:
   requests:
     cpu: 50m
     memory: 256Mi
+
+tolerations: {}

--- a/charts/stack/Chart.lock
+++ b/charts/stack/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 0.1.5
 - name: events
   repository: file://../internal/events
-  version: 0.1.8
-digest: sha256:89b0033dc26382e68c4ad9406e1973f6b2b6e6e53a419e934e1e5e3b5b81f16c
-generated: "2023-07-11T11:35:42.035217-07:00"
+  version: 0.1.9
+digest: sha256:983a0d441b7cb4f75a53aced0500c1b770551342e4435b56fd81b34be3cc27f7
+generated: "2023-07-18T13:20:42.791581-03:00"

--- a/charts/stack/Chart.yaml
+++ b/charts/stack/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: stack
 description: Observe Kubernetes agent stack
 type: application
-version: 0.1.10
+version: 0.1.11
 dependencies:
   - name: logs
     version: 0.1.5
@@ -13,6 +13,6 @@ dependencies:
     repository: file://../internal/metrics
     condition: metrics.enabled
   - name: events
-    version: 0.1.8
+    version: 0.1.9
     repository: file://../internal/events
     condition: events.enabled


### PR DESCRIPTION
This PR adds:
* custom environments variables via extraEnv
* custom toleration for the events deployment
* custom imagePullPolicy for the events deployment images
* custom command and arguments if needed. If not specified, the default ones from the previous version will be used
* possibility to not use the `envFrom: - secretRef` if a user wants to specify this directly via extraEnvs or other means
* possibility to use a custom `secretRef` name if needed/wanted
* also added a few default values in the values.yaml allowing users to properly run `helm template` and `helm lint` with the chart out-of-the-box.