### PR TITLE
feat: add option for logs encoding in telemetry

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent
 description: Chart to install K8s collection stack based on Observe Agent
 type: application
-version: 0.9.3
+version: 0.10.0
 appVersion: "1.0.0"
 dependencies:
   - name: opentelemetry-collector

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -1,6 +1,6 @@
 # agent
 
-![Version: 0.9.3](https://img.shields.io/badge/Version-0.9.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 0.10.0](https://img.shields.io/badge/Version-0.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 > [!CAUTION]
 > This chart is under active development and is not meant to be installed yet.
@@ -29,6 +29,7 @@ Chart to install K8s collection stack based on Observe Agent
 | agent.config.global.debug.verbosity | string | `"basic"` |  |
 | agent.config.global.processors.batch.send_batch_max_size | int | `100` |  |
 | agent.config.global.processors.batch.send_batch_size | int | `100` |  |
+| agent.config.global.service.telemetry.logging_encoding | string | `"console"` |  |
 | agent.config.global.service.telemetry.logging_level | string | `"WARN"` |  |
 | agent.config.global.service.telemetry.metrics_level | string | `"normal"` |  |
 | agent.selfMonitor.enabled | bool | `true` |  |

--- a/charts/agent/templates/_config-telemetry.tpl
+++ b/charts/agent/templates/_config-telemetry.tpl
@@ -5,4 +5,5 @@ telemetry:
       address: {{ template "config.local_host"}}:8888
     logs:
       level: {{ .Values.agent.config.global.service.telemetry.logging_level }}
+      encoding: {{ .Values.agent.config.global.service.telemetry.logging_encoding }}
 {{- end -}}

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -46,6 +46,7 @@ agent:
         telemetry:
           metrics_level: normal
           logging_level: WARN
+          logging_encoding: console
       debug:
         # values basic, normal, detailed
         verbosity: basic


### PR DESCRIPTION
Allows telemetry logging to be configurable. This is currently needed for integration tests 

Eg: json as below for pod logs instead of pipe to console (default)
```
{"level":"warn","ts":1726165986.746206,"caller":"internal/resourcedetection.go:130","msg":"failed to detect resource","kind":"processor","name":"resourcedetection/cloud","pipeline":"metrics/forward","error":"isEks() error retrieving auth configmap: failed to retrieve ConfigMap kube-system/aws-auth: configmaps \"aws-auth\" not found"}
``` 

Reference: https://opentelemetry.io/docs/collector/internal-telemetry/ 