### PR TITLE
fix(traces): image.repository must be set

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ you are prompted to create.
 helm install --namespace=observe observe-traces observe/traces \
 	--set global.observe.collectionEndpoint="${OBSERVE_COLLECTION_ENDPOINT}" \
   --set observe.token.value="${OBSERVE_TOKEN}" \
-  --set opentelemetry-collector.image.repository=otel/opentelemetry-collector-contrib \
   --create-namespace
 
 

--- a/charts/logs/Chart.yaml
+++ b/charts/logs/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: logs
 description: Observe logs collection
 type: application
-version: 0.1.25
+version: 0.1.26
 dependencies:
   - name: fluent-bit
     version: 0.46.11

--- a/charts/logs/README.md
+++ b/charts/logs/README.md
@@ -1,6 +1,6 @@
 # logs
 
-![Version: 0.1.24](https://img.shields.io/badge/Version-0.1.24-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.1.26](https://img.shields.io/badge/Version-0.1.26-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Observe logs collection
 
@@ -15,7 +15,7 @@ Observe logs collection
 | Repository | Name | Version |
 |------------|------|---------|
 | file://../endpoint | endpoint | 0.1.10 |
-| https://fluent.github.io/helm-charts | fluent-bit | 0.46.7 |
+| https://fluent.github.io/helm-charts | fluent-bit | 0.46.11 |
 
 ## Values
 

--- a/charts/metrics/Chart.yaml
+++ b/charts/metrics/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: metrics
 description: Observe metrics collection
 type: application
-version: 0.3.20
+version: 0.3.21
 dependencies:
   - name: grafana-agent
     version: 0.41.0

--- a/charts/metrics/README.md
+++ b/charts/metrics/README.md
@@ -1,6 +1,6 @@
 # metrics
 
-![Version: 0.3.19](https://img.shields.io/badge/Version-0.3.19-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.3.21](https://img.shields.io/badge/Version-0.3.21-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Observe metrics collection
 
@@ -15,7 +15,7 @@ Observe metrics collection
 | Repository | Name | Version |
 |------------|------|---------|
 | file://../endpoint | endpoint | 0.1.10 |
-| https://grafana.github.io/helm-charts | grafana-agent | 0.40.0 |
+| https://grafana.github.io/helm-charts | grafana-agent | 0.41.0 |
 
 ## Values
 

--- a/charts/stack/Chart.lock
+++ b/charts/stack/Chart.lock
@@ -1,10 +1,10 @@
 dependencies:
 - name: logs
   repository: file://../logs
-  version: 0.1.25
+  version: 0.1.26
 - name: metrics
   repository: file://../metrics
-  version: 0.3.20
+  version: 0.3.21
 - name: events
   repository: file://../events
   version: 0.1.23
@@ -13,6 +13,6 @@ dependencies:
   version: 0.1.6
 - name: traces
   repository: file://../traces
-  version: 0.2.19
-digest: sha256:37349af46b2b524f817b4f639247fb3d6467338d8387dc18ca4312b8ff2f7c6f
-generated: "2024-06-30T00:19:25.856792554Z"
+  version: 0.2.20
+digest: sha256:82df41dddad0a0a71079ce3d386eaee4c55cf25bbdf12e56e642bca26f7f589e
+generated: "2024-07-04T15:24:03.461242-04:00"

--- a/charts/stack/Chart.yaml
+++ b/charts/stack/Chart.yaml
@@ -2,14 +2,14 @@ apiVersion: v2
 name: stack
 description: Observe Kubernetes agent stack
 type: application
-version: 0.4.32
+version: 0.4.33
 dependencies:
   - name: logs
-    version: 0.1.25
+    version: 0.1.26
     repository: file://../logs
     condition: logs.enabled
   - name: metrics
-    version: 0.3.20
+    version: 0.3.21
     repository: file://../metrics
     condition: metrics.enabled
   - name: events
@@ -21,7 +21,7 @@ dependencies:
     repository: file://../proxy
     condition: proxy.enabled
   - name: traces
-    version: 0.2.19
+    version: 0.2.20
     repository: file://../traces
     condition: traces.enabled
 maintainers:

--- a/charts/stack/README.md
+++ b/charts/stack/README.md
@@ -1,6 +1,6 @@
 # stack
 
-![Version: 0.4.30](https://img.shields.io/badge/Version-0.4.30-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.4.33](https://img.shields.io/badge/Version-0.4.33-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Observe Kubernetes agent stack
 
@@ -15,10 +15,10 @@ Observe Kubernetes agent stack
 | Repository | Name | Version |
 |------------|------|---------|
 | file://../events | events | 0.1.23 |
-| file://../logs | logs | 0.1.24 |
-| file://../metrics | metrics | 0.3.19 |
+| file://../logs | logs | 0.1.26 |
+| file://../metrics | metrics | 0.3.21 |
 | file://../proxy | proxy | 0.1.6 |
-| file://../traces | traces | 0.2.17 |
+| file://../traces | traces | 0.2.20 |
 
 ## Values
 

--- a/charts/traces/Chart.yaml
+++ b/charts/traces/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traces
 description: Observe OpenTelemetry trace collection
 type: application
-version: 0.2.19
+version: 0.2.20
 dependencies:
   - name: opentelemetry-collector
     version: 0.96.0

--- a/charts/traces/README.md
+++ b/charts/traces/README.md
@@ -1,6 +1,6 @@
 # traces
 
-![Version: 0.2.17](https://img.shields.io/badge/Version-0.2.17-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.2.20](https://img.shields.io/badge/Version-0.2.20-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Observe OpenTelemetry trace collection
 
@@ -16,7 +16,7 @@ Observe OpenTelemetry trace collection
 |------------|------|---------|
 | file://../endpoint | endpoint | 0.1.10 |
 | file://../proxy | proxy | 0.1.6 |
-| https://open-telemetry.github.io/opentelemetry-helm-charts | opentelemetry-collector | 0.80.0 |
+| https://open-telemetry.github.io/opentelemetry-helm-charts | opentelemetry-collector | 0.96.0 |
 
 ## Values
 
@@ -87,6 +87,7 @@ Observe OpenTelemetry trace collection
 | opentelemetry-collector.extraEnvs[0].valueFrom.secretKeyRef.key | string | `"OBSERVE_TOKEN"` |  |
 | opentelemetry-collector.extraEnvs[0].valueFrom.secretKeyRef.name | string | `"otel-credentials"` |  |
 | opentelemetry-collector.fullnameOverride | string | `"observe-traces"` |  |
+| opentelemetry-collector.image.repository | string | `"otel/opentelemetry-collector-contrib"` |  |
 | opentelemetry-collector.livenessProbe.initialDelaySeconds | int | `5` |  |
 | opentelemetry-collector.mode | string | `"daemonset"` |  |
 | opentelemetry-collector.nameOverride | string | `"traces"` |  |

--- a/charts/traces/values.yaml
+++ b/charts/traces/values.yaml
@@ -16,6 +16,8 @@ opentelemetry-collector:
   mode: "daemonset"  # daemonset or deployment
   service:
     enabled: true
+  image:
+    repository: "otel/opentelemetry-collector-contrib"
   command:
     extraArgs: ["--set=service.telemetry.metrics.address=:58888"]
   resources:


### PR DESCRIPTION
`image.repository` should be set explicitly following a [breaking change](https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-collector/UPGRADING.md#0880-to-0890) in the upstream chart 