### PR TITLE
fix: pull fluent-bit image from docker hub

### DIFF
--- a/charts/logs/Chart.lock
+++ b/charts/logs/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: fluent-bit
   repository: https://fluent.github.io/helm-charts
-  version: 0.40.0
+  version: 0.42.0
 - name: endpoint
   repository: file://../endpoint
   version: 0.1.8
-digest: sha256:6db156ab78ce43d4d883e3d9ff105468f2abacae3567e473304a1f8b1e167f82
-generated: "2023-12-21T15:57:16.190252-08:00"
+digest: sha256:d2be76d61d8d0da5b4daf11f54eb9e3b3da358014cb209e22e6fcd29a0f0d2ee
+generated: "2024-01-11T12:30:02.700366-08:00"

--- a/charts/logs/Chart.yaml
+++ b/charts/logs/Chart.yaml
@@ -2,10 +2,10 @@ apiVersion: v2
 name: logs
 description: Observe logs collection
 type: application
-version: 0.1.14
+version: 0.1.15
 dependencies:
   - name: fluent-bit
-    version: 0.40.0
+    version: 0.42.0
     repository: https://fluent.github.io/helm-charts
   - name: endpoint
     version: 0.1.8

--- a/charts/logs/README.md
+++ b/charts/logs/README.md
@@ -1,6 +1,6 @@
 # logs
 
-![Version: 0.1.14](https://img.shields.io/badge/Version-0.1.14-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.1.15](https://img.shields.io/badge/Version-0.1.15-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Observe logs collection
 
@@ -15,7 +15,7 @@ Observe logs collection
 | Repository | Name | Version |
 |------------|------|---------|
 | file://../endpoint | endpoint | 0.1.8 |
-| https://fluent.github.io/helm-charts | fluent-bit | 0.40.0 |
+| https://fluent.github.io/helm-charts | fluent-bit | 0.42.0 |
 
 ## Values
 
@@ -62,6 +62,7 @@ Observe logs collection
 | fluent-bit.env[2].valueFrom.fieldRef.fieldPath | string | `"spec.nodeName"` |  |
 | fluent-bit.env[3].name | string | `"NAMESPACE"` |  |
 | fluent-bit.env[3].valueFrom.fieldRef.fieldPath | string | `"metadata.namespace"` |  |
+| fluent-bit.image.repository | string | `"fluent/fluent-bit"` |  |
 | fluent-bit.nameOverride | string | `"logs"` |  |
 | fluent-bit.resources.limits.cpu | string | `"100m"` |  |
 | fluent-bit.resources.limits.memory | string | `"128Mi"` |  |

--- a/charts/logs/values.yaml
+++ b/charts/logs/values.yaml
@@ -3,6 +3,8 @@ global:
   observe: {}
 
 fluent-bit:
+  image:
+    repository: fluent/fluent-bit
   nameOverride: logs
   env:
     - name: OBSERVE_CLUSTER

--- a/charts/metrics/Chart.lock
+++ b/charts/metrics/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: grafana-agent
   repository: https://grafana.github.io/helm-charts
-  version: 0.29.0
+  version: 0.31.0
 - name: endpoint
   repository: file://../endpoint
   version: 0.1.8
-digest: sha256:596eeaee92fec5f5379fe1b7253318d8b2f5c51d5ef55c7fcabe943ce37a4fb4
-generated: "2023-12-21T15:57:17.875581-08:00"
+digest: sha256:aad73ac788c587aba5f595e569ca939a8cc2b6eae18573462c5667d6379f0a22
+generated: "2024-01-11T12:30:04.567641-08:00"

--- a/charts/metrics/Chart.yaml
+++ b/charts/metrics/Chart.yaml
@@ -2,10 +2,10 @@ apiVersion: v2
 name: metrics
 description: Observe metrics collection
 type: application
-version: 0.3.10
+version: 0.3.11
 dependencies:
   - name: grafana-agent
-    version: 0.29.0
+    version: 0.31.0
     repository: https://grafana.github.io/helm-charts
   - name: endpoint
     version: 0.1.8

--- a/charts/metrics/README.md
+++ b/charts/metrics/README.md
@@ -1,6 +1,6 @@
 # metrics
 
-![Version: 0.3.10](https://img.shields.io/badge/Version-0.3.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.3.11](https://img.shields.io/badge/Version-0.3.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Observe metrics collection
 
@@ -15,7 +15,7 @@ Observe metrics collection
 | Repository | Name | Version |
 |------------|------|---------|
 | file://../endpoint | endpoint | 0.1.8 |
-| https://grafana.github.io/helm-charts | grafana-agent | 0.29.0 |
+| https://grafana.github.io/helm-charts | grafana-agent | 0.31.0 |
 
 ## Values
 

--- a/charts/stack/Chart.lock
+++ b/charts/stack/Chart.lock
@@ -1,10 +1,10 @@
 dependencies:
 - name: logs
   repository: file://../logs
-  version: 0.1.14
+  version: 0.1.15
 - name: metrics
   repository: file://../metrics
-  version: 0.3.10
+  version: 0.3.11
 - name: events
   repository: file://../events
   version: 0.1.20
@@ -13,6 +13,6 @@ dependencies:
   version: 0.1.4
 - name: traces
   repository: file://../traces
-  version: 0.2.9
-digest: sha256:349ec4eacc047a34efc954d9233c5ef6233e87c16474f68298a955fc9cbe2410
-generated: "2023-12-21T15:57:19.249921-08:00"
+  version: 0.2.10
+digest: sha256:1393f876bf575db4f2ecb6fc3009932613e5fc335e310fe12ba43288a3f1b03f
+generated: "2024-01-11T12:30:22.435663-08:00"

--- a/charts/stack/Chart.yaml
+++ b/charts/stack/Chart.yaml
@@ -2,14 +2,14 @@ apiVersion: v2
 name: stack
 description: Observe Kubernetes agent stack
 type: application
-version: 0.4.14
+version: 0.4.15
 dependencies:
   - name: logs
-    version: 0.1.14
+    version: 0.1.15
     repository: file://../logs
     condition: logs.enabled
   - name: metrics
-    version: 0.3.10
+    version: 0.3.11
     repository: file://../metrics
     condition: metrics.enabled
   - name: events
@@ -21,7 +21,7 @@ dependencies:
     repository: file://../proxy
     condition: proxy.enabled
   - name: traces
-    version: 0.2.9
+    version: 0.2.10
     repository: file://../traces
     condition: traces.enabled
 maintainers:

--- a/charts/stack/README.md
+++ b/charts/stack/README.md
@@ -1,6 +1,6 @@
 # stack
 
-![Version: 0.4.14](https://img.shields.io/badge/Version-0.4.14-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.4.15](https://img.shields.io/badge/Version-0.4.15-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Observe Kubernetes agent stack
 
@@ -15,10 +15,10 @@ Observe Kubernetes agent stack
 | Repository | Name | Version |
 |------------|------|---------|
 | file://../events | events | 0.1.20 |
-| file://../logs | logs | 0.1.14 |
-| file://../metrics | metrics | 0.3.10 |
+| file://../logs | logs | 0.1.15 |
+| file://../metrics | metrics | 0.3.11 |
 | file://../proxy | proxy | 0.1.4 |
-| file://../traces | traces | 0.2.9 |
+| file://../traces | traces | 0.2.10 |
 
 ## Values
 

--- a/charts/traces/Chart.lock
+++ b/charts/traces/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: opentelemetry-collector
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
-  version: 0.77.0
+  version: 0.78.0
 - name: endpoint
   repository: file://../endpoint
   version: 0.1.8
 - name: proxy
   repository: file://../proxy
   version: 0.1.4
-digest: sha256:3124a89fc2e459f135aa44ab98b9f24afcba688a7334c42a6900b2f56b4513ed
-generated: "2023-12-21T15:57:19.813099-08:00"
+digest: sha256:51997814273aea7a9d1e56b9732e67c55f75d9b3143e7c30470b65d89eb414eb
+generated: "2024-01-11T12:30:06.722282-08:00"

--- a/charts/traces/Chart.yaml
+++ b/charts/traces/Chart.yaml
@@ -2,10 +2,10 @@ apiVersion: v2
 name: traces
 description: Observe OpenTelemetry trace collection
 type: application
-version: 0.2.9
+version: 0.2.10
 dependencies:
   - name: opentelemetry-collector
-    version: 0.77.0
+    version: 0.78.0
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
   - name: endpoint
     version: 0.1.8

--- a/charts/traces/README.md
+++ b/charts/traces/README.md
@@ -1,6 +1,6 @@
 # traces
 
-![Version: 0.2.9](https://img.shields.io/badge/Version-0.2.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.2.10](https://img.shields.io/badge/Version-0.2.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Observe OpenTelemetry trace collection
 
@@ -16,7 +16,7 @@ Observe OpenTelemetry trace collection
 |------------|------|---------|
 | file://../endpoint | endpoint | 0.1.8 |
 | file://../proxy | proxy | 0.1.4 |
-| https://open-telemetry.github.io/opentelemetry-helm-charts | opentelemetry-collector | 0.77.0 |
+| https://open-telemetry.github.io/opentelemetry-helm-charts | opentelemetry-collector | 0.78.0 |
 
 ## Values
 


### PR DESCRIPTION
Our kustomize manifests pull images from dockerhub which has higher rate limits than fluent-bit's registry.  This ensures that our kustomize and helm deployments are in sync.