### PR TITLE
feat: add agent monitoring pod

### DIFF
--- a/charts/agent/Chart.lock
+++ b/charts/agent/Chart.lock
@@ -8,5 +8,8 @@ dependencies:
 - name: opentelemetry-collector
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
   version: 0.101.1
-digest: sha256:535f85827a84e6710f5499f990f14655b4e66d51975a16a6b02d63d46c1cb0c5
-generated: "2024-08-15T17:30:12.708469-07:00"
+- name: opentelemetry-collector
+  repository: https://open-telemetry.github.io/opentelemetry-helm-charts
+  version: 0.101.1
+digest: sha256:987a47d694c8ea67e5dbcfa46bbdf84702bd9c8dee497fda7b8ff4c6f2e90a43
+generated: "2024-08-16T12:28:54.945971-07:00"

--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent
 description: Chart to install K8s collection stack based on Observe Agent
 type: application
-version: 0.5.1
+version: 0.5.2
 appVersion: "0.11.0"
 dependencies:
   - name: opentelemetry-collector
@@ -17,6 +17,10 @@ dependencies:
     version: 0.101.1
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
     alias: daemonset-logs-metrics
+  - name: opentelemetry-collector
+    version: 0.101.1
+    repository: https://open-telemetry.github.io/opentelemetry-helm-charts
+    alias: deployment-agent-monitor
 maintainers:
   - name: Observe
     email: support@observeinc.com

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -1,6 +1,6 @@
 # agent
 
-![Version: 0.5.1](https://img.shields.io/badge/Version-0.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.11.0](https://img.shields.io/badge/AppVersion-0.11.0-informational?style=flat-square)
+![Version: 0.5.2](https://img.shields.io/badge/Version-0.5.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.11.0](https://img.shields.io/badge/AppVersion-0.11.0-informational?style=flat-square)
 
 > [!CAUTION]
 > This chart is under active development and is not meant to be installed yet.
@@ -20,6 +20,7 @@ Chart to install K8s collection stack based on Observe Agent
 | https://open-telemetry.github.io/opentelemetry-helm-charts | deployment-cluster-events(opentelemetry-collector) | 0.101.1 |
 | https://open-telemetry.github.io/opentelemetry-helm-charts | deployment-cluster-metrics(opentelemetry-collector) | 0.101.1 |
 | https://open-telemetry.github.io/opentelemetry-helm-charts | daemonset-logs-metrics(opentelemetry-collector) | 0.101.1 |
+| https://open-telemetry.github.io/opentelemetry-helm-charts | deployment-agent-monitor(opentelemetry-collector) | 0.101.1 |
 
 ## Values
 
@@ -111,6 +112,60 @@ Chart to install K8s collection stack based on Observe Agent
 | daemonset-logs-metrics.securityContext.runAsUser | int | `0` |  |
 | daemonset-logs-metrics.serviceAccount.create | bool | `false` |  |
 | daemonset-logs-metrics.serviceAccount.name | string | `"observe-agent-service-account"` |  |
+| deployment-agent-monitor.clusterRole.create | bool | `false` |  |
+| deployment-agent-monitor.clusterRole.name | string | `"observe-agent-cluster-role"` |  |
+| deployment-agent-monitor.command.extraArgs[0] | string | `"start"` |  |
+| deployment-agent-monitor.command.extraArgs[1] | string | `"--config=/observe-agent-conf/observe-agent.yaml"` |  |
+| deployment-agent-monitor.command.extraArgs[2] | string | `"--otel-config=/conf/relay.yaml"` |  |
+| deployment-agent-monitor.command.name | string | `"observe-agent"` |  |
+| deployment-agent-monitor.configMap.create | bool | `false` |  |
+| deployment-agent-monitor.configMap.existingName | string | `"deployment-agent-monitor"` |  |
+| deployment-agent-monitor.extraEnvsFrom | list | `[]` |  |
+| deployment-agent-monitor.extraEnvs[0].name | string | `"OBSERVE_CLUSTER_NAME"` |  |
+| deployment-agent-monitor.extraEnvs[0].valueFrom.configMapKeyRef.key | string | `"name"` |  |
+| deployment-agent-monitor.extraEnvs[0].valueFrom.configMapKeyRef.name | string | `"cluster-name"` |  |
+| deployment-agent-monitor.extraEnvs[1].name | string | `"OBSERVE_CLUSTER_UID"` |  |
+| deployment-agent-monitor.extraEnvs[1].valueFrom.configMapKeyRef.key | string | `"id"` |  |
+| deployment-agent-monitor.extraEnvs[1].valueFrom.configMapKeyRef.name | string | `"cluster-info"` |  |
+| deployment-agent-monitor.extraVolumeMounts[0].mountPath | string | `"/observe-agent-conf"` |  |
+| deployment-agent-monitor.extraVolumeMounts[0].name | string | `"observe-agent-deployment-config"` |  |
+| deployment-agent-monitor.extraVolumes[0].configMap.defaultMode | int | `420` |  |
+| deployment-agent-monitor.extraVolumes[0].configMap.items[0].key | string | `"relay"` |  |
+| deployment-agent-monitor.extraVolumes[0].configMap.items[0].path | string | `"observe-agent.yaml"` |  |
+| deployment-agent-monitor.extraVolumes[0].configMap.name | string | `"observe-agent"` |  |
+| deployment-agent-monitor.extraVolumes[0].name | string | `"observe-agent-deployment-config"` |  |
+| deployment-agent-monitor.image.pullPolicy | string | `"IfNotPresent"` |  |
+| deployment-agent-monitor.image.repository | string | `"observeinc/observe-agent"` |  |
+| deployment-agent-monitor.image.tag | string | `"0.11.0"` |  |
+| deployment-agent-monitor.initContainers[0].env[0].name | string | `"NAMESPACE"` |  |
+| deployment-agent-monitor.initContainers[0].env[0].valueFrom.fieldRef.fieldPath | string | `"metadata.namespace"` |  |
+| deployment-agent-monitor.initContainers[0].image | string | `"observeinc/kube-cluster-info:v0.11.1"` |  |
+| deployment-agent-monitor.initContainers[0].imagePullPolicy | string | `"Always"` |  |
+| deployment-agent-monitor.initContainers[0].name | string | `"kube-cluster-info"` |  |
+| deployment-agent-monitor.livenessProbe.httpGet.path | string | `"/status"` |  |
+| deployment-agent-monitor.livenessProbe.httpGet.port | int | `13133` |  |
+| deployment-agent-monitor.livenessProbe.initialDelaySeconds | int | `30` |  |
+| deployment-agent-monitor.livenessProbe.periodSeconds | int | `5` |  |
+| deployment-agent-monitor.mode | string | `"deployment"` |  |
+| deployment-agent-monitor.nameOverride | string | `"deployment-agent-monitor"` | --------------------------------------- # Different for each deployment/daemonset # |
+| deployment-agent-monitor.namespaceOverride | string | `"observe"` |  |
+| deployment-agent-monitor.networkPolicy.egressRules[0] | object | `{}` |  |
+| deployment-agent-monitor.networkPolicy.enabled | bool | `true` |  |
+| deployment-agent-monitor.podAnnotations.observe_monitor_path | string | `"/metrics"` |  |
+| deployment-agent-monitor.podAnnotations.observe_monitor_port | string | `"8888"` |  |
+| deployment-agent-monitor.podAnnotations.observe_monitor_purpose | string | `"observecollection"` |  |
+| deployment-agent-monitor.podAnnotations.observe_monitor_scrape | string | `"false"` |  |
+| deployment-agent-monitor.ports.metrics.containerPort | int | `8888` |  |
+| deployment-agent-monitor.ports.metrics.enabled | bool | `true` |  |
+| deployment-agent-monitor.ports.metrics.protocol | string | `"TCP"` |  |
+| deployment-agent-monitor.ports.metrics.servicePort | int | `8888` |  |
+| deployment-agent-monitor.readinessProbe.httpGet.path | string | `"/status"` |  |
+| deployment-agent-monitor.readinessProbe.httpGet.port | int | `13133` |  |
+| deployment-agent-monitor.readinessProbe.initialDelaySeconds | int | `30` |  |
+| deployment-agent-monitor.readinessProbe.periodSeconds | int | `5` |  |
+| deployment-agent-monitor.resources | object | `{"requests":{"cpu":"250m","memory":"256Mi"}}` | --------------------------------------- # Same for each deployment/daemonset      # |
+| deployment-agent-monitor.serviceAccount.create | bool | `false` |  |
+| deployment-agent-monitor.serviceAccount.name | string | `"observe-agent-service-account"` |  |
 | deployment-cluster-events.clusterRole.create | bool | `false` |  |
 | deployment-cluster-events.clusterRole.name | string | `"observe-agent-cluster-role"` |  |
 | deployment-cluster-events.command.extraArgs[0] | string | `"start"` |  |

--- a/charts/agent/templates/_deployment-agent-monitor-config.tpl
+++ b/charts/agent/templates/_deployment-agent-monitor-config.tpl
@@ -1,0 +1,81 @@
+{{- define "observe.deployment.agentMonitor.config" -}}
+
+extensions:
+{{- include "config.extensions.health_check" . | nindent 2 }}
+
+exporters:
+{{- include "config.exporters.debug" . | nindent 2 }}
+{{- include "config.exporters.prometheusremotewrite" . | nindent 2 }}
+
+receivers:
+  prometheus/collector:
+        config:
+          scrape_configs:
+          - job_name: opentelemetry-collector-self
+            scrape_interval: 10s
+            static_configs:
+            - targets:
+              - ${env:MY_POD_IP}:8888
+          - job_name: opentelemetry-collector-other
+            scrape_interval: 10s
+            honor_labels: true
+            kubernetes_sd_configs:
+            - role: pod
+            relabel_configs:
+            # select only those pods that has "observe_monitor_purpose: observecollection" annotation
+            - source_labels: [__meta_kubernetes_pod_annotation_observe_monitor_purpose]
+              action: keep
+              regex: observecollection
+            # select only those pods that has "observe_monitor_scrape: true" annotation
+            - source_labels: [__meta_kubernetes_pod_annotation_observe_monitor_scrape]
+              action: keep
+              regex: true
+              # set metrics_path (default is /metrics) to the metrics path specified in "prometheus.io/path: <metric path>" annotation.
+            - source_labels: [__meta_kubernetes_pod_annotationobserve_monitor_path]
+              action: replace
+              target_label: __metrics_path__
+              regex: (.+)
+              # set the scrapping port to the port specified in "prometheus.io/port: <port>" annotation and set address accordingly.
+            - source_labels: [__address__, __meta_kubernetes_pod_annotation_observe_monitor_port]
+              action: replace
+              regex: ([^:]+)(?::\d+)?;(\d+)
+              replacement: $$1:$$2
+              target_label: __address__
+            - action: labelmap
+              regex: __meta_kubernetes_pod_label_(.+)
+            - source_labels: [__meta_kubernetes_namespace]
+              action: replace
+              target_label: kubernetes_namespace
+            - source_labels: [__meta_kubernetes_pod_name]
+              action: replace
+              target_label: kubernetes_pod_name
+
+
+processors:
+{{- include "config.processors.memory_limiter" . | nindent 2 }}
+
+{{- include "config.processors.resource_detection.cloud" . | nindent 2 }}
+
+{{- include "config.processors.batch" . | nindent 2 }}
+
+{{- include "config.processors.attributes.k8sattributes" . | nindent 2 }}
+
+{{- include "config.processors.attributes.observe_common" . | nindent 2 }}
+
+  # attributes to append to objects
+  attributes/debug_objectSource_agent_monitor:
+    actions:
+      - key: debug_objectSource
+        action: insert
+        value: agent_monitor
+
+service:
+  extensions: [health_check]
+  pipelines:
+      metrics:
+        receivers: [prometheus/collector]
+        processors: [memory_limiter, batch, resourcedetection/cloud, attributes/observe_common, k8sattributes, attributes/debug_objectSource_agent_monitor]
+        exporters: [prometheusremotewrite]
+{{- include "config.service.telemetry" . | nindent 2 }}
+
+ {{- end }}

--- a/charts/agent/templates/deployment-agent-monitor-configmap.yaml
+++ b/charts/agent/templates/deployment-agent-monitor-configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: deployment-agent-monitor
+  namespace: {{ template "observe-agent.namespace" . }}
+data:
+  relay: |
+      {{- include "observe.deployment.agentMonitor.config" . | nindent 4 -}}

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -380,3 +380,110 @@ daemonset-logs-metrics:
     runAsUser: 0
     runAsGroup: 0
   # ----------------------------------------- #
+
+################################################
+deployment-agent-monitor:
+  mode: deployment
+  # ----------------------------------------- #
+  # Different for each deployment/daemonset #
+  nameOverride: "deployment-agent-monitor"
+  namespaceOverride: "observe"
+
+  configMap:
+    create: false
+    existingName: "deployment-agent-monitor"
+  # ----------------------------------------- #
+
+  # ----------------------------------------- #
+  # Same for each deployment/daemonset      #
+  resources:
+    requests:
+      cpu: 250m
+      memory: 256Mi
+
+  image:
+    repository: observeinc/observe-agent
+    # # Overrides the image tag whose default is the chart appVersion.
+    # # The service's name will be applied to the end of this value.
+    tag: "0.11.0"
+    pullPolicy: IfNotPresent
+
+  command:
+    name: "observe-agent"
+    extraArgs: ["start", "--config=/observe-agent-conf/observe-agent.yaml", "--otel-config=/conf/relay.yaml"]
+
+  serviceAccount:
+    create: false
+    name: "observe-agent-service-account"
+  clusterRole:
+    create: false
+    name: "observe-agent-cluster-role"
+
+  livenessProbe:
+    httpGet:
+      port: 13133
+      path: /status
+    initialDelaySeconds: 30
+    periodSeconds: 5
+
+  readinessProbe:
+    httpGet:
+      port: 13133
+      path: /status
+    initialDelaySeconds: 30
+    periodSeconds: 5
+
+  networkPolicy:
+    enabled: true
+    egressRules: [{}]
+
+  podAnnotations: {
+    observe_monitor_purpose: observecollection,
+    observe_monitor_scrape: 'false',
+    observe_monitor_path: '/metrics',
+    observe_monitor_port: '8888',
+  }
+  ports:
+    metrics:
+      # The metrics port is disabled by default. However you need to enable the port
+      # in order to use the ServiceMonitor (serviceMonitor.enabled) or PodMonitor (podMonitor.enabled).
+      enabled: true
+      containerPort: 8888
+      servicePort: 8888
+      protocol: TCP
+  # this init container provides the cluster uid (kube-system namespace) as config map
+  initContainers:
+    - name: kube-cluster-info
+      image: observeinc/kube-cluster-info:v0.11.1
+      imagePullPolicy: Always
+      env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+  # extract clusteruid from configmap create by init container
+  extraEnvs:
+    - name: OBSERVE_CLUSTER_NAME
+      valueFrom:
+        configMapKeyRef:
+          name: cluster-name
+          key: name
+    - name: OBSERVE_CLUSTER_UID
+      valueFrom:
+        configMapKeyRef:
+          name: cluster-info
+          key: id
+
+  extraEnvsFrom: []
+  extraVolumes:
+    - name: "observe-agent-deployment-config"
+      configMap:
+        name: "observe-agent"
+        items:
+          - key: "relay"
+            path: "observe-agent.yaml"
+        defaultMode: 420
+  extraVolumeMounts:
+    - name: observe-agent-deployment-config
+      mountPath: /observe-agent-conf
+  # ----------------------------------------- #


### PR DESCRIPTION
Add pod for scraping metrics from other collector pods.  

Purpose is to separate the fate of the collectors from the collection of their health metrics so we can have reliable monitoring signals.

Other collector deployments have annotations for selection to scrape metrics

`  podAnnotations: {
    observe_monitor_purpose: observecollection,
    observe_monitor_scrape: 'true',
    observe_monitor_path: '/metrics',
    observe_monitor_port: '8888',
  }`

prometheus scrape configuration only selects pods with these annotations -
observe_monitor_purpose: observecollection,
observe_monitor_scrape: 'true'