### PR TITLE
fix(metrics): pin grafana-agent image

### DIFF
--- a/charts/metrics/Chart.yaml
+++ b/charts/metrics/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: metrics
 description: Observe metrics collection
 type: application
-version: 0.3.18
+version: 0.3.19
 dependencies:
   - name: grafana-agent
     version: 0.40.0

--- a/charts/metrics/README.md
+++ b/charts/metrics/README.md
@@ -1,6 +1,6 @@
 # metrics
 
-![Version: 0.3.18](https://img.shields.io/badge/Version-0.3.18-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.3.19](https://img.shields.io/badge/Version-0.3.19-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Observe metrics collection
 
@@ -54,7 +54,6 @@ Observe metrics collection
 | grafana-agent.controller.replicas | int | `1` |  |
 | grafana-agent.controller.type | string | `"deployment"` |  |
 | grafana-agent.crds.create | bool | `false` |  |
-| grafana-agent.image.tag | string | `"latest"` |  |
 | grafana-agent.nameOverride | string | `"metrics"` |  |
 | grafana-agent.prom_config.batch_send_deadline | string | `"5s"` |  |
 | grafana-agent.prom_config.capacity | int | `15000` |  |

--- a/charts/metrics/values.yaml
+++ b/charts/metrics/values.yaml
@@ -95,9 +95,6 @@ grafana-agent:
                 - {key: observeinc.com/unschedulable, operator: DoesNotExist}
                 - {key: kubernetes.io/os, operator: NotIn, values: [windows]}
 
-  image:
-    tag: latest
-
   agent:
     mode: static
     enableReporting: false

--- a/charts/stack/Chart.lock
+++ b/charts/stack/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 0.1.24
 - name: metrics
   repository: file://../metrics
-  version: 0.3.18
+  version: 0.3.19
 - name: events
   repository: file://../events
   version: 0.1.23
@@ -14,5 +14,5 @@ dependencies:
 - name: traces
   repository: file://../traces
   version: 0.2.17
-digest: sha256:4430c9dd31d4f1b0145837c3fa98746ce481b9d21c52e37ecbb67376f030d974
-generated: "2024-06-04T13:16:09.174412-04:00"
+digest: sha256:f17c4deca1f4ce6245708861a9a0b4bf40cd2ea29235bd02f8af47f8b349d0e3
+generated: "2024-06-04T13:47:50.314717-04:00"

--- a/charts/stack/Chart.yaml
+++ b/charts/stack/Chart.yaml
@@ -2,14 +2,14 @@ apiVersion: v2
 name: stack
 description: Observe Kubernetes agent stack
 type: application
-version: 0.4.29
+version: 0.4.30
 dependencies:
   - name: logs
     version: 0.1.24
     repository: file://../logs
     condition: logs.enabled
   - name: metrics
-    version: 0.3.18
+    version: 0.3.19
     repository: file://../metrics
     condition: metrics.enabled
   - name: events

--- a/charts/stack/README.md
+++ b/charts/stack/README.md
@@ -1,6 +1,6 @@
 # stack
 
-![Version: 0.4.29](https://img.shields.io/badge/Version-0.4.29-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.4.30](https://img.shields.io/badge/Version-0.4.30-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Observe Kubernetes agent stack
 
@@ -16,7 +16,7 @@ Observe Kubernetes agent stack
 |------------|------|---------|
 | file://../events | events | 0.1.23 |
 | file://../logs | logs | 0.1.24 |
-| file://../metrics | metrics | 0.3.18 |
+| file://../metrics | metrics | 0.3.19 |
 | file://../proxy | proxy | 0.1.6 |
 | file://../traces | traces | 0.2.17 |
 


### PR DESCRIPTION
[Upstream GA helm chart by default (when image.tag is unset) pins the image tag to `appVersion`](https://github.com/grafana/agent/blob/6ead6f7d071f8ba9fabc0414be60c3e9b93105ef/operations/helm/charts/grafana-agent/values.yaml#L104), whereas we currently set it to `latest`. 

This results in the unexpected consequence that a user pinning to a static version of `observe/stack` or `observe/metrics` would still end up installing varying versions of grafana-agent at the image level.

With this change, we normalize to upstream chart behavior i.e., pin the image tag to appVersion.