### PR TITLE
chore(ci): use helm-docs instead of pre-commit to auto-update chart documentation

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -24,11 +24,10 @@ jobs:
         env:
           UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run pre-commit
-        uses: pre-commit/action@v3.0.1
-        continue-on-error: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run helm-docs
+        uses: losisin/helm-docs-github-action@v1
+        with:
+          git-push: false
 
       # Use Peter Evans Pull Request Action to create a pull request
       - name: Create Pull Request


### PR DESCRIPTION
Previously, we tried the pre-commit action which does not work, because it only checks for diffs and doesn't behave as it would locally. Since we're mainly solving for helm-docs, we prefer to use that instead.