### PR TITLE
fix(traces): extract k8s.cluster.uid through k8sattributes

### DIFF
--- a/charts/stack/Chart.lock
+++ b/charts/stack/Chart.lock
@@ -13,6 +13,6 @@ dependencies:
   version: 0.1.3
 - name: traces
   repository: file://../traces
-  version: 0.2.4
-digest: sha256:7fe2e33514dd32f4600ef4e157d8d36ecce6031c45ef3556a988adadd1279fb1
-generated: "2023-11-13T10:21:53.911028432-05:00"
+  version: 0.2.5
+digest: sha256:b5a9d5c7f06756337a79df7e5a73172d43d54ee142f11b60fb1228a5dfa0b591
+generated: "2023-11-15T10:52:47.595698-05:00"

--- a/charts/stack/Chart.yaml
+++ b/charts/stack/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: stack
 description: Observe Kubernetes agent stack
 type: application
-version: 0.4.6
+version: 0.4.7
 dependencies:
   - name: logs
     version: 0.1.12
@@ -21,7 +21,7 @@ dependencies:
     repository: file://../proxy
     condition: proxy.enabled
   - name: traces
-    version: 0.2.4
+    version: 0.2.5
     repository: file://../traces
     condition: traces.enabled
 maintainers:

--- a/charts/stack/README.md
+++ b/charts/stack/README.md
@@ -1,6 +1,6 @@
 # stack
 
-![Version: 0.4.6](https://img.shields.io/badge/Version-0.4.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.4.7](https://img.shields.io/badge/Version-0.4.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Observe Kubernetes agent stack
 
@@ -18,7 +18,7 @@ Observe Kubernetes agent stack
 | file://../logs | logs | 0.1.12 |
 | file://../metrics | metrics | 0.3.6 |
 | file://../proxy | proxy | 0.1.3 |
-| file://../traces | traces | 0.2.4 |
+| file://../traces | traces | 0.2.5 |
 
 ## Values
 

--- a/charts/traces/Chart.lock
+++ b/charts/traces/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: opentelemetry-collector
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
-  version: 0.69.0
+  version: 0.73.1
 - name: endpoint
   repository: file://../endpoint
   version: 0.1.7
 - name: proxy
   repository: file://../proxy
   version: 0.1.3
-digest: sha256:390487ce0fcf56626369258040b22656cea0c60784dc1894f6899e068ed34517
-generated: "2023-11-08T10:02:42.189325275-05:00"
+digest: sha256:8426f1587deb61ba68ceada3f20fc94980baf00d2ba0aef6602df95f4a573713
+generated: "2023-11-15T10:52:27.020997-05:00"

--- a/charts/traces/Chart.yaml
+++ b/charts/traces/Chart.yaml
@@ -2,10 +2,10 @@ apiVersion: v2
 name: traces
 description: Observe OpenTelemetry trace collection
 type: application
-version: 0.2.4
+version: 0.2.5
 dependencies:
   - name: opentelemetry-collector
-    version: 0.69.0
+    version: 0.73.1
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
   - name: endpoint
     version: 0.1.7

--- a/charts/traces/README.md
+++ b/charts/traces/README.md
@@ -1,6 +1,6 @@
 # traces
 
-![Version: 0.2.4](https://img.shields.io/badge/Version-0.2.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.2.5](https://img.shields.io/badge/Version-0.2.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Observe OpenTelemetry trace collection
 
@@ -16,7 +16,7 @@ Observe OpenTelemetry trace collection
 |------------|------|---------|
 | file://../endpoint | endpoint | 0.1.7 |
 | file://../proxy | proxy | 0.1.3 |
-| https://open-telemetry.github.io/opentelemetry-helm-charts | opentelemetry-collector | 0.69.0 |
+| https://open-telemetry.github.io/opentelemetry-helm-charts | opentelemetry-collector | 0.73.1 |
 
 ## Values
 
@@ -32,6 +32,7 @@ Observe OpenTelemetry trace collection
 | opentelemetry-collector.clusterRole.create | bool | `true` |  |
 | opentelemetry-collector.clusterRole.rules[0].apiGroups[0] | string | `""` |  |
 | opentelemetry-collector.clusterRole.rules[0].resources[0] | string | `"pods"` |  |
+| opentelemetry-collector.clusterRole.rules[0].resources[1] | string | `"namespaces"` |  |
 | opentelemetry-collector.clusterRole.rules[0].verbs[0] | string | `"get"` |  |
 | opentelemetry-collector.clusterRole.rules[0].verbs[1] | string | `"list"` |  |
 | opentelemetry-collector.clusterRole.rules[0].verbs[2] | string | `"watch"` |  |
@@ -47,54 +48,44 @@ Observe OpenTelemetry trace collection
 | opentelemetry-collector.config.processors.batch | string | `nil` |  |
 | opentelemetry-collector.config.processors.k8sattributes.extract.metadata[0] | string | `"k8s.pod.name"` |  |
 | opentelemetry-collector.config.processors.k8sattributes.extract.metadata[1] | string | `"k8s.namespace.name"` |  |
+| opentelemetry-collector.config.processors.k8sattributes.extract.metadata[2] | string | `"k8s.cluster.uid"` |  |
+| opentelemetry-collector.config.processors.k8sattributes.filter.node_from_env_var | string | `"NODE_NAME"` |  |
 | opentelemetry-collector.config.processors.k8sattributes.passthrough | bool | `false` |  |
-| opentelemetry-collector.config.processors.k8sattributes.pod_association[0].from | string | `"resource_attribute"` |  |
-| opentelemetry-collector.config.processors.k8sattributes.pod_association[0].name | string | `"k8s.pod.ip"` |  |
-| opentelemetry-collector.config.processors.k8sattributes.pod_association[1].from | string | `"connection"` |  |
+| opentelemetry-collector.config.processors.k8sattributes.pod_association[0].sources[0].from | string | `"resource_attribute"` |  |
+| opentelemetry-collector.config.processors.k8sattributes.pod_association[0].sources[0].name | string | `"k8s.pod.ip"` |  |
+| opentelemetry-collector.config.processors.k8sattributes.pod_association[0].sources[1].from | string | `"connection"` |  |
 | opentelemetry-collector.config.processors.memory_limiter.check_interval | string | `"5s"` |  |
 | opentelemetry-collector.config.processors.memory_limiter.limit_mib | int | `192` |  |
 | opentelemetry-collector.config.processors.memory_limiter.spike_limit_mib | int | `100` |  |
 | opentelemetry-collector.config.processors.probabilistic_sampler.hash_seed | int | `22` |  |
 | opentelemetry-collector.config.processors.probabilistic_sampler.sampling_percentage | int | `100` |  |
-| opentelemetry-collector.config.processors.resource.attributes[0].action | string | `"insert"` |  |
-| opentelemetry-collector.config.processors.resource.attributes[0].key | string | `"k8s.cluster.uid"` |  |
-| opentelemetry-collector.config.processors.resource.attributes[0].value | string | `"${OBSERVE_CLUSTER}"` |  |
 | opentelemetry-collector.config.receivers.otlp.protocols.grpc | string | `nil` |  |
 | opentelemetry-collector.config.receivers.otlp.protocols.http | string | `nil` |  |
 | opentelemetry-collector.config.receivers.zipkin | string | `nil` |  |
 | opentelemetry-collector.config.service.pipelines.logs.exporters[0] | string | `"otlphttp"` |  |
 | opentelemetry-collector.config.service.pipelines.logs.exporters[1] | string | `"logging"` |  |
-| opentelemetry-collector.config.service.pipelines.logs.processors[0] | string | `"resource"` |  |
-| opentelemetry-collector.config.service.pipelines.logs.processors[1] | string | `"k8sattributes"` |  |
-| opentelemetry-collector.config.service.pipelines.logs.processors[2] | string | `"memory_limiter"` |  |
-| opentelemetry-collector.config.service.pipelines.logs.processors[3] | string | `"batch"` |  |
+| opentelemetry-collector.config.service.pipelines.logs.processors[0] | string | `"k8sattributes"` |  |
+| opentelemetry-collector.config.service.pipelines.logs.processors[1] | string | `"memory_limiter"` |  |
+| opentelemetry-collector.config.service.pipelines.logs.processors[2] | string | `"batch"` |  |
 | opentelemetry-collector.config.service.pipelines.logs.receivers[0] | string | `"otlp"` |  |
 | opentelemetry-collector.config.service.pipelines.metrics.exporters[0] | string | `"otlphttp"` |  |
 | opentelemetry-collector.config.service.pipelines.metrics.exporters[1] | string | `"logging"` |  |
-| opentelemetry-collector.config.service.pipelines.metrics.processors[0] | string | `"resource"` |  |
-| opentelemetry-collector.config.service.pipelines.metrics.processors[1] | string | `"k8sattributes"` |  |
-| opentelemetry-collector.config.service.pipelines.metrics.processors[2] | string | `"memory_limiter"` |  |
-| opentelemetry-collector.config.service.pipelines.metrics.processors[3] | string | `"batch"` |  |
+| opentelemetry-collector.config.service.pipelines.metrics.processors[0] | string | `"k8sattributes"` |  |
+| opentelemetry-collector.config.service.pipelines.metrics.processors[1] | string | `"memory_limiter"` |  |
+| opentelemetry-collector.config.service.pipelines.metrics.processors[2] | string | `"batch"` |  |
 | opentelemetry-collector.config.service.pipelines.metrics.receivers[0] | string | `"otlp"` |  |
 | opentelemetry-collector.config.service.pipelines.traces.exporters[0] | string | `"otlphttp"` |  |
 | opentelemetry-collector.config.service.pipelines.traces.exporters[1] | string | `"logging"` |  |
-| opentelemetry-collector.config.service.pipelines.traces.processors[0] | string | `"resource"` |  |
-| opentelemetry-collector.config.service.pipelines.traces.processors[1] | string | `"probabilistic_sampler"` |  |
-| opentelemetry-collector.config.service.pipelines.traces.processors[2] | string | `"k8sattributes"` |  |
-| opentelemetry-collector.config.service.pipelines.traces.processors[3] | string | `"memory_limiter"` |  |
-| opentelemetry-collector.config.service.pipelines.traces.processors[4] | string | `"batch"` |  |
+| opentelemetry-collector.config.service.pipelines.traces.processors[0] | string | `"probabilistic_sampler"` |  |
+| opentelemetry-collector.config.service.pipelines.traces.processors[1] | string | `"k8sattributes"` |  |
+| opentelemetry-collector.config.service.pipelines.traces.processors[2] | string | `"memory_limiter"` |  |
+| opentelemetry-collector.config.service.pipelines.traces.processors[3] | string | `"batch"` |  |
 | opentelemetry-collector.config.service.pipelines.traces.receivers[0] | string | `"otlp"` |  |
 | opentelemetry-collector.config.service.pipelines.traces.receivers[1] | string | `"zipkin"` |  |
-| opentelemetry-collector.extraEnvs[0].name | string | `"NODE_NAME"` |  |
-| opentelemetry-collector.extraEnvs[0].valueFrom.fieldRef.fieldPath | string | `"spec.nodeName"` |  |
-| opentelemetry-collector.extraEnvs[1].name | string | `"OBSERVE_CLUSTER"` |  |
-| opentelemetry-collector.extraEnvs[1].valueFrom.configMapKeyRef.key | string | `"id"` |  |
-| opentelemetry-collector.extraEnvs[1].valueFrom.configMapKeyRef.name | string | `"cluster-info"` |  |
-| opentelemetry-collector.extraEnvs[2].name | string | `"OBSERVE_TOKEN"` |  |
-| opentelemetry-collector.extraEnvs[2].valueFrom.secretKeyRef.key | string | `"OBSERVE_TOKEN"` |  |
-| opentelemetry-collector.extraEnvs[2].valueFrom.secretKeyRef.name | string | `"otel-credentials"` |  |
+| opentelemetry-collector.extraEnvs[0].name | string | `"OBSERVE_TOKEN"` |  |
+| opentelemetry-collector.extraEnvs[0].valueFrom.secretKeyRef.key | string | `"OBSERVE_TOKEN"` |  |
+| opentelemetry-collector.extraEnvs[0].valueFrom.secretKeyRef.name | string | `"otel-credentials"` |  |
 | opentelemetry-collector.fullnameOverride | string | `"observe-traces"` |  |
-| opentelemetry-collector.image.tag | string | `"0.62.1"` |  |
 | opentelemetry-collector.livenessProbe.initialDelaySeconds | int | `5` |  |
 | opentelemetry-collector.mode | string | `"daemonset"` |  |
 | opentelemetry-collector.nameOverride | string | `"traces"` |  |

--- a/charts/traces/values.yaml
+++ b/charts/traces/values.yaml
@@ -9,8 +9,6 @@ proxy:
 opentelemetry-collector:
   fullnameOverride: "observe-traces"
   nameOverride: traces
-  image:
-    tag: "0.62.1"
   mode: "daemonset"  # daemonset or deployment
   service:
     enabled: true
@@ -31,6 +29,7 @@ opentelemetry-collector:
           - ""
         resources:
           - pods
+          - namespaces
         verbs:
           - get
           - list
@@ -73,15 +72,6 @@ opentelemetry-collector:
     jaeger-grpc:
       enabled: false
   extraEnvs:
-    - name: NODE_NAME
-      valueFrom:
-        fieldRef:
-          fieldPath: spec.nodeName
-    - name: OBSERVE_CLUSTER
-      valueFrom:
-        configMapKeyRef:
-          name: cluster-info
-          key: id
     - name: OBSERVE_TOKEN
       valueFrom:
         secretKeyRef:
@@ -120,21 +110,20 @@ opentelemetry-collector:
       probabilistic_sampler:
         hash_seed: 22
         sampling_percentage: 100
-      resource:
-        attributes:
-          - key: k8s.cluster.uid
-            value: "${OBSERVE_CLUSTER}"
-            action: insert
       k8sattributes:
         passthrough: false
+        filter:
+          node_from_env_var: NODE_NAME
         extract:
           metadata:
             - k8s.pod.name
             - k8s.namespace.name
+            - k8s.cluster.uid
         pod_association:
-          - from: resource_attribute
-            name: k8s.pod.ip
-          - from: connection
+          - sources:
+              - from: resource_attribute
+                name: k8s.pod.ip
+              - from: connection
       batch:
       memory_limiter:
         # 80% of maximum memory up to 2G
@@ -153,13 +142,13 @@ opentelemetry-collector:
       pipelines:
         traces:
           receivers: [otlp, zipkin]
-          processors: [resource, probabilistic_sampler, k8sattributes, memory_limiter, batch]
+          processors: [probabilistic_sampler, k8sattributes, memory_limiter, batch]
           exporters: [otlphttp, logging]
         metrics:
           receivers: [otlp]
-          processors: [resource, k8sattributes, memory_limiter, batch]
+          processors: [k8sattributes, memory_limiter, batch]
           exporters: [otlphttp, logging]
         logs:
           receivers: [otlp]
-          processors: [resource, k8sattributes, memory_limiter, batch]
+          processors: [k8sattributes, memory_limiter, batch]
           exporters: [otlphttp, logging]


### PR DESCRIPTION
k8sattributes processor now natively supports extracting `k8s.cluster.uid`, so we don't need to handle this through the resource processor anymore.

Kustomize PR: https://github.com/observeinc/manifests/pull/131