### PR TITLE
fix(metrics): drop pod metrics by default

### DIFF
--- a/charts/metrics/Chart.yaml
+++ b/charts/metrics/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: metrics
 description: Observe metrics collection
 type: application
-version: 0.3.13
+version: 0.3.14
 dependencies:
   - name: grafana-agent
     version: 0.31.1

--- a/charts/metrics/README.md
+++ b/charts/metrics/README.md
@@ -1,6 +1,6 @@
 # metrics
 
-![Version: 0.3.13](https://img.shields.io/badge/Version-0.3.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.3.14](https://img.shields.io/badge/Version-0.3.14-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Observe metrics collection
 
@@ -76,7 +76,7 @@ Observe metrics collection
 | grafana-agent.prom_config.scrape_configs.kubelet_interval | string | `nil` |  |
 | grafana-agent.prom_config.scrape_configs.kubelet_metric_drop_regex | string | `nil` |  |
 | grafana-agent.prom_config.scrape_configs.kubelet_metric_keep_regex | string | `"(.*)"` |  |
-| grafana-agent.prom_config.scrape_configs.pod_action | string | `"keep"` |  |
+| grafana-agent.prom_config.scrape_configs.pod_action | string | `"drop"` |  |
 | grafana-agent.prom_config.scrape_configs.pod_interval | string | `nil` |  |
 | grafana-agent.prom_config.scrape_configs.pod_metric_drop_regex | string | `".*bucket"` |  |
 | grafana-agent.prom_config.scrape_configs.pod_metric_keep_regex | string | `"(.*)"` |  |

--- a/charts/metrics/values.yaml
+++ b/charts/metrics/values.yaml
@@ -33,7 +33,7 @@ grafana-agent:
       # The following block can be used to enable or disable scraping of metrics from
       # the corresponding targets. See below for finer-grained filtering.
       kubelet_action: drop  # set to "drop" to drop all kubelet metrics
-      pod_action: keep  # set to "drop" to drop all pod metrics
+      pod_action: drop  # set to "drop" to drop all pod metrics
       resource_action: keep  # set to "drop" to drop all resource metrics
       cadvisor_action: keep  # set to "drop" to drop all cadvisor metrics
 

--- a/charts/stack/Chart.lock
+++ b/charts/stack/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 0.1.19
 - name: metrics
   repository: file://../metrics
-  version: 0.3.13
+  version: 0.3.14
 - name: events
   repository: file://../events
   version: 0.1.21
@@ -14,5 +14,5 @@ dependencies:
 - name: traces
   repository: file://../traces
   version: 0.2.13
-digest: sha256:0f52d5524d2cd99e41db1527ff82d658a0c25046e363b7f19e4dc1a9365bb1bf
-generated: "2024-01-31T12:12:20.297074-08:00"
+digest: sha256:c0a3de4bff4793a3c97bd70607aed3a90e01fbe7883e712ff43f86c5cee7d314
+generated: "2024-01-31T13:30:28.364035-08:00"

--- a/charts/stack/Chart.yaml
+++ b/charts/stack/Chart.yaml
@@ -2,14 +2,14 @@ apiVersion: v2
 name: stack
 description: Observe Kubernetes agent stack
 type: application
-version: 0.4.19
+version: 0.4.20
 dependencies:
   - name: logs
     version: 0.1.19
     repository: file://../logs
     condition: logs.enabled
   - name: metrics
-    version: 0.3.13
+    version: 0.3.14
     repository: file://../metrics
     condition: metrics.enabled
   - name: events

--- a/charts/stack/README.md
+++ b/charts/stack/README.md
@@ -1,6 +1,6 @@
 # stack
 
-![Version: 0.4.19](https://img.shields.io/badge/Version-0.4.19-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.4.20](https://img.shields.io/badge/Version-0.4.20-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Observe Kubernetes agent stack
 
@@ -16,7 +16,7 @@ Observe Kubernetes agent stack
 |------------|------|---------|
 | file://../events | events | 0.1.21 |
 | file://../logs | logs | 0.1.19 |
-| file://../metrics | metrics | 0.3.13 |
+| file://../metrics | metrics | 0.3.14 |
 | file://../proxy | proxy | 0.1.4 |
 | file://../traces | traces | 0.2.13 |
 


### PR DESCRIPTION
https://www.notion.so/observeinc/Kubernetes-Follow-up-on-OB-27594-0c3e01f24f554505bde424517870bdbb#1c00281607504f19ada61a3a75565411

Address #2 

Tested and verified in K8s that metrics are dropped 

<img width="1072" alt="Screenshot 2024-01-31 at 1 31 31 PM" src="https://github.com/observeinc/helm-charts/assets/124205220/bdf32991-c3e8-4ffc-b31d-70ba27fe80a7">
