### PR TITLE
fix(traces): Makes collection endpoint path configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ For example:
 ```
 helm install --namespace=observe observe-traces observe/traces \
 	--set global.observe.collectionEndpoint="${OBSERVE_COLLECTION_ENDPOINT}" \
-	--set global.observe.collectionEndpoint="/v2/otel" \
+	--set global.observe.otelPath="/v2/otel" \
 	--set observe.token.value="${OBSERVE_TOKEN}"
 ```
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,21 @@ helm install --namespace=observe observe-traces observe/traces \
 helm -n observe get values observe-traces -o yaml > observe-traces-values.yaml
 ```
 
+### Using v2 of collection endpoint
+
+If you are using the 1.0.0 release of the OpenTelemetry Observe app or newer, you should use the v2 collection endpoint which
+provides a more efficient representation of trace observations in the datastream. To use the v2 collection endpoint,
+set `global.observe.otelPath` to `/v2/otel`. The default value is `/v1/otel`.
+
+For example:
+
+```
+helm install --namespace=observe observe-traces observe/traces \
+	--set global.observe.collectionEndpoint="${OBSERVE_COLLECTION_ENDPOINT}" \
+	--set global.observe.collectionEndpoint="/v2/otel" \
+	--set observe.token.value="${OBSERVE_TOKEN}"
+```
+
 # Configuration
 
 ## Required Values

--- a/charts/stack/Chart.lock
+++ b/charts/stack/Chart.lock
@@ -13,6 +13,6 @@ dependencies:
   version: 0.1.4
 - name: traces
   repository: file://../traces
-  version: 0.2.13
-digest: sha256:df6f9c7fa7bf3aac32799481808be8cc1f8f2b5aaa042bafeebaf75ffd107895
-generated: "2024-01-31T14:26:51.350494-08:00"
+  version: 0.2.14
+digest: sha256:2002d3f4835af681bfa20572e40e2d465d6ea7eeaf2c91e7e7d30c960de186c2
+generated: "2024-02-06T17:54:34.772791-08:00"

--- a/charts/stack/Chart.yaml
+++ b/charts/stack/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: stack
 description: Observe Kubernetes agent stack
 type: application
-version: 0.4.21
+version: 0.4.22
 dependencies:
   - name: logs
     version: 0.1.19
@@ -21,7 +21,7 @@ dependencies:
     repository: file://../proxy
     condition: proxy.enabled
   - name: traces
-    version: 0.2.13
+    version: 0.2.14
     repository: file://../traces
     condition: traces.enabled
 maintainers:

--- a/charts/stack/README.md
+++ b/charts/stack/README.md
@@ -1,6 +1,6 @@
 # stack
 
-![Version: 0.4.21](https://img.shields.io/badge/Version-0.4.21-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.4.22](https://img.shields.io/badge/Version-0.4.22-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Observe Kubernetes agent stack
 
@@ -18,7 +18,7 @@ Observe Kubernetes agent stack
 | file://../logs | logs | 0.1.19 |
 | file://../metrics | metrics | 0.3.15 |
 | file://../proxy | proxy | 0.1.4 |
-| file://../traces | traces | 0.2.13 |
+| file://../traces | traces | 0.2.14 |
 
 ## Values
 

--- a/charts/traces/Chart.yaml
+++ b/charts/traces/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traces
 description: Observe OpenTelemetry trace collection
 type: application
-version: 0.2.13
+version: 0.2.14
 dependencies:
   - name: opentelemetry-collector
     version: 0.80.0

--- a/charts/traces/README.md
+++ b/charts/traces/README.md
@@ -1,6 +1,6 @@
 # traces
 
-![Version: 0.2.13](https://img.shields.io/badge/Version-0.2.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.2.14](https://img.shields.io/badge/Version-0.2.14-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Observe OpenTelemetry trace collection
 

--- a/charts/traces/README.md
+++ b/charts/traces/README.md
@@ -22,6 +22,7 @@ Observe OpenTelemetry trace collection
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| global.observe.otelPath | string | `"/v1/otel"` |  |
 | observe.token.create | bool | `true` |  |
 | observe.token.value | string | `""` |  |
 | opentelemetry-collector.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key | string | `"observeinc.com/unschedulable"` |  |
@@ -38,7 +39,7 @@ Observe OpenTelemetry trace collection
 | opentelemetry-collector.clusterRole.rules[0].verbs[2] | string | `"watch"` |  |
 | opentelemetry-collector.command.extraArgs[0] | string | `"--set=service.telemetry.metrics.address=:58888"` |  |
 | opentelemetry-collector.config.exporters.logging.loglevel | string | `"info"` |  |
-| opentelemetry-collector.config.exporters.otlphttp.endpoint | string | `"{{ include \"observe.collectionEndpoint\" . }}/v1/otel"` |  |
+| opentelemetry-collector.config.exporters.otlphttp.endpoint | string | `"{{ include \"observe.collectionEndpoint\" . }}{{ .Values.global.observe.otelPath }}"` |  |
 | opentelemetry-collector.config.exporters.otlphttp.headers.authorization | string | `"Bearer ${OBSERVE_TOKEN}"` |  |
 | opentelemetry-collector.config.exporters.otlphttp.retry_on_failure.enabled | bool | `true` |  |
 | opentelemetry-collector.config.exporters.otlphttp.sending_queue.num_consumers | int | `4` |  |

--- a/charts/traces/values.yaml
+++ b/charts/traces/values.yaml
@@ -1,3 +1,7 @@
+gloabal:
+  observe:
+    otelPath: "/v1/otel"
+
 observe:
   token:
     create: true
@@ -95,7 +99,7 @@ opentelemetry-collector:
       logging:
         loglevel: info
       otlphttp:
-        endpoint: '{{ include "observe.collectionEndpoint" . }}/v1/otel'
+        endpoint: '{{ include "observe.collectionEndpoint" . }}{{ .Values.global.observe.otelPath }}'
         headers:
           authorization: "Bearer ${OBSERVE_TOKEN}"
         sending_queue:

--- a/charts/traces/values.yaml
+++ b/charts/traces/values.yaml
@@ -1,4 +1,4 @@
-gloabal:
+global:
   observe:
     otelPath: "/v1/otel"
 


### PR DESCRIPTION
https://observe.atlassian.net/browse/OB-28334

Introduces a new optional configuration value `global.observe.otelPath` which is set to `/v1/otel` by default. Can be set to `/v2/otel` to send OpenTelemetry observations to v2 version of collection endpoint. 