### PR TITLE
fix: adjust the updatecli grafana-agent regex

### DIFF
--- a/updatecli/external/grafana.yml
+++ b/updatecli/external/grafana.yml
@@ -7,7 +7,7 @@ sources:
       token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
       versionFilter:
         kind: regex
-        pattern: "grafana-agent-(.*)$"
+        pattern: '^grafana-agent-(\d+\.\d+\.\d+)$'
     transformers:
       - trimprefix: "grafana-agent-"
 targets:


### PR DESCRIPTION
regex needed to be tweaked to match grafana-agent-x.y.z and not include grafana-agent-operator-x.y.z

![image](https://github.com/observeinc/helm-charts/assets/131207535/5c356c78-5fd3-4689-a651-fc85646318fa)
