### PR TITLE
chore(ci): skip updatecli version bumps on README changes

### DIFF
--- a/updatecli/internal/03_events_major.yml
+++ b/updatecli/internal/03_events_major.yml
@@ -12,7 +12,7 @@ conditions:
     name: "Check if charts/events/ has changes"
     kind: shell
     spec:
-      command: git diff --quiet --name-only origin/main...HEAD -- charts/events/ && git diff --quiet --name-only -- charts/events/ && exit 1 || exit 0
+      command: git diff --quiet --name-only origin/main...HEAD -- charts/events/ ':(exclude)charts/events/README.md' ':(exclude)charts/events/README.md.gotmpl' && git diff --quiet --name-only -- charts/events/ ':(exclude)charts/events/README.md' ':(exclude)charts/events/README.md.gotmpl' && exit 1 || exit 0
     disablesourceinput: true
   breakingChanges:
     name: "Check if commit is a breaking change"

--- a/updatecli/internal/03_logs_major.yml
+++ b/updatecli/internal/03_logs_major.yml
@@ -12,7 +12,7 @@ conditions:
     name: "Check if charts/logs/ has changes"
     kind: shell
     spec:
-      command: git diff --quiet --name-only origin/main...HEAD -- charts/logs/ && git diff --quiet --name-only -- charts/logs/ && exit 1 || exit 0
+      command: git diff --quiet --name-only origin/main...HEAD -- charts/logs/ ':(exclude)charts/logs/README.md' ':(exclude)charts/logs/README.md.gotmpl' && git diff --quiet --name-only -- charts/logs/ ':(exclude)charts/logs/README.md' ':(exclude)charts/logs/README.md.gotmpl' && exit 1 || exit 0
     disablesourceinput: true
   breakingChanges:
     name: "Check if commit is a breaking change"

--- a/updatecli/internal/03_metrics_major.yml
+++ b/updatecli/internal/03_metrics_major.yml
@@ -12,7 +12,7 @@ conditions:
     name: "Check if charts/metrics/ has changes"
     kind: shell
     spec:
-      command: git diff --quiet --name-only origin/main...HEAD -- charts/metrics/ && git diff --quiet --name-only -- charts/metrics/ && exit 1 || exit 0
+      command: git diff --quiet --name-only origin/main...HEAD -- charts/metrics/ ':(exclude)charts/metrics/README.md' ':(exclude)charts/metrics/README.md.gotmpl' && git diff --quiet --name-only -- charts/metrics/ ':(exclude)charts/metrics/README.md' ':(exclude)charts/metrics/README.md.gotmpl' && exit 1 || exit 0
     disablesourceinput: true
   breakingChanges:
     name: "Check if commit is a breaking change"

--- a/updatecli/internal/03_traces_major.yml
+++ b/updatecli/internal/03_traces_major.yml
@@ -12,7 +12,7 @@ conditions:
     name: "Check if charts/traces/ has changes"
     kind: shell
     spec:
-      command: git diff --quiet --name-only origin/main...HEAD -- charts/traces/ && git diff --quiet --name-only -- charts/traces/ && exit 1 || exit 0
+      command: git diff --quiet --name-only origin/main...HEAD -- charts/traces/ ':(exclude)charts/traces/README.md' ':(exclude)charts/traces/README.md.gotmpl' && git diff --quiet --name-only -- charts/traces/ ':(exclude)charts/traces/README.md' ':(exclude)charts/traces/README.md.gotmpl' && exit 1 || exit 0
     disablesourceinput: true
   breakingChanges:
     name: "Check if commit is a breaking change"

--- a/updatecli/internal/04_events_minor.yml
+++ b/updatecli/internal/04_events_minor.yml
@@ -12,7 +12,7 @@ conditions:
     name: "Check if charts/events/ has changes"
     kind: shell
     spec:
-      command: git diff --quiet --name-only origin/main...HEAD -- charts/events/ && git diff --quiet --name-only -- charts/events/ && exit 1 || exit 0
+      command: git diff --quiet --name-only origin/main...HEAD -- charts/events/ ':(exclude)charts/events/README.md' ':(exclude)charts/events/README.md.gotmpl' && git diff --quiet --name-only -- charts/events/ ':(exclude)charts/events/README.md' ':(exclude)charts/events/README.md.gotmpl' && exit 1 || exit 0
     disablesourceinput: true
   nonBreakingChanges:
     name: "Check if commit is non-breaking"

--- a/updatecli/internal/04_logs_minor.yml
+++ b/updatecli/internal/04_logs_minor.yml
@@ -12,7 +12,7 @@ conditions:
     name: "Check if charts/logs/ has changes"
     kind: shell
     spec:
-      command: git diff --quiet --name-only origin/main...HEAD -- charts/logs/ && git diff --quiet --name-only -- charts/logs/ && exit 1 || exit 0
+      command: git diff --quiet --name-only origin/main...HEAD -- charts/logs/ ':(exclude)charts/logs/README.md' ':(exclude)charts/logs/README.md.gotmpl' && git diff --quiet --name-only -- charts/logs/ ':(exclude)charts/logs/README.md' ':(exclude)charts/logs/README.md.gotmpl' && exit 1 || exit 0
     disablesourceinput: true
   nonBreakingChanges:
     name: "Check if commit is non-breaking"

--- a/updatecli/internal/04_metrics_minor.yml
+++ b/updatecli/internal/04_metrics_minor.yml
@@ -12,7 +12,7 @@ conditions:
     name: "Check if charts/metrics/ has changes"
     kind: shell
     spec:
-      command: git diff --quiet --name-only origin/main...HEAD -- charts/metrics/ && git diff --quiet --name-only -- charts/metrics/ && exit 1 || exit 0
+      command: git diff --quiet --name-only origin/main...HEAD -- charts/metrics/ ':(exclude)charts/metrics/README.md' ':(exclude)charts/metrics/README.md.gotmpl' && git diff --quiet --name-only -- charts/metrics/ ':(exclude)charts/metrics/README.md' ':(exclude)charts/metrics/README.md.gotmpl' && exit 1 || exit 0
     disablesourceinput: true
   nonBreakingChanges:
     name: "Check if commit is non-breaking"

--- a/updatecli/internal/04_traces_minor.yml
+++ b/updatecli/internal/04_traces_minor.yml
@@ -12,7 +12,7 @@ conditions:
     name: "Check if charts/traces/ has changes"
     kind: shell
     spec:
-      command: git diff --quiet --name-only origin/main...HEAD -- charts/traces/ && git diff --quiet --name-only -- charts/traces/ && exit 1 || exit 0
+      command: git diff --quiet --name-only origin/main...HEAD -- charts/traces/ ':(exclude)charts/traces/README.md' ':(exclude)charts/traces/README.md.gotmpl' && git diff --quiet --name-only -- charts/traces/ ':(exclude)charts/traces/README.md' ':(exclude)charts/traces/README.md.gotmpl' && exit 1 || exit 0
     disablesourceinput: true
   nonBreakingChanges:
     name: "Check if commit is non-breaking"

--- a/updatecli/internal/05_events_patch.yml
+++ b/updatecli/internal/05_events_patch.yml
@@ -12,7 +12,7 @@ conditions:
     name: "Check if charts/events/ has changes"
     kind: shell
     spec:
-      command: git diff --quiet --name-only origin/main...HEAD -- charts/events/ && git diff --quiet --name-only -- charts/events/ && exit 1 || exit 0
+      command: git diff --quiet --name-only origin/main...HEAD -- charts/events/ ':(exclude)charts/events/README.md' ':(exclude)charts/events/README.md.gotmpl' && git diff --quiet --name-only -- charts/events/ ':(exclude)charts/events/README.md' ':(exclude)charts/events/README.md.gotmpl' && exit 1 || exit 0
     disablesourceinput: true
   nonBreakingChanges:
     name: "Check if commit is non-breaking"

--- a/updatecli/internal/05_logs_patch.yml
+++ b/updatecli/internal/05_logs_patch.yml
@@ -12,7 +12,7 @@ conditions:
     name: "Check if charts/logs/ has changes"
     kind: shell
     spec:
-      command: git diff --quiet --name-only origin/main...HEAD -- charts/logs/ && git diff --quiet --name-only -- charts/logs/ && exit 1 || exit 0
+      command: git diff --quiet --name-only origin/main...HEAD -- charts/logs/ ':(exclude)charts/logs/README.md' ':(exclude)charts/logs/README.md.gotmpl' && git diff --quiet --name-only -- charts/logs/ ':(exclude)charts/logs/README.md' ':(exclude)charts/logs/README.md.gotmpl' && exit 1 || exit 0
     disablesourceinput: true
   nonBreakingChanges:
     name: "Check if commit is non-breaking"

--- a/updatecli/internal/05_metrics_patch.yml
+++ b/updatecli/internal/05_metrics_patch.yml
@@ -12,7 +12,7 @@ conditions:
     name: "Check if charts/metrics/ has changes"
     kind: shell
     spec:
-      command: git diff --quiet --name-only origin/main...HEAD -- charts/metrics/ && git diff --quiet --name-only -- charts/metrics/ && exit 1 || exit 0
+      command: git diff --quiet --name-only origin/main...HEAD -- charts/metrics/ ':(exclude)charts/metrics/README.md' ':(exclude)charts/metrics/README.md.gotmpl' && git diff --quiet --name-only -- charts/metrics/ ':(exclude)charts/metrics/README.md' ':(exclude)charts/metrics/README.md.gotmpl' && exit 1 || exit 0
     disablesourceinput: true
   nonBreakingChanges:
     name: "Check if commit is non-breaking"

--- a/updatecli/internal/05_traces_patch.yml
+++ b/updatecli/internal/05_traces_patch.yml
@@ -12,7 +12,7 @@ conditions:
     name: "Check if charts/traces/ has changes"
     kind: shell
     spec:
-      command: git diff --quiet --name-only origin/main...HEAD -- charts/traces/ && git diff --quiet --name-only -- charts/traces/ && exit 1 || exit 0
+      command: git diff --quiet --name-only origin/main...HEAD -- charts/traces/ ':(exclude)charts/traces/README.md' ':(exclude)charts/traces/README.md.gotmpl' && git diff --quiet --name-only -- charts/traces/ ':(exclude)charts/traces/README.md' ':(exclude)charts/traces/README.md.gotmpl' && exit 1 || exit 0
     disablesourceinput: true
   nonBreakingChanges:
     name: "Check if commit is non-breaking"

--- a/updatecli/internal/06_stack_major.yml
+++ b/updatecli/internal/06_stack_major.yml
@@ -12,7 +12,7 @@ conditions:
     name: "Check if charts/stack/ has changes"
     kind: shell
     spec:
-      command: git diff --quiet --name-only origin/main...HEAD -- charts/stack/ && git diff --quiet --name-only -- charts/stack/ && exit 1 || exit 0
+      command: git diff --quiet --name-only origin/main...HEAD -- charts/stack/ ':(exclude)charts/stack/README.md' ':(exclude)charts/stack/README.md.gotmpl' && git diff --quiet --name-only -- charts/stack/ ':(exclude)charts/stack/README.md' ':(exclude)charts/stack/README.md.gotmpl' && exit 1 || exit 0
     disablesourceinput: true
   breakingChanges:
     name: "Check if commit message is a breaking change"

--- a/updatecli/internal/07_stack_minor.yml
+++ b/updatecli/internal/07_stack_minor.yml
@@ -12,7 +12,7 @@ conditions:
     name: "Check if charts/stack/ has changes"
     kind: shell
     spec:
-      command: git diff --quiet --name-only origin/main...HEAD -- charts/stack/ && git diff --quiet --name-only -- charts/stack/ && exit 1 || exit 0
+      command: git diff --quiet --name-only origin/main...HEAD -- charts/stack/ ':(exclude)charts/stack/README.md' ':(exclude)charts/stack/README.md.gotmpl' && git diff --quiet --name-only -- charts/stack/ ':(exclude)charts/stack/README.md' ':(exclude)charts/stack/README.md.gotmpl' && exit 1 || exit 0
     disablesourceinput: true
   nonBreakingChanges:
     name: "Check if commit is non-breaking"

--- a/updatecli/internal/08_stack_patch.yml
+++ b/updatecli/internal/08_stack_patch.yml
@@ -12,7 +12,7 @@ conditions:
     name: "Check if charts/stack/ has changes"
     kind: shell
     spec:
-      command: git diff --quiet --name-only origin/main...HEAD -- charts/stack/ && git diff --quiet --name-only -- charts/stack/ && exit 1 || exit 0
+      command: git diff --quiet --name-only origin/main...HEAD -- charts/stack/ ':(exclude)charts/stack/README.md' ':(exclude)charts/stack/README.md.gotmpl' && git diff --quiet --name-only -- charts/stack/ ':(exclude)charts/stack/README.md' ':(exclude)charts/stack/README.md.gotmpl' && exit 1 || exit 0
     disablesourceinput: true
   nonBreakingChanges:
     name: "Check if commit is non-breaking"

--- a/updatecli/internal/09_agent_major.yml
+++ b/updatecli/internal/09_agent_major.yml
@@ -12,7 +12,7 @@ conditions:
     name: "Check if charts/agent/ has changes"
     kind: shell
     spec:
-      command: git diff --quiet --name-only origin/main...HEAD -- charts/agent/ && git diff --quiet --name-only -- charts/agent/ && exit 1 || exit 0
+      command: git diff --quiet --name-only origin/main...HEAD -- charts/agent/ ':(exclude)charts/agent/README.md' ':(exclude)charts/agent/README.md.gotmpl' && git diff --quiet --name-only -- charts/agent/ ':(exclude)charts/agent/README.md' ':(exclude)charts/agent/README.md.gotmpl' && exit 1 || exit 0
     disablesourceinput: true
   breakingChanges:
     name: "Check if commit message is a breaking change"

--- a/updatecli/internal/09_agent_minor.yml
+++ b/updatecli/internal/09_agent_minor.yml
@@ -12,7 +12,7 @@ conditions:
     name: "Check if charts/agent/ has changes"
     kind: shell
     spec:
-      command: git diff --quiet --name-only origin/main...HEAD -- charts/agent/ && git diff --quiet --name-only -- charts/agent/ && exit 1 || exit 0
+      command: git diff --quiet --name-only origin/main...HEAD -- charts/agent/ ':(exclude)charts/agent/README.md' ':(exclude)charts/agent/README.md.gotmpl' && git diff --quiet --name-only -- charts/agent/ ':(exclude)charts/agent/README.md' ':(exclude)charts/agent/README.md.gotmpl' && exit 1 || exit 0
     disablesourceinput: true
   nonBreakingChanges:
     name: "Check if commit is non-breaking"

--- a/updatecli/internal/09_agent_patch.yml
+++ b/updatecli/internal/09_agent_patch.yml
@@ -12,7 +12,7 @@ conditions:
     name: "Check if charts/agent/ has changes"
     kind: shell
     spec:
-      command: git diff --quiet --name-only origin/main...HEAD -- charts/agent/ && git diff --quiet --name-only -- charts/agent/ && exit 1 || exit 0
+      command: git diff --quiet --name-only origin/main...HEAD -- charts/agent/ ':(exclude)charts/agent/README.md' ':(exclude)charts/agent/README.md.gotmpl' && git diff --quiet --name-only -- charts/agent/ ':(exclude)charts/agent/README.md' ':(exclude)charts/agent/README.md.gotmpl' && exit 1 || exit 0
     disablesourceinput: true
   nonBreakingChanges:
     name: "Check if commit is non-breaking"


### PR DESCRIPTION
Exclude README.md files from `updatecli/internal` rules. This should prevent some unnecessary version bumps and releases.