### PR TITLE
chore(ci): need fetch depth of zero

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.0.0
+        with:
+          fetch-depth: 0
 
       - name: Check if Chart.yaml versions are bumped if relevant
         run: |


### PR DESCRIPTION
Resolving the following issue
```
0s
Run make validate-chart-version
fatal: ambiguous argument 'origin/main...HEAD': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- **[<file>...]'
```

![image](https://github.com/observeinc/helm-charts/assets/131207535/bf544f5b-3999-4052-a38f-712b0f9537f5)
