### PR TITLE
fix: add test hook annotations to test ConfigMaps

### DIFF
--- a/charts/stack/templates/tests/test-stack.yaml
+++ b/charts/stack/templates/tests/test-stack.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: queries
+  annotations:
+    "helm.sh/hook": test
 data:
   # Queries have the format <JMESPath query> -> <matching regexp>.
   # This syntax is based on the syntax used in the JMESPath docs, which describe queries as:

--- a/charts/stack/templates/tests/test-stack.yaml
+++ b/charts/stack/templates/tests/test-stack.yaml
@@ -4,6 +4,7 @@ metadata:
   name: queries
   annotations:
     "helm.sh/hook": test
+    "helm.sh/hook-weight": "-1"
 data:
   # Queries have the format <JMESPath query> -> <matching regexp>.
   # This syntax is based on the syntax used in the JMESPath docs, which describe queries as:

--- a/charts/traces/templates/tests/test-traces.yaml
+++ b/charts/traces/templates/tests/test-traces.yaml
@@ -4,6 +4,7 @@ metadata:
   name: queries
   annotations:
     "helm.sh/hook": test
+    "helm.sh/hook-weight": "-1"
 data:
   # Queries have the format <JMESPath query> -> <matching regexp>.
   # This syntax is based on the syntax used in the JMESPath docs, which describe queries as:
@@ -18,6 +19,7 @@ metadata:
   name: cluster-info
   annotations:
     "helm.sh/hook": test
+    "helm.sh/hook-weight": "-1"
 data:
   id: "fake-cluster-id"
 

--- a/charts/traces/templates/tests/test-traces.yaml
+++ b/charts/traces/templates/tests/test-traces.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: queries
+  annotations:
+    "helm.sh/hook": test
 data:
   # Queries have the format <JMESPath query> -> <matching regexp>.
   # This syntax is based on the syntax used in the JMESPath docs, which describe queries as:
@@ -14,6 +16,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: cluster-info
+  annotations:
+    "helm.sh/hook": test
 data:
   id: "fake-cluster-id"
 

--- a/test/test.sh
+++ b/test/test.sh
@@ -72,3 +72,9 @@ for chart in "$@"; do
     $helm uninstall --wait test-$chart 2>/dev/null
     $kc delete configmap/cluster-info 2>/dev/null || true
 done
+
+echo "Installing charts in series (without wait/cleanup): $*"
+for chart in "$@"; do
+    echo "Installing charts/$chart:"
+    $helm install --debug test-$chart $repo/charts/$chart -f $repo/charts/$chart/ci/test-values.yaml
+done

--- a/test/test.sh
+++ b/test/test.sh
@@ -73,8 +73,16 @@ for chart in "$@"; do
     $kc delete configmap/cluster-info 2>/dev/null || true
 done
 
+# Verifies that the charts can be installed together (in series) without naming conflicts
 echo "Installing charts in series (without wait/cleanup): $*"
 for chart in "$@"; do
     echo "Installing charts/$chart:"
     $helm install --debug test-$chart $repo/charts/$chart -f $repo/charts/$chart/ci/test-values.yaml
+done
+
+echo "Uninstalling charts in series: $*"
+for chart in "$@"; do
+    echo "Uninstalling charts/$chart:"
+    $helm uninstall --wait test-$chart 2>/dev/null
+    $kc delete configmap/cluster-info 2>/dev/null || true
 done


### PR DESCRIPTION
* Adds test hook annotations to ConfigMaps used in tests to prevent installation during a normal `helm install`
* Adds test coverage by also installing charts together, but not waiting. This will detect any naming conflict which might arise between the charts, this case just happened to be test resources. 