### PR TITLE
fix(metrics): disable CRDs deployed by grafana-agent subchart

### DIFF
--- a/charts/endpoint/Chart.yaml
+++ b/charts/endpoint/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: endpoint
 description: Observe collection endpoint utility functions
 type: library
-version: 0.1.9
+version: 0.1.10
 maintainers:
   - name: Observe
     email: support@observeinc.com

--- a/charts/endpoint/README.md
+++ b/charts/endpoint/README.md
@@ -1,6 +1,6 @@
 # endpoint
 
-![Version: 0.1.9](https://img.shields.io/badge/Version-0.1.9-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
+![Version: 0.1.10](https://img.shields.io/badge/Version-0.1.10-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
 
 Observe collection endpoint utility functions
 

--- a/charts/events/Chart.lock
+++ b/charts/events/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: endpoint
   repository: file://../endpoint
-  version: 0.1.9
-digest: sha256:702a3ceb9db0b8dd381e8fb26eed9ded7ac6b9efac2862b2b4a81163aad66f93
-generated: "2024-03-11T15:27:47.409137-07:00"
+  version: 0.1.10
+digest: sha256:8fcb378ae8c303b61722b1929b9ed7ab4a151257e15d3c305b1647a75b4bdbd7
+generated: "2024-03-15T15:09:02.904517-04:00"

--- a/charts/events/Chart.yaml
+++ b/charts/events/Chart.yaml
@@ -2,11 +2,11 @@ apiVersion: v2
 name: events
 description: Observe kubernetes event collection
 type: application
-version: 0.1.22
+version: 0.1.23
 appVersion: v0.11.1
 dependencies:
   - name: endpoint
-    version: 0.1.9
+    version: 0.1.10
     repository: file://../endpoint
 maintainers:
   - name: Observe

--- a/charts/events/README.md
+++ b/charts/events/README.md
@@ -1,6 +1,6 @@
 # events
 
-![Version: 0.1.22](https://img.shields.io/badge/Version-0.1.22-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.11.1](https://img.shields.io/badge/AppVersion-v0.11.1-informational?style=flat-square)
+![Version: 0.1.23](https://img.shields.io/badge/Version-0.1.23-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.11.1](https://img.shields.io/badge/AppVersion-v0.11.1-informational?style=flat-square)
 
 Observe kubernetes event collection
 
@@ -14,7 +14,7 @@ Observe kubernetes event collection
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../endpoint | endpoint | 0.1.9 |
+| file://../endpoint | endpoint | 0.1.10 |
 
 ## Values
 

--- a/charts/logs/Chart.lock
+++ b/charts/logs/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 0.43.0
 - name: endpoint
   repository: file://../endpoint
-  version: 0.1.9
-digest: sha256:aa915ea93520671c9b0a592b442b9d60c870599968fdc69aa910a52ee738d815
-generated: "2024-03-11T15:30:54.093615-07:00"
+  version: 0.1.10
+digest: sha256:9832cceb08ccc54bd6f03018cc74d45079ff691455fe9a756d7cac878df60615
+generated: "2024-03-15T15:08:56.504347-04:00"

--- a/charts/logs/Chart.yaml
+++ b/charts/logs/Chart.yaml
@@ -2,13 +2,13 @@ apiVersion: v2
 name: logs
 description: Observe logs collection
 type: application
-version: 0.1.21
+version: 0.1.22
 dependencies:
   - name: fluent-bit
     version: 0.43.0
     repository: https://fluent.github.io/helm-charts
   - name: endpoint
-    version: 0.1.9
+    version: 0.1.10
     repository: file://../endpoint
 maintainers:
   - name: Observe

--- a/charts/logs/README.md
+++ b/charts/logs/README.md
@@ -1,6 +1,6 @@
 # logs
 
-![Version: 0.1.21](https://img.shields.io/badge/Version-0.1.21-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.1.22](https://img.shields.io/badge/Version-0.1.22-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Observe logs collection
 
@@ -14,7 +14,7 @@ Observe logs collection
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../endpoint | endpoint | 0.1.9 |
+| file://../endpoint | endpoint | 0.1.10 |
 | https://fluent.github.io/helm-charts | fluent-bit | 0.43.0 |
 
 ## Values

--- a/charts/metrics/Chart.lock
+++ b/charts/metrics/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 0.31.1
 - name: endpoint
   repository: file://../endpoint
-  version: 0.1.9
-digest: sha256:36504bb80956c44a408775be884f1b2652835ed1cfc8b4771ef14db08cbc30c5
-generated: "2024-03-11T15:30:55.310557-07:00"
+  version: 0.1.10
+digest: sha256:e0c5a5f8cbac4cc39489032de28a1f32520b8c7749ddb084b9da67f23e35d15e
+generated: "2024-03-15T13:39:56.415484-04:00"

--- a/charts/metrics/Chart.yaml
+++ b/charts/metrics/Chart.yaml
@@ -2,13 +2,13 @@ apiVersion: v2
 name: metrics
 description: Observe metrics collection
 type: application
-version: 0.3.16
+version: 0.3.17
 dependencies:
   - name: grafana-agent
     version: 0.31.1
     repository: https://grafana.github.io/helm-charts
   - name: endpoint
-    version: 0.1.9
+    version: 0.1.10
     repository: file://../endpoint
 maintainers:
   - name: Observe

--- a/charts/metrics/README.md
+++ b/charts/metrics/README.md
@@ -1,6 +1,6 @@
 # metrics
 
-![Version: 0.3.16](https://img.shields.io/badge/Version-0.3.16-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.3.17](https://img.shields.io/badge/Version-0.3.17-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Observe metrics collection
 
@@ -14,7 +14,7 @@ Observe metrics collection
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../endpoint | endpoint | 0.1.9 |
+| file://../endpoint | endpoint | 0.1.10 |
 | https://grafana.github.io/helm-charts | grafana-agent | 0.31.1 |
 
 ## Values
@@ -52,6 +52,7 @@ Observe metrics collection
 | grafana-agent.controller.podLabels.name | string | `"metrics"` |  |
 | grafana-agent.controller.replicas | int | `1` |  |
 | grafana-agent.controller.type | string | `"deployment"` |  |
+| grafana-agent.crds.create | bool | `false` |  |
 | grafana-agent.image.tag | string | `"latest"` |  |
 | grafana-agent.nameOverride | string | `"metrics"` |  |
 | grafana-agent.prom_config.batch_send_deadline | string | `"5s"` |  |

--- a/charts/metrics/values.yaml
+++ b/charts/metrics/values.yaml
@@ -4,6 +4,8 @@ global:
 
 grafana-agent:
   nameOverride: metrics
+  crds:
+    create: false
   prom_config:
     batch_send_deadline: 5s
     capacity: 15000

--- a/charts/proxy/Chart.yaml
+++ b/charts/proxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: proxy
 description: "Observe agent proxy (for testing only, do not use)"
 type: application
-version: 0.1.5
+version: 0.1.6
 maintainers:
   - name: Observe
     email: support@observeinc.com

--- a/charts/proxy/README.md
+++ b/charts/proxy/README.md
@@ -1,6 +1,6 @@
 # proxy
 
-![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.1.6](https://img.shields.io/badge/Version-0.1.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Observe agent proxy (for testing only, do not use)
 

--- a/charts/stack/Chart.lock
+++ b/charts/stack/Chart.lock
@@ -1,18 +1,18 @@
 dependencies:
 - name: logs
   repository: file://../logs
-  version: 0.1.21
+  version: 0.1.22
 - name: metrics
   repository: file://../metrics
-  version: 0.3.16
+  version: 0.3.17
 - name: events
   repository: file://../events
-  version: 0.1.22
+  version: 0.1.23
 - name: proxy
   repository: file://../proxy
-  version: 0.1.5
+  version: 0.1.6
 - name: traces
   repository: file://../traces
-  version: 0.2.16
-digest: sha256:43d750c124a8e71b6195d8bbf99249fa565a27c260874d9cc86011aebe7a97eb
-generated: "2024-03-11T15:32:53.310977-07:00"
+  version: 0.2.17
+digest: sha256:0d5293b83b8546611a4a7e4c5d4936eaffd12d8dd9a8780b7d61ed2a80a30883
+generated: "2024-03-15T15:08:50.220545-04:00"

--- a/charts/stack/Chart.yaml
+++ b/charts/stack/Chart.yaml
@@ -2,26 +2,26 @@ apiVersion: v2
 name: stack
 description: Observe Kubernetes agent stack
 type: application
-version: 0.4.25
+version: 0.4.26
 dependencies:
   - name: logs
-    version: 0.1.21
+    version: 0.1.22
     repository: file://../logs
     condition: logs.enabled
   - name: metrics
-    version: 0.3.16
+    version: 0.3.17
     repository: file://../metrics
     condition: metrics.enabled
   - name: events
-    version: 0.1.22
+    version: 0.1.23
     repository: file://../events
     condition: events.enabled
   - name: proxy
-    version: 0.1.5
+    version: 0.1.6
     repository: file://../proxy
     condition: proxy.enabled
   - name: traces
-    version: 0.2.16
+    version: 0.2.17
     repository: file://../traces
     condition: traces.enabled
 maintainers:

--- a/charts/stack/README.md
+++ b/charts/stack/README.md
@@ -1,6 +1,6 @@
 # stack
 
-![Version: 0.4.25](https://img.shields.io/badge/Version-0.4.25-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.4.26](https://img.shields.io/badge/Version-0.4.26-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Observe Kubernetes agent stack
 
@@ -14,11 +14,11 @@ Observe Kubernetes agent stack
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../events | events | 0.1.22 |
-| file://../logs | logs | 0.1.21 |
-| file://../metrics | metrics | 0.3.16 |
-| file://../proxy | proxy | 0.1.5 |
-| file://../traces | traces | 0.2.16 |
+| file://../events | events | 0.1.23 |
+| file://../logs | logs | 0.1.22 |
+| file://../metrics | metrics | 0.3.17 |
+| file://../proxy | proxy | 0.1.6 |
+| file://../traces | traces | 0.2.17 |
 
 ## Values
 

--- a/charts/traces/Chart.lock
+++ b/charts/traces/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 0.80.0
 - name: endpoint
   repository: file://../endpoint
-  version: 0.1.9
+  version: 0.1.10
 - name: proxy
   repository: file://../proxy
-  version: 0.1.5
-digest: sha256:e16f4d4a005be78158e5f1df17cc3e2c2e523149a727c2a36d2130496857f4f4
-generated: "2024-03-11T15:31:59.018291-07:00"
+  version: 0.1.6
+digest: sha256:dd8d44c3d6a838105e1decf0a8a73ee960f7a97a90698b14016dbf8ce304b06e
+generated: "2024-03-15T15:09:08.768866-04:00"

--- a/charts/traces/Chart.yaml
+++ b/charts/traces/Chart.yaml
@@ -2,16 +2,16 @@ apiVersion: v2
 name: traces
 description: Observe OpenTelemetry trace collection
 type: application
-version: 0.2.16
+version: 0.2.17
 dependencies:
   - name: opentelemetry-collector
     version: 0.80.0
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
   - name: endpoint
-    version: 0.1.9
+    version: 0.1.10
     repository: file://../endpoint
   - name: proxy
-    version: 0.1.5
+    version: 0.1.6
     repository: file://../proxy
     condition: proxy.enabled
 maintainers:

--- a/charts/traces/README.md
+++ b/charts/traces/README.md
@@ -1,6 +1,6 @@
 # traces
 
-![Version: 0.2.16](https://img.shields.io/badge/Version-0.2.16-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.2.17](https://img.shields.io/badge/Version-0.2.17-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Observe OpenTelemetry trace collection
 
@@ -14,8 +14,8 @@ Observe OpenTelemetry trace collection
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../endpoint | endpoint | 0.1.9 |
-| file://../proxy | proxy | 0.1.5 |
+| file://../endpoint | endpoint | 0.1.10 |
+| file://../proxy | proxy | 0.1.6 |
 | https://open-telemetry.github.io/opentelemetry-helm-charts | opentelemetry-collector | 0.80.0 |
 
 ## Values


### PR DESCRIPTION
The grafana-agent helm chart deploys CRDs by default
```
crds:
  # -- Whether to install CRDs for monitoring.
  create: true
```
https://github.com/grafana/agent/blob/9d65d9f483ea2690f34681431dd32b6356a6026f/operations/helm/charts/grafana-agent/values.yaml#L23
Which tends to cause unnecessary errors for our customers, such as:
```
Failed sync attempt to 438b29f3078f29e227ed9569cb40b065172af04c: one or more objects failed to apply, reason: error when patching "/dev/shm/886469721": CustomResourceDefinition.apiextensions.k8s.io "podlogs.monitoring.grafana.com" is invalid: status.storedVersions[0]: Invalid value: "v1alpha1": must appear in spec.versions (retried 2 times).
```
Our helm chart should disable this by default going forward. 