### PR TITLE
fix: OB-35984-add-namespace-name-to-cluster-role

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent
 description: Chart to install K8s collection stack based on Observe Agent
 type: application
-version: 0.8.0
+version: 0.8.1
 appVersion: "1.0.0"
 dependencies:
   - name: opentelemetry-collector

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -1,6 +1,6 @@
 # agent
 
-![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 0.8.1](https://img.shields.io/badge/Version-0.8.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 > [!CAUTION]
 > This chart is under active development and is not meant to be installed yet.
@@ -37,6 +37,7 @@ Chart to install K8s collection stack based on Observe Agent
 | cluster.metrics.enabled | bool | `true` |  |
 | cluster.name | string | `"observe-agent-monitored-cluster"` |  |
 | cluster.namespaceOverride.value | string | `"observe"` |  |
+| cluster.uidOverride.value | string | `""` |  |
 | containers.logs.enabled | bool | `true` |  |
 | containers.metrics.enabled | bool | `true` |  |
 | daemonset-logs-metrics.clusterRole.create | bool | `false` |  |
@@ -305,6 +306,7 @@ Chart to install K8s collection stack based on Observe Agent
 | deployment-cluster-metrics.serviceAccount.name | string | `"observe-agent-service-account"` |  |
 | observe.collectionEndpoint.value | string | `""` |  |
 | observe.entityToken.create | bool | `false` |  |
+| observe.entityToken.use | bool | `false` |  |
 | observe.entityToken.value | string | `""` |  |
 | observe.token.create | bool | `true` |  |
 | observe.token.value | string | `""` |  |

--- a/charts/agent/templates/_config-exporters.tpl
+++ b/charts/agent/templates/_config-exporters.tpl
@@ -9,7 +9,7 @@ otlphttp/observe/base:
 otlphttp/observe/entity:
     logs_endpoint: "{{ .Values.observe.collectionEndpoint.value | toString | trimSuffix "/" }}/v1/kubernetes/v1/entity"
     headers:
-        authorization: "Bearer {env:ENTITY_TOKEN}"
+        authorization: "Bearer ${env:ENTITY_TOKEN}"
 {{- end -}}
 
 {{- define "config.exporters.prometheusremotewrite" -}}

--- a/charts/agent/templates/_config-processors.tpl
+++ b/charts/agent/templates/_config-processors.tpl
@@ -48,7 +48,11 @@ attributes/observe_common:
       value: ${env:OBSERVE_CLUSTER_NAME}
     - key: k8s.cluster.uid
       action: insert
+      {{ if .Values.cluster.uidOverride.value -}}
+      value:  {{ .Values.cluster.uidOverride.value }}
+      {{ else -}}
       value:  ${env:OBSERVE_CLUSTER_UID}
+      {{ end -}}
 {{- end -}}
 
 {{- define "config.processors.memory_limiter" -}}

--- a/charts/agent/templates/_deployment-cluster-events-config.tpl
+++ b/charts/agent/templates/_deployment-cluster-events-config.tpl
@@ -5,7 +5,7 @@ extensions:
 
 exporters:
 {{- include "config.exporters.debug" . | nindent 2 }}
-{{ if .Values.observe.entityToken.create }}
+{{ if .Values.observe.entityToken.use }}
 {{- include "config.exporters.otlphttp.observe.entity" . | nindent 2 }}
 {{ end }}
 {{- include "config.exporters.otlphttp.observe.base" . | nindent 2 }}
@@ -295,7 +295,7 @@ service:
         receivers: [k8sobjects/cluster]
         processors: [memory_limiter, batch, attributes/observe_common, filter/cluster, transform/cluster]
         exporters: [otlphttp/observe/base, debug/override]
-      {{ if .Values.observe.entityToken.create  -}}
+      {{ if .Values.observe.entityToken.use  -}}
       logs/entity:
         receivers: [k8sobjects/objects]
         processors: [memory_limiter, batch, attributes/observe_common, transform/object, observek8sattributes]

--- a/charts/agent/templates/cluster-role.yaml
+++ b/charts/agent/templates/cluster-role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: observe-agent-cluster-role
+  name: observe-agent-cluster-role-{{ template "observe-agent.namespace" . }}
   labels:
     app.kubernetes.io/name: observe-agent-cluster-role
     app.kubernetes.io/instance: observe-agent
@@ -38,12 +38,12 @@ kind: ClusterRoleBinding
 metadata:
   name: observe-agent-cluster-role-binding
   labels:
-    app.kubernetes.io/name: observe-agent-cluster-role-binding
+    app.kubernetes.io/name: observe-agent-cluster-role-binding-{{ template "observe-agent.namespace" . }}
     app.kubernetes.io/instance: observe-agent
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: observe-agent-cluster-role
+  name: observe-agent-cluster-role-{{ template "observe-agent.namespace" . }}
 subjects:
 - kind: ServiceAccount
   name: observe-agent-service-account

--- a/charts/agent/templates/daemonset-logs-metrics-configmap.yaml
+++ b/charts/agent/templates/daemonset-logs-metrics-configmap.yaml
@@ -1,3 +1,5 @@
+{{ if .Values.containers.logs.enabled -}}
+# TO DO: seperate logs and metrics
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -6,3 +8,4 @@ metadata:
 data:
   relay: |
       {{- include "observe.daemonset.logsMetrics.config" . | nindent 4 -}}
+{{ end -}}

--- a/charts/agent/templates/deployment-agent-monitor-configmap.yaml
+++ b/charts/agent/templates/deployment-agent-monitor-configmap.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.agent.selfMonitor.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -6,3 +7,4 @@ metadata:
 data:
   relay: |
       {{- include "observe.deployment.agentMonitor.config" . | nindent 4 -}}
+{{ end -}}

--- a/charts/agent/templates/deployment-cluster-events-configmap.yaml
+++ b/charts/agent/templates/deployment-cluster-events-configmap.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.cluster.events.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -6,3 +7,4 @@ metadata:
 data:
   relay: |
       {{- include "observe.deployment.clusterEvents.config" . | nindent 4 -}}
+{{ end -}}

--- a/charts/agent/templates/deployment-cluster-metrics-configmap.yaml
+++ b/charts/agent/templates/deployment-cluster-metrics-configmap.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.cluster.metrics.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -6,3 +7,4 @@ metadata:
 data:
   relay: |
       {{- include "observe.deployment.clusterMetrics.config" . | nindent 4 -}}
+{{ end -}}

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -8,8 +8,12 @@ observe:
     value: ""
   # this is temporary and will be removed
   entityToken:
+    # To create secret
     create: false
     value: ""
+    # To use exporter
+    use: false
+
 
 cluster:
   name: observe-agent-monitored-cluster
@@ -22,6 +26,8 @@ cluster:
   namespaceOverride:
     # ! This needs to have same value as namespaceOverride in deployments and daemonsets below
     value: observe
+  uidOverride:
+    value: ""
 
 containers:
   logs:


### PR DESCRIPTION
- Add the namespace name to cluster role and cluster role binding
- Make configmap creation conditional based on enabled flag for deployment/daemonset
- Make entity token use value drive exporter creation
Added a use field to entity token because we have to separate the creation of the secret from the usage because we deploy secrets is a separate workflow on our clusters.  Should all be temporary.

@xueweiz and I validated that this branch auto generates yaml that deploys on eng using kustomize.

Related pr - https://gerrit.observeinc.com/c/observe/+/55077