### PR TITLE
feat(fluent): add a toleration to the fluent sub-chart refs #FSH-66

### DIFF
--- a/charts/logs/values.yaml
+++ b/charts/logs/values.yaml
@@ -30,6 +30,8 @@ fluent-bit:
     requests:
       cpu: 100m
       memory: 128Mi
+  tolerations:
+    - operator: Exists
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
Tested as follows

```
helm template v0 charts/logs > before.yaml
---- make the pr change ----
helm template v0 charts/logs > after.yaml
diff before.yaml after.yaml

314a315,316
>       tolerations:
>         - operator: Exists

--- in context ----

# Source: logs/charts/fluent-bit/templates/daemonset.yaml
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: v0-logs
  labels:
    helm.sh/chart: fluent-bit-0.25.0
    app.kubernetes.io/name: logs
    app.kubernetes.io/instance: v0
    app.kubernetes.io/version: "2.0.10"
    app.kubernetes.io/managed-by: Helm
spec:
  selector:
    matchLabels:
      app.kubernetes.io/name: logs
      app.kubernetes.io/instance: v0
  template:
    metadata:
      annotations:
        checksum/config: eebb6a66a3110f93c3dbd80f0708ae78e14be1d5534eadc4ae764f07619a7c8b
        checksum/luascripts: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
      labels:
        app.kubernetes.io/name: logs
        app.kubernetes.io/instance: v0
    spec:
      serviceAccountName: v0-logs
      hostNetwork: false
      dnsPolicy: ClusterFirst
      containers: snip
      volumes: snip
      affinity:
        nodeAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
            nodeSelectorTerms:
            - matchExpressions:
              - key: observeinc.com/unschedulable
                operator: DoesNotExist
              - key: kubernetes.io/os
                operator: NotIn
                values:
                - windows
      tolerations:
        - operator: Exists
```