### PR TITLE
chore(updatecli): Need a template file for every chart

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -28,6 +28,7 @@ jobs:
         uses: losisin/helm-docs-github-action@v1
         with:
           git-push: false
+          template-files: README.md.gotmpl
 
       # Use Peter Evans Pull Request Action to create a pull request
       - name: Create Pull Request

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,4 +15,3 @@ repos:
     - id: helm-docs
       args:
         - --chart-search-root=charts
-        - --skip-version-footer

--- a/charts/endpoint/README.md.gotmpl
+++ b/charts/endpoint/README.md.gotmpl
@@ -3,9 +3,6 @@
 
 {{ template "chart.badgesSection" . }}
 
-> [!CAUTION]
-> This chart is under active development and is not meant to be installed yet.
-
 {{ template "chart.description" . }}
 
 {{ template "chart.homepageLine" . }}

--- a/charts/events/README.md.gotmpl
+++ b/charts/events/README.md.gotmpl
@@ -3,9 +3,6 @@
 
 {{ template "chart.badgesSection" . }}
 
-> [!CAUTION]
-> This chart is under active development and is not meant to be installed yet.
-
 {{ template "chart.description" . }}
 
 {{ template "chart.homepageLine" . }}

--- a/charts/logs/README.md.gotmpl
+++ b/charts/logs/README.md.gotmpl
@@ -3,9 +3,6 @@
 
 {{ template "chart.badgesSection" . }}
 
-> [!CAUTION]
-> This chart is under active development and is not meant to be installed yet.
-
 {{ template "chart.description" . }}
 
 {{ template "chart.homepageLine" . }}

--- a/charts/metrics/README.md.gotmpl
+++ b/charts/metrics/README.md.gotmpl
@@ -3,9 +3,6 @@
 
 {{ template "chart.badgesSection" . }}
 
-> [!CAUTION]
-> This chart is under active development and is not meant to be installed yet.
-
 {{ template "chart.description" . }}
 
 {{ template "chart.homepageLine" . }}

--- a/charts/proxy/README.md.gotmpl
+++ b/charts/proxy/README.md.gotmpl
@@ -3,9 +3,6 @@
 
 {{ template "chart.badgesSection" . }}
 
-> [!CAUTION]
-> This chart is under active development and is not meant to be installed yet.
-
 {{ template "chart.description" . }}
 
 {{ template "chart.homepageLine" . }}

--- a/charts/stack/README.md.gotmpl
+++ b/charts/stack/README.md.gotmpl
@@ -3,9 +3,6 @@
 
 {{ template "chart.badgesSection" . }}
 
-> [!CAUTION]
-> This chart is under active development and is not meant to be installed yet.
-
 {{ template "chart.description" . }}
 
 {{ template "chart.homepageLine" . }}

--- a/charts/traces/README.md.gotmpl
+++ b/charts/traces/README.md.gotmpl
@@ -3,9 +3,6 @@
 
 {{ template "chart.badgesSection" . }}
 
-> [!CAUTION]
-> This chart is under active development and is not meant to be installed yet.
-
 {{ template "chart.description" . }}
 
 {{ template "chart.homepageLine" . }}


### PR DESCRIPTION
 to avoid version footer

helm docs default includes version of helm docs in footer which creates unnecessary  changes on readme when different tools run helm docs

Should fix this - https://github.com/observeinc/helm-charts/pull/215