### PR TITLE
fix(traces): use v2 otel endpoint for tracing

### DIFF
--- a/charts/stack/Chart.lock
+++ b/charts/stack/Chart.lock
@@ -13,6 +13,6 @@ dependencies:
   version: 0.1.3
 - name: traces
   repository: file://../traces
-  version: 0.2.7
-digest: sha256:2f3edd9700b20aae7eb9adb67d38df20602377b22a8e0b9a9236af4362457823
-generated: "2023-11-29T12:42:11.5012943-05:00"
+  version: 0.2.8
+digest: sha256:d86f4f6ae8cdf6db3b494920b07885b1a11b7ff4523e825523717586db533873
+generated: "2023-12-13T12:23:12.626276-08:00"

--- a/charts/stack/Chart.yaml
+++ b/charts/stack/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: stack
 description: Observe Kubernetes agent stack
 type: application
-version: 0.4.12
+version: 0.4.13
 dependencies:
   - name: logs
     version: 0.1.13
@@ -21,7 +21,7 @@ dependencies:
     repository: file://../proxy
     condition: proxy.enabled
   - name: traces
-    version: 0.2.7
+    version: 0.2.8
     repository: file://../traces
     condition: traces.enabled
 maintainers:

--- a/charts/stack/README.md
+++ b/charts/stack/README.md
@@ -1,6 +1,6 @@
 # stack
 
-![Version: 0.4.12](https://img.shields.io/badge/Version-0.4.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.4.13](https://img.shields.io/badge/Version-0.4.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Observe Kubernetes agent stack
 
@@ -18,7 +18,7 @@ Observe Kubernetes agent stack
 | file://../logs | logs | 0.1.13 |
 | file://../metrics | metrics | 0.3.8 |
 | file://../proxy | proxy | 0.1.3 |
-| file://../traces | traces | 0.2.7 |
+| file://../traces | traces | 0.2.8 |
 
 ## Values
 

--- a/charts/traces/Chart.yaml
+++ b/charts/traces/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traces
 description: Observe OpenTelemetry trace collection
 type: application
-version: 0.2.7
+version: 0.2.8
 dependencies:
   - name: opentelemetry-collector
     version: 0.74.1

--- a/charts/traces/README.md
+++ b/charts/traces/README.md
@@ -1,6 +1,6 @@
 # traces
 
-![Version: 0.2.7](https://img.shields.io/badge/Version-0.2.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.2.8](https://img.shields.io/badge/Version-0.2.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Observe OpenTelemetry trace collection
 
@@ -38,7 +38,7 @@ Observe OpenTelemetry trace collection
 | opentelemetry-collector.clusterRole.rules[0].verbs[2] | string | `"watch"` |  |
 | opentelemetry-collector.command.extraArgs[0] | string | `"--set=service.telemetry.metrics.address=:58888"` |  |
 | opentelemetry-collector.config.exporters.logging.loglevel | string | `"info"` |  |
-| opentelemetry-collector.config.exporters.otlphttp.endpoint | string | `"{{ include \"observe.collectionEndpoint\" . }}/v1/otel"` |  |
+| opentelemetry-collector.config.exporters.otlphttp.endpoint | string | `"{{ include \"observe.collectionEndpoint\" . }}/v2/otel"` |  |
 | opentelemetry-collector.config.exporters.otlphttp.headers.authorization | string | `"Bearer ${OBSERVE_TOKEN}"` |  |
 | opentelemetry-collector.config.exporters.otlphttp.retry_on_failure.enabled | bool | `true` |  |
 | opentelemetry-collector.config.exporters.otlphttp.sending_queue.num_consumers | int | `4` |  |

--- a/charts/traces/templates/tests/test-traces.yaml
+++ b/charts/traces/templates/tests/test-traces.yaml
@@ -15,5 +15,5 @@ spec:
       # Queries have the format <JMESPath query> -> <matching regexp>.
       # This syntax is based on the syntax used in the JMESPath docs, which describe queries as:
       # search(query, input) -> result
-      - -q="Path -> ^/v1/otel/v1/traces$"
+      - -q="Path -> ^/v2/otel/v1/traces$"
       - 'http://test-traces-collector.testing.svc.cluster.local:8080/dump'

--- a/charts/traces/values.yaml
+++ b/charts/traces/values.yaml
@@ -95,7 +95,7 @@ opentelemetry-collector:
       logging:
         loglevel: info
       otlphttp:
-        endpoint: '{{ include "observe.collectionEndpoint" . }}/v1/otel'
+        endpoint: '{{ include "observe.collectionEndpoint" . }}/v2/otel'
         headers:
           authorization: "Bearer ${OBSERVE_TOKEN}"
         sending_queue:


### PR DESCRIPTION
DO NOT MERGE UNTIL ALL CUSTOMERS HAVE MIGRATED TO LATEST OTEL APP!!
Our otel endpoint is being updated to flatten attributes.  We need to update the charts to use the new endpoint when it hits production.  This updates the charts to accommodate.