### PR TITLE
fix: add clusteruid to remote_rewrite

### DIFF
--- a/charts/metrics/Chart.yaml
+++ b/charts/metrics/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: metrics
 description: Observe metrics collection
 type: application
-version: 0.1.5
+version: 0.1.6
 dependencies:
   - name: grafana-agent
     version: 0.10.0

--- a/charts/metrics/values.yaml
+++ b/charts/metrics/values.yaml
@@ -111,7 +111,7 @@ grafana-agent:
               wal_truncate_frequency: {{.Values.prom_config.wal_truncate_frequency}}
               remote_flush_deadline: {{.Values.prom_config.remote_flush_deadline}}
               remote_write:
-                - url: {{ include "observe.collectionEndpoint" . }}/v1/prometheus
+                - url: {{ include "observe.collectionEndpoint" . }}/v1/prometheus?clusterUid=${OBSERVE_CLUSTER}
                   authorization:
                     credentials: ${OBSERVE_TOKEN}
                   remote_timeout: {{.Values.prom_config.remote_timeout}}

--- a/charts/metrics/values.yaml
+++ b/charts/metrics/values.yaml
@@ -101,8 +101,6 @@ grafana-agent:
           global:
             scrape_interval: {{.Values.prom_config.scrape_interval}}
             scrape_timeout: {{.Values.prom_config.scrape_timeout}}
-            external_labels:
-              clusterUid: ${OBSERVE_CLUSTER}
           configs:
             - name: integrations
               host_filter: {{.Values.prom_config.host_filter}}

--- a/charts/stack/Chart.lock
+++ b/charts/stack/Chart.lock
@@ -4,12 +4,12 @@ dependencies:
   version: 0.1.5
 - name: metrics
   repository: file://../metrics
-  version: 0.1.5
+  version: 0.1.6
 - name: events
   repository: file://../events
   version: 0.1.8
 - name: proxy
   repository: file://../proxy
   version: 0.1.0
-digest: sha256:3ec8741969affc098704ddc588b51d6c9e065b1a260f74599910a655b0efca19
-generated: "2023-07-20T13:52:33.572107-07:00"
+digest: sha256:8cfa163fc85837f7778972a4706ca01978b9e8ecba45a8c75d962f75e2c805a0
+generated: "2023-08-03T00:29:37.564935-07:00"

--- a/charts/stack/Chart.yaml
+++ b/charts/stack/Chart.yaml
@@ -2,14 +2,14 @@ apiVersion: v2
 name: stack
 description: Observe Kubernetes agent stack
 type: application
-version: 0.1.11
+version: 0.1.12
 dependencies:
   - name: logs
     version: 0.1.5
     repository: file://../logs
     condition: logs.enabled
   - name: metrics
-    version: 0.1.5
+    version: 0.1.6
     repository: file://../metrics
     condition: metrics.enabled
   - name: events


### PR DESCRIPTION
This PR to add clusterUid to prometheus remote_rewrite to include the tags for the prometheus metadata that is pushed to by grafana-agent.
Tested this change in eng environment - https://101.observe-eng.com/workspace/41000011/dataset/event/Observation-41046423?filter-OBSERVATION_KIND=prom_md&s=3380-1hn05klz

<img width="1711" alt="Screen Shot 2023-08-04 at 1 07 59 AM" src="https://github.com/observeinc/helm-charts/assets/127884651/94e85c7f-246d-4497-be6a-d402e8cceadf">

Related JIRA - https://observe.atlassian.net/browse/CON-1717 & https://observe.atlassian.net/browse/OB-21039 
