### PR TITLE
feat(labels): add custom label capability

### DIFF
--- a/charts/endpoint/Chart.yaml
+++ b/charts/endpoint/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: endpoint
 description: Observe collection endpoint utility functions
 type: library
-version: 0.1.4
+version: 0.1.5
 maintainers:
   - name: Observe
     email: support@observeinc.com

--- a/charts/endpoint/README.md
+++ b/charts/endpoint/README.md
@@ -1,6 +1,6 @@
 # endpoint
 
-![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
+![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
 
 Observe collection endpoint utility functions
 

--- a/charts/events/Chart.lock
+++ b/charts/events/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: endpoint
   repository: file://../endpoint
-  version: 0.1.4
-digest: sha256:657e56ee4df48f0ef42ba3bdc3261e18c714c2084d4defd1a0985b9601c03c1a
-generated: "2023-09-15T09:43:59.665623489-04:00"
+  version: 0.1.5
+digest: sha256:b1ed0b96f242262bac527b87fc0a2a1353c63e4d7067fd03fc0bf0dce9fab6b8
+generated: "2023-09-18T15:05:46.381219055-04:00"

--- a/charts/events/Chart.yaml
+++ b/charts/events/Chart.yaml
@@ -6,7 +6,7 @@ version: 0.1.10
 appVersion: v0.9.1
 dependencies:
   - name: endpoint
-    version: 0.1.4
+    version: 0.1.5
     repository: file://../endpoint
 maintainers:
   - name: Observe

--- a/charts/events/Chart.yaml
+++ b/charts/events/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: events
 description: Observe kubernetes event collection
 type: application
-version: 0.1.9
+version: 0.1.10
 appVersion: v0.9.1
 dependencies:
   - name: endpoint

--- a/charts/events/README.md
+++ b/charts/events/README.md
@@ -20,6 +20,7 @@ Observe kubernetes event collection
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| customLabels | object | `{}` |  |
 | global.observe | object | `{}` |  |
 | image.kube_cluster_info.repository | string | `"observeinc/kube-cluster-info"` |  |
 | image.kube_cluster_info.tag | string | `""` |  |

--- a/charts/events/README.md
+++ b/charts/events/README.md
@@ -1,6 +1,6 @@
 # events
 
-![Version: 0.1.9](https://img.shields.io/badge/Version-0.1.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.9.1](https://img.shields.io/badge/AppVersion-v0.9.1-informational?style=flat-square)
+![Version: 0.1.10](https://img.shields.io/badge/Version-0.1.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.9.1](https://img.shields.io/badge/AppVersion-v0.9.1-informational?style=flat-square)
 
 Observe kubernetes event collection
 

--- a/charts/events/README.md
+++ b/charts/events/README.md
@@ -14,7 +14,7 @@ Observe kubernetes event collection
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../endpoint | endpoint | 0.1.4 |
+| file://../endpoint | endpoint | 0.1.5 |
 
 ## Values
 

--- a/charts/events/templates/deployment.yaml
+++ b/charts/events/templates/deployment.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "kube-events.fullname" . }}
   labels:
     {{- include "kube-events.labels" . | nindent 4 }}
+    {{- with .Values.customLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   selector:
     matchLabels:

--- a/charts/events/templates/rbac.yaml
+++ b/charts/events/templates/rbac.yaml
@@ -24,6 +24,9 @@ metadata:
   name: {{ include "kube-events.fullname" . }}
   labels:
     {{- include "kube-events.labels" . | nindent 4 }}
+    {{- with .Values.customLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -51,6 +54,9 @@ metadata:
   name: {{ include "kube-events.fullname" . }}
   labels:
     {{- include "kube-events.labels" . | nindent 4 }}
+    {{- with .Values.customLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/events/templates/serviceaccount.yaml
+++ b/charts/events/templates/serviceaccount.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "kube-events.serviceAccountName" . }}
   labels:
     {{- include "kube-events.labels" . | nindent 4 }}
+    {{- with .Values.customLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/events/values.yaml
+++ b/charts/events/values.yaml
@@ -2,6 +2,8 @@ global:
   # https://github.com/helm/helm/issues/8489 workaround
   observe: {}
 
+customLabels: {}
+
 image:
   kube_cluster_info:
     repository: observeinc/kube-cluster-info

--- a/charts/logs/Chart.lock
+++ b/charts/logs/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 0.25.0
 - name: endpoint
   repository: file://../endpoint
-  version: 0.1.4
-digest: sha256:691b500f5efd629e157d876bdb9efedcdda6820429e43cdedb4be0481215ea0c
-generated: "2023-09-15T09:43:59.967721734-04:00"
+  version: 0.1.5
+digest: sha256:a23bcc1e8fa328081813ac8add89eb957e07a2f87996ef935ff1c742cf56c9a4
+generated: "2023-09-18T15:08:31.609373733-04:00"

--- a/charts/logs/Chart.yaml
+++ b/charts/logs/Chart.yaml
@@ -8,7 +8,7 @@ dependencies:
     version: 0.25.0
     repository: https://fluent.github.io/helm-charts
   - name: endpoint
-    version: 0.1.4
+    version: 0.1.5
     repository: file://../endpoint
 maintainers:
   - name: Observe

--- a/charts/logs/Chart.yaml
+++ b/charts/logs/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: logs
 description: Observe logs collection
 type: application
-version: 0.1.7
+version: 0.1.8
 dependencies:
   - name: fluent-bit
     version: 0.25.0

--- a/charts/logs/README.md
+++ b/charts/logs/README.md
@@ -14,7 +14,7 @@ Observe logs collection
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../endpoint | endpoint | 0.1.4 |
+| file://../endpoint | endpoint | 0.1.5 |
 | https://fluent.github.io/helm-charts | fluent-bit | 0.25.0 |
 
 ## Values

--- a/charts/logs/README.md
+++ b/charts/logs/README.md
@@ -1,6 +1,6 @@
 # logs
 
-![Version: 0.1.7](https://img.shields.io/badge/Version-0.1.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.1.8](https://img.shields.io/badge/Version-0.1.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Observe logs collection
 

--- a/charts/metrics/Chart.lock
+++ b/charts/metrics/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 0.10.0
 - name: endpoint
   repository: file://../endpoint
-  version: 0.1.4
-digest: sha256:61bb219dd48ee08f155ad588b85a510e07145ad4c9a5cbb4ba05fa29137b39dc
-generated: "2023-09-15T09:44:01.849865849-04:00"
+  version: 0.1.5
+digest: sha256:998c51cd428330df186d3e852b24ca7d11e2eb20ed694bb70d7cf834854168c4
+generated: "2023-09-18T15:08:32.520631744-04:00"

--- a/charts/metrics/Chart.yaml
+++ b/charts/metrics/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: metrics
 description: Observe metrics collection
 type: application
-version: 0.3.1
+version: 0.3.2
 dependencies:
   - name: grafana-agent
     version: 0.10.0

--- a/charts/metrics/Chart.yaml
+++ b/charts/metrics/Chart.yaml
@@ -8,7 +8,7 @@ dependencies:
     version: 0.10.0
     repository: https://grafana.github.io/helm-charts
   - name: endpoint
-    version: 0.1.4
+    version: 0.1.5
     repository: file://../endpoint
 maintainers:
   - name: Observe

--- a/charts/metrics/README.md
+++ b/charts/metrics/README.md
@@ -1,6 +1,6 @@
 # metrics
 
-![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Observe metrics collection
 

--- a/charts/metrics/README.md
+++ b/charts/metrics/README.md
@@ -14,7 +14,7 @@ Observe metrics collection
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../endpoint | endpoint | 0.1.4 |
+| file://../endpoint | endpoint | 0.1.5 |
 | https://grafana.github.io/helm-charts | grafana-agent | 0.10.0 |
 
 ## Values

--- a/charts/proxy/Chart.yaml
+++ b/charts/proxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: proxy
 description: "Observe agent proxy (for testing only, do not use)"
 type: application
-version: 0.1.1
+version: 0.1.2
 maintainers:
   - name: Observe
     email: support@observeinc.com

--- a/charts/proxy/README.md
+++ b/charts/proxy/README.md
@@ -1,6 +1,6 @@
 # proxy
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Observe agent proxy (for testing only, do not use)
 

--- a/charts/proxy/README.md
+++ b/charts/proxy/README.md
@@ -19,6 +19,7 @@ Observe agent proxy (for testing only, do not use)
 | autoscaling.maxReplicas | int | `100` |  |
 | autoscaling.minReplicas | int | `1` |  |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
+| customLabels | object | `{}` |  |
 | fullnameOverride | string | `""` |  |
 | global.observe | object | `{}` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |

--- a/charts/proxy/templates/deployment.yaml
+++ b/charts/proxy/templates/deployment.yaml
@@ -4,6 +4,9 @@ metadata:
   name: {{ include "proxy.fullname" . }}
   labels:
     {{- include "proxy.labels" . | nindent 4 }}
+    {{- with .Values.customLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}

--- a/charts/proxy/templates/hpa.yaml
+++ b/charts/proxy/templates/hpa.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "proxy.fullname" . }}
   labels:
     {{- include "proxy.labels" . | nindent 4 }}
+    {{- with .Values.customLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/charts/proxy/templates/ingress.yaml
+++ b/charts/proxy/templates/ingress.yaml
@@ -18,6 +18,9 @@ metadata:
   name: {{ $fullName }}
   labels:
     {{- include "proxy.labels" . | nindent 4 }}
+    {{- with .Values.customLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/proxy/templates/service.yaml
+++ b/charts/proxy/templates/service.yaml
@@ -4,6 +4,9 @@ metadata:
   name: {{ include "proxy.fullname" . }}
   labels:
     {{- include "proxy.labels" . | nindent 4 }}
+    {{- with .Values.customLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/proxy/templates/serviceaccount.yaml
+++ b/charts/proxy/templates/serviceaccount.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "proxy.serviceAccountName" . }}
   labels:
     {{- include "proxy.labels" . | nindent 4 }}
+    {{- with .Values.customLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/proxy/values.yaml
+++ b/charts/proxy/values.yaml
@@ -2,6 +2,9 @@ global:
   # https://github.com/helm/helm/issues/8489 workaround
   observe: {}
 
+# Apply custom labels
+customLabels: {}
+
 replicaCount: 1
 
 image:

--- a/charts/stack/Chart.lock
+++ b/charts/stack/Chart.lock
@@ -1,15 +1,15 @@
 dependencies:
 - name: logs
   repository: file://../logs
-  version: 0.1.7
+  version: 0.1.8
 - name: metrics
   repository: file://../metrics
-  version: 0.3.1
+  version: 0.3.2
 - name: events
   repository: file://../events
-  version: 0.1.9
+  version: 0.1.10
 - name: proxy
   repository: file://../proxy
-  version: 0.1.1
-digest: sha256:9d478a4b0c7c3c8f64c8de1f77152458eee86940634bfff4995d395f0ace087d
-generated: "2023-09-15T09:45:35.992280767-04:00"
+  version: 0.1.2
+digest: sha256:ebb9820237d74e9d3120539fc0b66230271086a07b079e5b3af39983d235c886
+generated: "2023-09-18T15:05:46.994629235-04:00"

--- a/charts/stack/Chart.yaml
+++ b/charts/stack/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: stack
 description: Observe Kubernetes agent stack
 type: application
-version: 0.3.1
+version: 0.3.2
 dependencies:
   - name: logs
     version: 0.1.7

--- a/charts/stack/Chart.yaml
+++ b/charts/stack/Chart.yaml
@@ -5,19 +5,19 @@ type: application
 version: 0.3.2
 dependencies:
   - name: logs
-    version: 0.1.7
+    version: 0.1.8
     repository: file://../logs
     condition: logs.enabled
   - name: metrics
-    version: 0.3.1
+    version: 0.3.2
     repository: file://../metrics
     condition: metrics.enabled
   - name: events
-    version: 0.1.9
+    version: 0.1.10
     repository: file://../events
     condition: events.enabled
   - name: proxy
-    version: 0.1.1
+    version: 0.1.2
     repository: file://../proxy
     condition: proxy.enabled
 maintainers:

--- a/charts/stack/README.md
+++ b/charts/stack/README.md
@@ -14,10 +14,10 @@ Observe Kubernetes agent stack
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../events | events | 0.1.9 |
-| file://../logs | logs | 0.1.7 |
-| file://../metrics | metrics | 0.3.1 |
-| file://../proxy | proxy | 0.1.1 |
+| file://../events | events | 0.1.10 |
+| file://../logs | logs | 0.1.8 |
+| file://../metrics | metrics | 0.3.2 |
+| file://../proxy | proxy | 0.1.2 |
 
 ## Values
 

--- a/charts/stack/README.md
+++ b/charts/stack/README.md
@@ -1,6 +1,6 @@
 # stack
 
-![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Observe Kubernetes agent stack
 

--- a/charts/traces/Chart.lock
+++ b/charts/traces/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 0.61.2
 - name: endpoint
   repository: file://../endpoint
-  version: 0.1.4
+  version: 0.1.5
 - name: proxy
   repository: file://../proxy
-  version: 0.1.1
-digest: sha256:f611eed24c070d5818d2ffe125dc7570407477f7506879e4f9d7c9364e22c4f5
-generated: "2023-09-15T09:45:36.333691496-04:00"
+  version: 0.1.2
+digest: sha256:24806d6c786e45316d300b9da119a78a62ad1c781202508e7dc8b61365845948
+generated: "2023-09-18T15:05:47.371185123-04:00"

--- a/charts/traces/Chart.yaml
+++ b/charts/traces/Chart.yaml
@@ -8,10 +8,10 @@ dependencies:
     version: 0.61.2
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
   - name: endpoint
-    version: 0.1.4
+    version: 0.1.5
     repository: file://../endpoint
   - name: proxy
-    version: 0.1.1
+    version: 0.1.2
     repository: file://../proxy
     condition: proxy.enabled
 maintainers:

--- a/charts/traces/Chart.yaml
+++ b/charts/traces/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traces
 description: Observe OpenTelemetry trace collection
 type: application
-version: 0.1.12
+version: 0.1.13
 dependencies:
   - name: opentelemetry-collector
     version: 0.61.2

--- a/charts/traces/README.md
+++ b/charts/traces/README.md
@@ -14,8 +14,8 @@ Observe OpenTelemetry trace collection
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../endpoint | endpoint | 0.1.4 |
-| file://../proxy | proxy | 0.1.1 |
+| file://../endpoint | endpoint | 0.1.5 |
+| file://../proxy | proxy | 0.1.2 |
 | https://open-telemetry.github.io/opentelemetry-helm-charts | opentelemetry-collector | 0.61.2 |
 
 ## Values

--- a/charts/traces/README.md
+++ b/charts/traces/README.md
@@ -1,6 +1,6 @@
 # traces
 
-![Version: 0.1.12](https://img.shields.io/badge/Version-0.1.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.1.13](https://img.shields.io/badge/Version-0.1.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Observe OpenTelemetry trace collection
 


### PR DESCRIPTION
by changing values.yaml to
```
customLabels:
  environment: production
  team: my-team
```

The resulting diff in the manifest is
```
11a12,13
>     environment: production
>     team: my-team
22a25,26
>     environment: production
>     team: my-team
43a48,49
>     environment: production
>     team: my-team
```

or in context:
```
# Source: proxy/templates/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: v0-proxy
  labels:
    helm.sh/chart: proxy-0.1.0
    app.kubernetes.io/name: proxy
    app.kubernetes.io/instance: v0
    app.kubernetes.io/managed-by: Helm
    environment: production
    team: my-team
    
    .....
    
---
# Source: proxy/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: v0-proxy
  labels:
    helm.sh/chart: proxy-0.1.0
    app.kubernetes.io/name: proxy
    app.kubernetes.io/instance: v0
    app.kubernetes.io/managed-by: Helm
    environment: production
    team: my-team
spec:
  type: ClusterIP
  ports:
  ......
  
# Source: proxy/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: v0-proxy
  labels:
    helm.sh/chart: proxy-0.1.0
    app.kubernetes.io/name: proxy
    app.kubernetes.io/instance: v0
    app.kubernetes.io/managed-by: Helm
    environment: production
    team: my-team
spec:
  replicas: 1

```