### PR TITLE
fix(metrics): update grafana-agent and sync securityContext with upstream

### DIFF
--- a/charts/metrics/Chart.lock
+++ b/charts/metrics/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: grafana-agent
   repository: https://grafana.github.io/helm-charts
-  version: 0.31.1
+  version: 0.40.0
 - name: endpoint
   repository: file://../endpoint
   version: 0.1.10
-digest: sha256:e0c5a5f8cbac4cc39489032de28a1f32520b8c7749ddb084b9da67f23e35d15e
-generated: "2024-03-15T13:39:56.415484-04:00"
+digest: sha256:7d85d613367d07480492d19b1642215f3408403536434c5e910f5fb8c03e6255
+generated: "2024-06-04T13:12:18.548923-04:00"

--- a/charts/metrics/Chart.yaml
+++ b/charts/metrics/Chart.yaml
@@ -2,10 +2,10 @@ apiVersion: v2
 name: metrics
 description: Observe metrics collection
 type: application
-version: 0.3.17
+version: 0.3.18
 dependencies:
   - name: grafana-agent
-    version: 0.31.1
+    version: 0.40.0
     repository: https://grafana.github.io/helm-charts
   - name: endpoint
     version: 0.1.10

--- a/charts/metrics/README.md
+++ b/charts/metrics/README.md
@@ -1,6 +1,6 @@
 # metrics
 
-![Version: 0.3.17](https://img.shields.io/badge/Version-0.3.17-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.3.18](https://img.shields.io/badge/Version-0.3.18-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Observe metrics collection
 
@@ -15,7 +15,7 @@ Observe metrics collection
 | Repository | Name | Version |
 |------------|------|---------|
 | file://../endpoint | endpoint | 0.1.10 |
-| https://grafana.github.io/helm-charts | grafana-agent | 0.31.1 |
+| https://grafana.github.io/helm-charts | grafana-agent | 0.40.0 |
 
 ## Values
 
@@ -41,6 +41,7 @@ Observe metrics collection
 | grafana-agent.agent.resources.limits.memory | string | `"2Gi"` |  |
 | grafana-agent.agent.resources.requests.cpu | string | `"250m"` |  |
 | grafana-agent.agent.resources.requests.memory | string | `"2Gi"` |  |
+| grafana-agent.agent.securityContext.capabilities.add[0] | string | `"NET_BIND_SERVICE"` |  |
 | grafana-agent.agent.securityContext.capabilities.drop[0] | string | `"all"` |  |
 | grafana-agent.agent.securityContext.runAsNonRoot | bool | `true` |  |
 | grafana-agent.agent.securityContext.runAsUser | int | `65534` |  |

--- a/charts/metrics/values.yaml
+++ b/charts/metrics/values.yaml
@@ -133,7 +133,8 @@ grafana-agent:
       capabilities:
         drop:
           - all
-
+        add:
+          - NET_BIND_SERVICE
     configMap:
       content: |
         {{- $endpoint := include "observe.collectionEndpoint" . }}

--- a/charts/stack/Chart.lock
+++ b/charts/stack/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 0.1.24
 - name: metrics
   repository: file://../metrics
-  version: 0.3.17
+  version: 0.3.18
 - name: events
   repository: file://../events
   version: 0.1.23
@@ -14,5 +14,5 @@ dependencies:
 - name: traces
   repository: file://../traces
   version: 0.2.17
-digest: sha256:958df606a4949781f9261e7bb97a72a65a152d0c3a4c456bd49955b9594d6bc7
-generated: "2024-05-21T18:46:38.084748-04:00"
+digest: sha256:4430c9dd31d4f1b0145837c3fa98746ce481b9d21c52e37ecbb67376f030d974
+generated: "2024-06-04T13:16:09.174412-04:00"

--- a/charts/stack/Chart.yaml
+++ b/charts/stack/Chart.yaml
@@ -2,14 +2,14 @@ apiVersion: v2
 name: stack
 description: Observe Kubernetes agent stack
 type: application
-version: 0.4.28
+version: 0.4.29
 dependencies:
   - name: logs
     version: 0.1.24
     repository: file://../logs
     condition: logs.enabled
   - name: metrics
-    version: 0.3.17
+    version: 0.3.18
     repository: file://../metrics
     condition: metrics.enabled
   - name: events

--- a/charts/stack/README.md
+++ b/charts/stack/README.md
@@ -1,6 +1,6 @@
 # stack
 
-![Version: 0.4.28](https://img.shields.io/badge/Version-0.4.28-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.4.29](https://img.shields.io/badge/Version-0.4.29-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Observe Kubernetes agent stack
 
@@ -16,7 +16,7 @@ Observe Kubernetes agent stack
 |------------|------|---------|
 | file://../events | events | 0.1.23 |
 | file://../logs | logs | 0.1.24 |
-| file://../metrics | metrics | 0.3.17 |
+| file://../metrics | metrics | 0.3.18 |
 | file://../proxy | proxy | 0.1.6 |
 | file://../traces | traces | 0.2.17 |
 


### PR DESCRIPTION
Changes:
- Redo grafana-agent update to 0.41.0
- Fix breaking securityContext causing exec /bin/grafana-agent: operation not permitted (caused by addition of NET_BIND_SERVICE capability to the Dockerfile - https://github.com/grafana/agent/pull/6817/files#diff-d6958d823dc69b52225f8854987a363fb9e6d08725ab542c0d06f5443b9dee71)

Related: https://github.com/observeinc/manifests/pull/174