### PR TITLE
fix(traces): split pod_association rules and remove node filtering in k8sattributes processor

### DIFF
--- a/charts/stack/Chart.lock
+++ b/charts/stack/Chart.lock
@@ -13,6 +13,6 @@ dependencies:
   version: 0.1.3
 - name: traces
   repository: file://../traces
-  version: 0.2.5
-digest: sha256:b5a9d5c7f06756337a79df7e5a73172d43d54ee142f11b60fb1228a5dfa0b591
-generated: "2023-11-15T10:52:47.595698-05:00"
+  version: 0.2.6
+digest: sha256:d2631a5f6a4107405bf0c4eac2276835b6a6b7106857f10094993dcb904b17c0
+generated: "2023-11-16T11:13:17.322825-05:00"

--- a/charts/stack/Chart.yaml
+++ b/charts/stack/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: stack
 description: Observe Kubernetes agent stack
 type: application
-version: 0.4.7
+version: 0.4.8
 dependencies:
   - name: logs
     version: 0.1.12
@@ -21,7 +21,7 @@ dependencies:
     repository: file://../proxy
     condition: proxy.enabled
   - name: traces
-    version: 0.2.5
+    version: 0.2.6
     repository: file://../traces
     condition: traces.enabled
 maintainers:

--- a/charts/stack/README.md
+++ b/charts/stack/README.md
@@ -1,6 +1,6 @@
 # stack
 
-![Version: 0.4.7](https://img.shields.io/badge/Version-0.4.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.4.8](https://img.shields.io/badge/Version-0.4.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Observe Kubernetes agent stack
 
@@ -18,7 +18,7 @@ Observe Kubernetes agent stack
 | file://../logs | logs | 0.1.12 |
 | file://../metrics | metrics | 0.3.6 |
 | file://../proxy | proxy | 0.1.3 |
-| file://../traces | traces | 0.2.5 |
+| file://../traces | traces | 0.2.6 |
 
 ## Values
 

--- a/charts/traces/Chart.lock
+++ b/charts/traces/Chart.lock
@@ -9,4 +9,4 @@ dependencies:
   repository: file://../proxy
   version: 0.1.3
 digest: sha256:8426f1587deb61ba68ceada3f20fc94980baf00d2ba0aef6602df95f4a573713
-generated: "2023-11-15T10:52:27.020997-05:00"
+generated: "2023-11-16T11:13:12.730825-05:00"

--- a/charts/traces/Chart.yaml
+++ b/charts/traces/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traces
 description: Observe OpenTelemetry trace collection
 type: application
-version: 0.2.5
+version: 0.2.6
 dependencies:
   - name: opentelemetry-collector
     version: 0.73.1

--- a/charts/traces/README.md
+++ b/charts/traces/README.md
@@ -1,6 +1,6 @@
 # traces
 
-![Version: 0.2.5](https://img.shields.io/badge/Version-0.2.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.2.6](https://img.shields.io/badge/Version-0.2.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Observe OpenTelemetry trace collection
 
@@ -46,14 +46,14 @@ Observe OpenTelemetry trace collection
 | opentelemetry-collector.config.extensions.health_check | object | `{}` |  |
 | opentelemetry-collector.config.extensions.zpages | object | `{}` |  |
 | opentelemetry-collector.config.processors.batch | string | `nil` |  |
+| opentelemetry-collector.config.processors.k8sattributes.auth_type | string | `"serviceAccount"` |  |
 | opentelemetry-collector.config.processors.k8sattributes.extract.metadata[0] | string | `"k8s.pod.name"` |  |
 | opentelemetry-collector.config.processors.k8sattributes.extract.metadata[1] | string | `"k8s.namespace.name"` |  |
 | opentelemetry-collector.config.processors.k8sattributes.extract.metadata[2] | string | `"k8s.cluster.uid"` |  |
-| opentelemetry-collector.config.processors.k8sattributes.filter.node_from_env_var | string | `"NODE_NAME"` |  |
 | opentelemetry-collector.config.processors.k8sattributes.passthrough | bool | `false` |  |
 | opentelemetry-collector.config.processors.k8sattributes.pod_association[0].sources[0].from | string | `"resource_attribute"` |  |
 | opentelemetry-collector.config.processors.k8sattributes.pod_association[0].sources[0].name | string | `"k8s.pod.ip"` |  |
-| opentelemetry-collector.config.processors.k8sattributes.pod_association[0].sources[1].from | string | `"connection"` |  |
+| opentelemetry-collector.config.processors.k8sattributes.pod_association[1].sources[0].from | string | `"connection"` |  |
 | opentelemetry-collector.config.processors.memory_limiter.check_interval | string | `"5s"` |  |
 | opentelemetry-collector.config.processors.memory_limiter.limit_mib | int | `192` |  |
 | opentelemetry-collector.config.processors.memory_limiter.spike_limit_mib | int | `100` |  |

--- a/charts/traces/values.yaml
+++ b/charts/traces/values.yaml
@@ -111,9 +111,8 @@ opentelemetry-collector:
         hash_seed: 22
         sampling_percentage: 100
       k8sattributes:
+        auth_type: serviceAccount
         passthrough: false
-        filter:
-          node_from_env_var: NODE_NAME
         extract:
           metadata:
             - k8s.pod.name
@@ -123,6 +122,7 @@ opentelemetry-collector:
           - sources:
               - from: resource_attribute
                 name: k8s.pod.ip
+          - sources:
               - from: connection
       batch:
       memory_limiter:


### PR DESCRIPTION
traces:
 - `connection` pod_association needs to be a separate rule
 - filtering nodes for caching pod attributes tends to break metrics and require nodes RBAC, which is not well documented upstream, so reverting for now

Kustomize PR: https://github.com/observeinc/manifests/pull/132