### PR TITLE
fix: define opentelemetry-collector.fullnameOverride so observe-traces fixed as the service name

### DIFF
--- a/charts/stack/Chart.lock
+++ b/charts/stack/Chart.lock
@@ -13,6 +13,6 @@ dependencies:
   version: 0.1.3
 - name: traces
   repository: file://../traces
-  version: 0.2.3
-digest: sha256:1b5d7badad8aab05b928e247b00373f3b773df9a788fd5959932e26ca6c51107
-generated: "2023-11-09T08:54:22.781964086-05:00"
+  version: 0.2.4
+digest: sha256:7fe2e33514dd32f4600ef4e157d8d36ecce6031c45ef3556a988adadd1279fb1
+generated: "2023-11-13T10:21:53.911028432-05:00"

--- a/charts/stack/Chart.yaml
+++ b/charts/stack/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: stack
 description: Observe Kubernetes agent stack
 type: application
-version: 0.4.5
+version: 0.4.6
 dependencies:
   - name: logs
     version: 0.1.12
@@ -21,7 +21,7 @@ dependencies:
     repository: file://../proxy
     condition: proxy.enabled
   - name: traces
-    version: 0.2.3
+    version: 0.2.4
     repository: file://../traces
     condition: traces.enabled
 maintainers:

--- a/charts/stack/README.md
+++ b/charts/stack/README.md
@@ -1,6 +1,6 @@
 # stack
 
-![Version: 0.4.5](https://img.shields.io/badge/Version-0.4.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.4.6](https://img.shields.io/badge/Version-0.4.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Observe Kubernetes agent stack
 
@@ -18,7 +18,7 @@ Observe Kubernetes agent stack
 | file://../logs | logs | 0.1.12 |
 | file://../metrics | metrics | 0.3.6 |
 | file://../proxy | proxy | 0.1.3 |
-| file://../traces | traces | 0.2.3 |
+| file://../traces | traces | 0.2.4 |
 
 ## Values
 

--- a/charts/traces/Chart.yaml
+++ b/charts/traces/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traces
 description: Observe OpenTelemetry trace collection
 type: application
-version: 0.2.3
+version: 0.2.4
 dependencies:
   - name: opentelemetry-collector
     version: 0.69.0

--- a/charts/traces/README.md
+++ b/charts/traces/README.md
@@ -1,6 +1,6 @@
 # traces
 
-![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.2.4](https://img.shields.io/badge/Version-0.2.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Observe OpenTelemetry trace collection
 
@@ -93,6 +93,7 @@ Observe OpenTelemetry trace collection
 | opentelemetry-collector.extraEnvs[2].name | string | `"OBSERVE_TOKEN"` |  |
 | opentelemetry-collector.extraEnvs[2].valueFrom.secretKeyRef.key | string | `"OBSERVE_TOKEN"` |  |
 | opentelemetry-collector.extraEnvs[2].valueFrom.secretKeyRef.name | string | `"otel-credentials"` |  |
+| opentelemetry-collector.fullnameOverride | string | `"observe-traces"` |  |
 | opentelemetry-collector.image.tag | string | `"0.62.1"` |  |
 | opentelemetry-collector.livenessProbe.initialDelaySeconds | int | `5` |  |
 | opentelemetry-collector.mode | string | `"daemonset"` |  |

--- a/charts/traces/ci/test-values.yaml
+++ b/charts/traces/ci/test-values.yaml
@@ -20,6 +20,7 @@ proxy:
     value: "http://test-traces.testing.svc.cluster.local:4318"
 
 opentelemetry-collector:
+  fullnameOverride: "test-traces"
   mode: deployment
   replicaCount: 1
   resources:

--- a/charts/traces/values.yaml
+++ b/charts/traces/values.yaml
@@ -7,6 +7,7 @@ proxy:
   enabled: false
 
 opentelemetry-collector:
+  fullnameOverride: "observe-traces"
   nameOverride: traces
   image:
     tag: "0.62.1"


### PR DESCRIPTION
We need to explicitely set opentelemetry-collector.fullnameOverride to observe-traces to match our documentation. The issue is by default the `helm install` uses the release name to build the service name so

`helm install blah` results in
```
# Source: stack/charts/traces/charts/opentelemetry-collector/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: blah-traces
  namespace: observe
```

Going forward `helm install blah` will always result in
```
# Source: stack/charts/traces/charts/opentelemetry-collector/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: observe-traces
  namespace: observe
```