### PR TITLE
fix: remove configmaps from tests

### DIFF
--- a/charts/stack/templates/tests/test-stack.yaml
+++ b/charts/stack/templates/tests/test-stack.yaml
@@ -1,18 +1,4 @@
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: queries
-data:
-  # Queries have the format <JMESPath query> -> <matching regexp>.
-  # This syntax is based on the syntax used in the JMESPath docs, which describe queries as:
-  # search(query, input) -> result
-  queries: |
-    Path -> ^/v1/prometheus$
-    Path -> ^/v1/http/kubernetes/logs$
-    Path -> ^/v1/http/kubernetes/events$
-
----
-apiVersion: v1
 kind: Pod
 metadata:
   name: "test-stack"
@@ -24,16 +10,12 @@ spec:
     - name: check
       image: test-client:latest
       imagePullPolicy: Never
-      args: ['check', '-f', '/config/queries', 'http://test-stack-collector.testing.svc.cluster.local:8080/dump']
-      volumeMounts:
-      - name: queries
-        mountPath: "/config"
-        readOnly: true
-  volumes:
-  - name: queries
-    configMap:
-      name: queries
-      # An array of keys from the ConfigMap to create as files
-      items:
-      - key: "queries"
-        path: "queries"
+      args:
+      - check
+      # Queries have the format <JMESPath query> -> <matching regexp>.
+      # This syntax is based on the syntax used in the JMESPath docs, which describe queries as:
+      # search(query, input) -> result
+      - -q="Path -> ^/v1/prometheus$"
+      - -q="Path -> ^/v1/http/kubernetes/logs$"
+      - -q="Path -> ^/v1/http/kubernetes/events$"
+      - http://test-stack-collector.testing.svc.cluster.local:8080/dump

--- a/charts/traces/templates/tests/test-traces.yaml
+++ b/charts/traces/templates/tests/test-traces.yaml
@@ -1,24 +1,4 @@
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: queries
-data:
-  # Queries have the format <JMESPath query> -> <matching regexp>.
-  # This syntax is based on the syntax used in the JMESPath docs, which describe queries as:
-  # search(query, input) -> result
-  queries: |
-    Path -> ^/v1/otel/v1/traces$
-
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: cluster-info
-data:
-  id: "fake-cluster-id"
-
----
-apiVersion: v1
 kind: Pod
 metadata:
   name: "test-traces"
@@ -30,16 +10,10 @@ spec:
     - name: check
       image: test-client:latest
       imagePullPolicy: Never
-      args: ['check', '-f', '/config/queries', 'http://test-traces-collector.testing.svc.cluster.local:8080/dump']
-      volumeMounts:
-      - name: queries
-        mountPath: "/config"
-        readOnly: true
-  volumes:
-  - name: queries
-    configMap:
-      name: queries
-      # An array of keys from the ConfigMap to create as files
-      items:
-      - key: "queries"
-        path: "queries"
+      args:
+      - check
+      # Queries have the format <JMESPath query> -> <matching regexp>.
+      # This syntax is based on the syntax used in the JMESPath docs, which describe queries as:
+      # search(query, input) -> result
+      - -q="Path -> ^/v1/otel/v1/traces$"
+      - 'http://test-traces-collector.testing.svc.cluster.local:8080/dump'

--- a/test/test.sh
+++ b/test/test.sh
@@ -70,5 +70,4 @@ for chart in "$@"; do
     echo
 
     $helm uninstall --wait test-$chart 2>/dev/null
-    $kc delete configmap/cluster-info 2>/dev/null || true
 done


### PR DESCRIPTION
Each kubernetes manifest is treated as a standalone test by helm, so creating configmaps to configure test pods does not work as expected -- configmaps either persist, which is a bug, or they are cleaned up before the job relying on them can be run. Avoid them entirely for the configuration of test pods.

Closes #32