### PR TITLE
feat: cleanup tagging for (mostly) metrics

### DIFF
--- a/charts/agent/templates/_config-processors.tpl
+++ b/charts/agent/templates/_config-processors.tpl
@@ -14,14 +14,6 @@ batch:
 {{- define "config.processors.attributes.k8sattributes" -}}
 k8sattributes:
   extract:
-    annotations:
-    - from: pod
-      key_regex: (.*)
-      tag_name: $$1
-    labels:
-    - from: pod
-      key_regex: (.*)
-      tag_name: $$1
     metadata:
     - k8s.namespace.name
     - k8s.deployment.name
@@ -33,7 +25,6 @@ k8sattributes:
     - k8s.node.name
     - k8s.pod.name
     - k8s.pod.uid
-    - k8s.pod.start_time
     - k8s.cluster.uid
     - k8s.node.name
     - k8s.node.uid
@@ -47,24 +38,6 @@ k8sattributes:
       name: k8s.pod.uid
   - sources:
     - from: connection
-{{- end -}}
-
-{{- define "config.processors.attributes.k8sattributes.podcontroller" -}}
-k8sattributes/podcontroller:
-  extract:
-    metadata:
-    - k8s.deployment.name
-    - k8s.statefulset.name
-    - k8s.replicaset.name
-    - k8s.daemonset.name
-    - k8s.cronjob.name
-    - k8s.job.name
-  pod_association:
-    - sources:
-        - from: resource_attribute
-          name: k8s.pod.name
-        - from: resource_attribute
-          name: k8s.namespace.name
 {{- end -}}
 
 {{- define "config.processors.attributes.observe_common" -}}

--- a/charts/agent/templates/_daemonset-logs-metrics-config.tpl
+++ b/charts/agent/templates/_daemonset-logs-metrics-config.tpl
@@ -96,14 +96,19 @@ processors:
 {{- include "config.processors.attributes.observe_common" . | nindent 2 }}
 
   # attributes to append to objects
-  attributes/debug_objectSource_pod_logs:
+  attributes/debug_source_pod_logs:
     actions:
-      - key: debug_objectSource
+      - key: debug_source
         action: insert
         value: pod_logs
-  attributes/debug_objectSource_kublet_metrics:
+  attributes/debug_source_hostmetrics:
     actions:
-      - key: debug_objectSource
+      - key: debug_source
+        action: insert
+        value: hostmetrics
+  attributes/debug_source_kubletstats_metrics:
+    actions:
+      - key: debug_source
         action: insert
         value: kubeletstats_metrics
 
@@ -112,11 +117,15 @@ service:
   pipelines:
       logs:
         receivers: [filelog]
-        processors: [memory_limiter, batch, resourcedetection/cloud, k8sattributes, attributes/observe_common, attributes/debug_objectSource_pod_logs]
+        processors: [memory_limiter, batch, resourcedetection/cloud, k8sattributes, attributes/observe_common, attributes/debug_source_pod_logs]
         exporters: [otlphttp/observe/base, debug/override]
-      metrics:
-        receivers: [hostmetrics, kubeletstats]
-        processors: [memory_limiter, batch, resourcedetection/cloud, k8sattributes, attributes/observe_common, attributes/debug_objectSource_kublet_metrics]
+      hostmetrics:
+        receivers: [hostmetrics]
+        processors: [memory_limiter, batch, resourcedetection/cloud, k8sattributes, attributes/observe_common, attributes/debug_source_hostmetrics]
+        exporters: [prometheusremotewrite, debug/override]
+      kubeletstatsmetrics:
+        receivers: [kubeletstats]
+        processors: [memory_limiter, batch, resourcedetection/cloud, k8sattributes, attributes/observe_common, attributes/debug_source_kubletstats_metrics]
         exporters: [prometheusremotewrite, debug/override]
 
 {{- include "config.service.telemetry" . | nindent 2 }}

--- a/charts/agent/templates/_deployment-agent-monitor-config.tpl
+++ b/charts/agent/templates/_deployment-agent-monitor-config.tpl
@@ -54,8 +54,6 @@ receivers:
 processors:
 {{- include "config.processors.memory_limiter" . | nindent 2 }}
 
-{{- include "config.processors.resource_detection.cloud" . | nindent 2 }}
-
 {{- include "config.processors.batch" . | nindent 2 }}
 
 {{- include "config.processors.attributes.k8sattributes" . | nindent 2 }}
@@ -63,9 +61,9 @@ processors:
 {{- include "config.processors.attributes.observe_common" . | nindent 2 }}
 
   # attributes to append to objects
-  attributes/debug_objectSource_agent_monitor:
+  attributes/debug_source_agent_monitor:
     actions:
-      - key: debug_objectSource
+      - key: debug_source
         action: insert
         value: agent_monitor
 
@@ -74,7 +72,7 @@ service:
   pipelines:
       metrics:
         receivers: [prometheus/collector]
-        processors: [memory_limiter, batch, resourcedetection/cloud, attributes/observe_common, k8sattributes, attributes/debug_objectSource_agent_monitor]
+        processors: [memory_limiter, batch, attributes/observe_common, k8sattributes, attributes/debug_source_agent_monitor]
         exporters: [prometheusremotewrite]
 {{- include "config.service.telemetry" . | nindent 2 }}
 

--- a/charts/agent/templates/_deployment-cluster-events-config.tpl
+++ b/charts/agent/templates/_deployment-cluster-events-config.tpl
@@ -75,8 +75,6 @@ receivers:
 processors:
 {{- include "config.processors.memory_limiter" . | nindent 2 }}
 
-{{- include "config.processors.resource_detection.cloud" . | nindent 2 }}
-
 {{- include "config.processors.batch" . | nindent 2 }}
 
 {{- include "config.processors.attributes.observe_common" . | nindent 2 }}
@@ -93,8 +91,8 @@ processors:
           - set(attributes["observe_filter"], "objects_pull_watch")
           # unwrapping for the object_watch stream
           - set(attributes["observe_transform"]["control"]["isDelete"], true) where body["object"] != nil and body["type"] == "DELETED"
-          - set(attributes["observe_transform"]["control"]["debug_objectSource"], "watch") where body["object"] != nil and body["type"] != nil
-          - set(attributes["observe_transform"]["control"]["debug_objectSource"], "pull") where body["object"] == nil or body["type"] == nil
+          - set(attributes["observe_transform"]["control"]["debug_source"], "watch") where body["object"] != nil and body["type"] != nil
+          - set(attributes["observe_transform"]["control"]["debug_source"], "pull") where body["object"] == nil or body["type"] == nil
           - set(body, body["object"]) where body["object"] != nil and body["type"] != nil
           # native columns: valid_from, valid_to, kind
           - set(attributes["observe_transform"]["valid_from"], observed_time_unix_nano)
@@ -218,8 +216,8 @@ processors:
           - set(attributes["observe_filter"], "objects_pull_watch")
           # unwrap the object out of the watch stream
           - set(attributes["observe_transform"]["control"]["isDelete"], true) where body["object"] != nil and body["type"] == "DELETED"
-          - set(attributes["observe_transform"]["control"]["debug_objectSource"], "watch") where body["object"] != nil and body["type"] != nil
-          - set(attributes["observe_transform"]["control"]["debug_objectSource"], "pull") where body["object"] == nil or body["type"] == nil
+          - set(attributes["observe_transform"]["control"]["debug_source"], "watch") where body["object"] != nil and body["type"] != nil
+          - set(attributes["observe_transform"]["control"]["debug_source"], "pull") where body["object"] == nil or body["type"] == nil
           - set(body, body["object"]) where body["object"] != nil and body["type"] != nil
           # native columns: valid_from, valid_to, kind
           - set(attributes["observe_transform"]["valid_from"], observed_time_unix_nano)
@@ -246,20 +244,20 @@ service:
   pipelines:
       logs/objects:
         receivers: [k8sobjects/objects]
-        processors: [memory_limiter, batch, resourcedetection/cloud, attributes/observe_common, transform/object, observek8sattributes]
+        processors: [memory_limiter, batch, attributes/observe_common, transform/object, observek8sattributes]
         exporters: [otlphttp/observe/base, debug/override]
       logs/cluster:
         receivers: [k8sobjects/cluster]
-        processors: [memory_limiter, batch, resourcedetection/cloud, attributes/observe_common, filter/cluster, transform/cluster]
+        processors: [memory_limiter, batch, attributes/observe_common, filter/cluster, transform/cluster]
         exporters: [otlphttp/observe/base, debug/override]
       {{ if .Values.observe.entityToken  -}}
       logs/entity:
         receivers: [k8sobjects/objects]
-        processors: [memory_limiter, batch, resourcedetection/cloud, attributes/observe_common, transform/object, observek8sattributes]
+        processors: [memory_limiter, batch, attributes/observe_common, transform/object, observek8sattributes]
         exporters: [otlphttp/observe/entity, debug/override]
       logs/cluster/entity:
         receivers: [k8sobjects/cluster]
-        processors: [memory_limiter, batch, resourcedetection/cloud, attributes/observe_common, filter/cluster, transform/cluster]
+        processors: [memory_limiter, batch, attributes/observe_common, filter/cluster, transform/cluster]
         exporters: [otlphttp/observe/entity, debug/override]
       {{- end }}
 

--- a/charts/agent/templates/_deployment-cluster-metrics-config.tpl
+++ b/charts/agent/templates/_deployment-cluster-metrics-config.tpl
@@ -22,8 +22,6 @@ receivers:
 processors:
 {{- include "config.processors.memory_limiter" . | nindent 2 }}
 
-{{- include "config.processors.resource_detection.cloud" . | nindent 2 }}
-
 {{- include "config.processors.batch" . | nindent 2 }}
 
 {{- include "config.processors.attributes.k8sattributes" . | nindent 2 }}
@@ -31,9 +29,9 @@ processors:
 {{- include "config.processors.attributes.observe_common" . | nindent 2 }}
 
   # attributes to append to objects
-  attributes/debug_objectSource_cluster_metrics:
+  attributes/debug_source_cluster_metrics:
     actions:
-      - key: debug_objectSource
+      - key: debug_source
         action: insert
         value: cluster_metrics
 
@@ -42,7 +40,7 @@ service:
   pipelines:
       metrics:
         receivers: [k8s_cluster]
-        processors: [memory_limiter, batch, resourcedetection/cloud, k8sattributes, attributes/observe_common, attributes/debug_objectSource_cluster_metrics]
+        processors: [memory_limiter, batch, k8sattributes, attributes/observe_common, attributes/debug_source_cluster_metrics]
         exporters: [prometheusremotewrite, debug/override]
 {{- include "config.service.telemetry" . | nindent 2 }}
 


### PR DESCRIPTION
1. in k8sattributes, stop adding all labels and annotations as tags. As that is a very pretty big list with unclear value. We should enable them selectively when user needs them.

2. removed k8sattributes/podcontroller, no one is using them

3. dropped resourcedetection for all deployments This is the one that tags a lot of node level information. But, for deployments, it tags about the node that the deployment runs on, instead of the node that runs the things being monitored (e.g. pods). So, the result is very confusing. Let's just drop it. We can add selective tags back when they are useful.

4. change the debug_objectSource tag to debug_source Since it was initially used for entity/object streams only. But now it's being used for logs & metrics data too.