### PR TITLE
chore(ci): workflows/update-deps precommit can continue on failure

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -26,6 +26,7 @@ jobs:
 
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.1
+        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
update-deps can cause version increments, which in turn can require pre-commit changes on the PR. Prior to this commit, the update-deps workflow would fail to continue on subchart updates, because pre-commit returns an exit code of `1` when it encounters diffs.