### PR TITLE
feat: OB-35438 Collect additional k8s metrics

### DIFF
--- a/charts/agent/templates/_daemonset-logs-metrics-config.tpl
+++ b/charts/agent/templates/_daemonset-logs-metrics-config.tpl
@@ -62,11 +62,60 @@ receivers:
     collection_interval: 10s
     auth_type: 'serviceAccount'
     endpoint: '${env:K8S_NODE_NAME}:10250'
+    node: '${env:K8S_NODE_NAME}'
     insecure_skip_verify: true
+    k8s_api_config:
+        auth_type: serviceAccount
     metric_groups:
       - node
       - pod
       - container
+    metrics:
+      # Disable deprecated metrics
+      k8s.node.cpu.utilization:
+        enabled: false
+      k8s.pod.cpu.utilization:
+        enabled: false
+      container.cpu.utilization:
+        enabled: false
+      # The following metrics are optional and must be enabled manually as per:
+      # https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/kubeletstatsreceiver/documentation.md#optional-metrics
+      container.cpu.usage:
+        enabled: true
+      container.uptime:
+        enabled: true
+      k8s.container.cpu.node.utilization:
+        enabled: true
+      k8s.container.cpu_limit_utilization:
+        enabled: true
+      k8s.container.cpu_request_utilization:
+        enabled: true
+      k8s.container.memory.node.utilization:
+        enabled: true
+      k8s.container.memory_limit_utilization:
+        enabled: true
+      k8s.container.memory_request_utilization:
+        enabled: true
+      k8s.node.cpu.usage:
+        enabled: true
+      k8s.node.uptime:
+        enabled: true
+      k8s.pod.cpu.node.utilization:
+        enabled: true
+      k8s.pod.cpu.usage:
+        enabled: true
+      k8s.pod.cpu_limit_utilization:
+        enabled: true
+      k8s.pod.cpu_request_utilization:
+        enabled: true
+      k8s.pod.memory.node.utilization:
+        enabled: true
+      k8s.pod.memory_limit_utilization:
+        enabled: true
+      k8s.pod.memory_request_utilization:
+        enabled: true
+      k8s.pod.uptime:
+        enabled: true
 
   filelog:
     exclude: []

--- a/charts/agent/templates/_deployment-cluster-metrics-config.tpl
+++ b/charts/agent/templates/_deployment-cluster-metrics-config.tpl
@@ -15,6 +15,11 @@ receivers:
     - Ready
     - MemoryPressure
     - DiskPressure
+    allocatable_types_to_report:
+    - cpu
+    - memory
+    - storage
+    - ephemeral-storage
     metrics:
       k8s.node.condition:
         enabled: true


### PR DESCRIPTION
Configure k8s_cluster receiver to collect allocatable cpu, mem, storage and ephemeral-storage metrics.

Replace collected metrics k8s.{pod,node}.{cpu,mem}.utilization with their k8s.{pod,node}.{cpu,mem}.usage counterpart.