### PR TITLE
ci: add integration testing for matrixing values files

### DIFF
--- a/.github/workflows/tests-integration.yaml
+++ b/.github/workflows/tests-integration.yaml
@@ -6,6 +6,8 @@ on:
   push:
     branches:
       - main
+  schedule:
+    - cron: "0 6 * * *" #Runs at 06:00 UTC Daily
 
 
 #Special permissions required for OIDC authentication
@@ -30,6 +32,8 @@ jobs:
       matrix:
           values:
             - default.yaml
+            - node_affinity.yaml
+            - node_taint.yaml
           namespace:
             - observe
           include: # Test not-observe namespace with default values only

--- a/integration/README.md
+++ b/integration/README.md
@@ -3,14 +3,22 @@
 
 The root of this module location is intended to run integration tests using the terraform test framework. The tests are located at `integration/tests`
 
-The tests are run using the `terraform test -verbose` command from this folder `helm-charts/integration`
+The tests are run using the `terraform test -verbose` command from this folder `helm-charts/integration`.  Before running this command, ensure that virtual enviroment is enabled:
+
+```
+integration git:(main) ✗ virtualenv venv source
+integration git:(main) ✗ source scripts/venv/bin/activate
+integration git:(main):✗ terraform test -verbose
+```
+
 
 When the above command is run, the tests in the `integration/tests` directory are ran using the variables provided. The tests are ran in the order of the run blocks provided in `<test>.tftest.hcl`
 
 Generally a test will do the following
 - Create a local kind K8s cluster (`modules/create_kind_cluster`)
-- Install the `agent` helm chart in the cluster (`modules/deploy_helm`)
-- Run a test using `observeinc/collection/aws//modules/testing/exec` module to accept python scripts located at `integration/tests/scripts` These scripts test the various flows of the helm chart installation
+- Configure the K8s cluster (`modules/setup_addnl_kubernetes`) if needed, based on the desired values file
+- Install the `agent` helm chart in the cluster (`modules/deploy_helm`) with desired values file
+- Run tests using `observeinc/collection/aws//modules/testing/exec` module to accept python scripts located at `integration/tests/scripts` These scripts test the various flows of the helm chart installation based on the values file.
 
 
 ### Variables
@@ -29,7 +37,7 @@ Optionally, add below namespace variable if testing alternative namespace that's
 ```
 helm_chart_agent_test_namespace = "<some_other_namespace_to_test_helm_chart_installation>"
 ```
-These variables get passed on to `modules/deploy_helm` appropriately when testing.
+These variables get passed on to `modules/deploy_helm` and `modules/setup_addnl_kubernetes` appropriately when testing.
 
 Note that the kubernetes and helm providers are automatically specified to use your `~/.kube/config` file by default, when using the context created by the kind cluster.
 

--- a/integration/modules/deploy_helm/provider.tf
+++ b/integration/modules/deploy_helm/provider.tf
@@ -6,7 +6,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.17.0"
+      version = "~> 2.32.0"
     }
   }
   required_version = "~> 1.3"

--- a/integration/modules/deploy_helm/values/node_affinity.yaml
+++ b/integration/modules/deploy_helm/values/node_affinity.yaml
@@ -1,0 +1,39 @@
+#Common for telemetry
+agent:
+  config:
+      global:
+        service:
+          telemetry:
+            logging_encoding: json
+            logging_level: INFO
+
+#Common for namepsace/url/token
+observe:
+  collectionEndpoint:
+    value: ${observe_url}
+  token:
+    value: ${observe_token}
+cluster:
+  namespaceOverride:
+    value: ${helm_chart_agent_test_namespace}
+cluster-events:
+  namespaceOverride:  ${helm_chart_agent_test_namespace}
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: node-type
+                operator: In
+                values: [useme]
+              - key: observeinc.com/unschedulable
+                operator: DoesNotExist
+              - key: kubernetes.io/os
+                operator: NotIn
+                values: [windows]
+cluster-metrics:
+  namespaceOverride:  ${helm_chart_agent_test_namespace}
+node-logs-metrics:
+  namespaceOverride:  ${helm_chart_agent_test_namespace}
+monitor:
+  namespaceOverride:  ${helm_chart_agent_test_namespace}

--- a/integration/modules/deploy_helm/values/node_taint.yaml
+++ b/integration/modules/deploy_helm/values/node_taint.yaml
@@ -1,0 +1,31 @@
+#Common for telemetry
+agent:
+  config:
+      global:
+        service:
+          telemetry:
+            logging_encoding: json
+            logging_level: INFO
+
+#Common for namepsace/url/token
+observe:
+  collectionEndpoint:
+    value: ${observe_url}
+  token:
+    value: ${observe_token}
+cluster:
+  namespaceOverride:
+    value: ${helm_chart_agent_test_namespace}
+cluster-events:
+  namespaceOverride:  ${helm_chart_agent_test_namespace}
+  tolerations:
+  - key: "deployObserve"
+    operator: "Equal"
+    value: "notAllowed"
+    effect: "NoSchedule"
+cluster-metrics:
+  namespaceOverride:  ${helm_chart_agent_test_namespace}
+node-logs-metrics:
+  namespaceOverride:  ${helm_chart_agent_test_namespace}
+monitor:
+  namespaceOverride:  ${helm_chart_agent_test_namespace}

--- a/integration/modules/local_sandbox_kind/README.md
+++ b/integration/modules/local_sandbox_kind/README.md
@@ -2,6 +2,7 @@
 
 This module is only intended to quickly install the agent helm chart without configuring a k8s cluster yourself and touching helm manually.  No tests will run here as this module just creates a kind cluster and installs a helm chart in it.
 
+The purpose is to mimic what `terraform test` does but since terrafrom test destroys the infrastructure, this sandbox allows you to preserve it
 
 # Local Sandbox
 
@@ -14,6 +15,7 @@ If you want install kind cluster with defaults and then deploy helm chart locall
 ```
 observe_url  = "https://your-observe-url.com"
 observe_token = "your-secure-token"
+helm_chart_agent_test_values_file = "default.yaml"
 ```
 
 Then run `terraform init` && `terraform apply` in this directory.

--- a/integration/modules/local_sandbox_kind/main.tf
+++ b/integration/modules/local_sandbox_kind/main.tf
@@ -1,11 +1,16 @@
+# Helm and Kubernetes provider must be instantiated AFTER kind cluster is created
+# See warning: https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs#stacking-with-managed-kubernetes-cluster-resources
+
 provider "helm" {
   kubernetes {
     config_path = pathexpand(var.cluster_config_path) #Needed by deploy_helm, uses current context
+    host    = module.setup_kind_cluster.kind_cluster_endpoint
   }
 }
 
 provider "kubernetes" {
   config_path = pathexpand(var.cluster_config_path) #Needed by deploy_helm, uses current context
+  host    = module.setup_kind_cluster.kind_cluster_endpoint
 }
 
 
@@ -15,14 +20,23 @@ module "setup_kind_cluster" {
   kind_cluster_config_path = var.cluster_config_path
 }
 
+module "setup_addnl_kubernetes" {
+
+  source = "./../setup_addnl_kubernetes"
+  helm_chart_agent_test_values_file = var.helm_chart_agent_test_values_file
+
+  depends_on = [ module.setup_kind_cluster ]
+}
+
 
 module "deploy_helm" {
   source                            = "./../deploy_helm"
   observe_url                       = var.observe_url
   observe_token                     = var.observe_token
-  helm_chart_agent_test_values_file = "default.yaml" #This is the default values file
-  helm_chart_agent_test_namespace   = "observe"
+  helm_chart_agent_test_values_file = var.helm_chart_agent_test_values_file
+  helm_chart_agent_test_namespace   = var.helm_chart_agent_test_namespace
   use_local_chart                   = true
 
-  depends_on = [module.setup_kind_cluster]
+  depends_on = [module.setup_addnl_kubernetes]
+  count = var.deploy_helm_enabled ? 1 : 0
 }

--- a/integration/modules/local_sandbox_kind/outputs.tf
+++ b/integration/modules/local_sandbox_kind/outputs.tf
@@ -15,15 +15,20 @@ output "kind_cluster_endpoint" {
 }
 output "helm_chart_agent_test_release_name" {
   description = "Helm_chart_agent_test_release_name"
-  value       = module.deploy_helm.helm_chart_agent_test_release_name
+  value       = var.deploy_helm_enabled ? module.deploy_helm[0].helm_chart_agent_test_release_name : null
 }
 
 output "helm_chart_agent_test_namespace" {
   description = "value of helm_chart_agent_test_namespace"
-  value       = module.deploy_helm.helm_chart_agent_test_namespace
+  value       = var.deploy_helm_enabled ? module.deploy_helm[0].helm_chart_agent_test_namespace : null
 }
 
 output "helm_chart_agent_test_values_file" {
   description = "Which values file was used for deployment"
-  value       = module.deploy_helm.helm_chart_agent_test_values_file
+  value       = var.deploy_helm_enabled ? module.deploy_helm[0].helm_chart_agent_test_values_file : null
+}
+
+output "node-details" {
+  value = module.setup_addnl_kubernetes.node-details
+
 }

--- a/integration/modules/local_sandbox_kind/variables.tf
+++ b/integration/modules/local_sandbox_kind/variables.tf
@@ -15,3 +15,20 @@ variable "observe_token" {
   sensitive   = true
   description = "Observe Token for Datastream for agent helm-chart to send data to. Eg: ds1....23AB"
 }
+variable "deploy_helm_enabled" {
+  description = "Enable or disable the deploy_helm module"
+  type        = bool
+  default     = true
+}
+
+variable "helm_chart_agent_test_namespace" {
+  type        = string
+  default     = "observe"
+  description = "namespace to use for agent helm chart"
+}
+
+
+variable "helm_chart_agent_test_values_file" {
+  type        = string
+  description = "Values file to use to install helm chart"
+}

--- a/integration/modules/setup_addnl_kubernetes/main.tf
+++ b/integration/modules/setup_addnl_kubernetes/main.tf
@@ -1,0 +1,50 @@
+data "kubernetes_nodes" "kind_nodes" {}
+# Refetch the node details after taints and labels are applied
+data "kubernetes_nodes" "kind_nodes_after" {
+  depends_on = [kubernetes_labels.last_node_name, kubernetes_node_taint.last_node_name]
+}
+locals {
+  node_names = [for node in data.kubernetes_nodes.kind_nodes.nodes : node.metadata.0.name]
+  last_node_name = element(local.node_names, length(local.node_names) - 1)
+  use_node_affinity = var.helm_chart_agent_test_values_file == "node_affinity.yaml"
+  use_node_taint = var.helm_chart_agent_test_values_file == "node_taint.yaml"
+
+}
+# Output the updated node details
+output "node-details" {
+  value = [
+    for node in data.kubernetes_nodes.kind_nodes_after.nodes : {
+      name        = node.metadata.0.name
+      taints      = length(node.spec.0.taints) > 0 ? node.spec.0.taints : null
+      labels      = length(node.metadata.0.labels) > 0 ? node.metadata.0.labels : null
+    }
+  ]
+}
+
+resource "kubernetes_labels" "last_node_name" {
+
+  count = local.use_node_affinity ? 1 : 0 #Label the last node for affinity testing
+  api_version = "v1"
+  kind        = "Node"
+  metadata {
+    name = local.last_node_name
+  }
+  labels = {
+    "node-type" = "useme"
+  }
+}
+
+
+resource "kubernetes_node_taint" "last_node_name" {
+  count = local.use_node_taint ? 1 : 0 #Taint the last node for taint testing
+  metadata {
+    name = local.last_node_name
+  }
+  taint {
+    key    = "deployObserve"
+    value  = "notAllowed"
+    effect = "NoSchedule"
+  }
+  force = true
+
+}

--- a/integration/modules/setup_addnl_kubernetes/provider.tf
+++ b/integration/modules/setup_addnl_kubernetes/provider.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.32.0"
+    }
+  }
+  required_version = "~> 1.3"
+}

--- a/integration/modules/setup_addnl_kubernetes/variables.tf
+++ b/integration/modules/setup_addnl_kubernetes/variables.tf
@@ -1,0 +1,5 @@
+
+variable "helm_chart_agent_test_values_file" {
+  type        = string
+  description = "Values file to use to install helm chart"
+}

--- a/integration/modules/setup_kind_cluster/kind.tf
+++ b/integration/modules/setup_kind_cluster/kind.tf
@@ -19,5 +19,9 @@ resource "kind_cluster" "cluster" {
     node {
       role = "worker"
     }
+
+    node {
+      role = "worker"
+    }
   }
 }

--- a/integration/pytest.ini
+++ b/integration/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+addopts = -v -s --suppress-no-test-exit-code --slowdown=0.1
+testpaths = ./scripts

--- a/integration/scripts/conftest.py
+++ b/integration/scripts/conftest.py
@@ -1,6 +1,15 @@
 import pytest
 import os
+import time
 from kubernetes import client, config
+
+def pytest_addoption(parser):
+    parser.addoption("--slowdown", action="store", default=0.1, help="Delay between tests in seconds")
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_runtest_protocol(item, nextitem):
+    slowdown = float(item.config.getoption("--slowdown"))
+    time.sleep(slowdown)  # Delay before each test
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -77,9 +86,77 @@ def ApiException():
     from kubernetes.client.rest import ApiException
     return ApiException
 
+
+
+
 @pytest.helpers.register
-def parseLogs():
+# Function to check if the node has the specific taint
+def has_taint(node, key, value, effect):
     """
-    returns
+    Helper function checks if a node has key=value:effect taint applied on it
+
+    Example taints:
+    [{'effect': 'NoSchedule',
+    'key': 'deployObserve',
+    'time_added': None,
+    'value': 'notAllowed'}]
     """
-    return "Hi"
+
+    taints = node.spec.taints
+    if taints:
+        for taint in taints:
+            if (taint.key == key and
+                (taint.value == value or value is None) and
+                taint.effect == effect):
+                return True
+    return False
+
+@pytest.helpers.register
+#Function to check if a pod has the specific toleration
+def has_toleration(pod, key, value, effect):
+
+    """
+    Helper function checks if a pod has key=value:effect toleration
+
+    Example tolerations:
+    [{'effect': 'NoSchedule',
+        'key': 'deployObserve',
+        'operator': 'Equal',
+        'toleration_seconds': None,
+        'value': 'notAllowed'}, {'effect': 'NoExecute',
+        'key': 'node.kubernetes.io/unreachable',
+        'operator': 'Exists',
+        'toleration_seconds': 300,
+        'value': None}]
+    """
+
+    tolerations = pod.spec.tolerations
+    if tolerations:
+        for toleration in tolerations:
+            print("Pod Toleration is: {}".format(toleration))
+            if (toleration.key == key and
+                (toleration.value == value or value is None) and
+                toleration.effect == effect):
+                return True
+    return False
+
+
+
+@pytest.helpers.register
+#Function to check if a pod has the specific affinity
+def has_affinity(pod, key, operator, value):
+
+    """
+    Helper function checks if a pod has affinity
+    """
+    node_affinity = getattr(pod.spec.affinity, 'node_affinity', None)
+    if node_affinity:
+        terms = getattr(node_affinity.required_during_scheduling_ignored_during_execution, 'node_selector_terms', [])
+        for term in terms:
+            for expression in term.match_expressions:
+                print("Pod Affinity expression is: {}".format(expression))
+                if (expression.key == key and
+                    expression.operator == operator and
+                    (value in expression.values or value is None)):
+                    return True
+    return False

--- a/integration/scripts/requirements.txt
+++ b/integration/scripts/requirements.txt
@@ -3,3 +3,4 @@ kubernetes==30.1.0
 pytest_tagging==1.5.3
 pyyaml==6.0.2
 pytest-helpers-namespace==2021.12.29
+pytest-custom-exit-code==0.3.0

--- a/integration/scripts/test_basic.py
+++ b/integration/scripts/test_basic.py
@@ -5,7 +5,10 @@ import base64
 import json, yaml
 import re
 
-@pytest.mark.tags("default.yaml")
+@pytest.mark.tags(
+        "default.yaml",
+        "node_affinity.yaml",
+        "node_taint.yaml")
 def test_helm_correctness(apps_client, helm_config):
     """
     Test to verify there are 3 deployments and 1 daemonset in the cluster.
@@ -23,7 +26,9 @@ def test_helm_correctness(apps_client, helm_config):
     print("All expected deployments and daemonsets found.")
 
 @pytest.mark.tags(
-        "default.yaml")
+        "default.yaml",
+        "node_affinity.yaml",
+        "node_taint.yaml")
 def test_pods_state(kube_client, helm_config):
     """
     This test does the following:
@@ -51,7 +56,10 @@ def test_pods_state(kube_client, helm_config):
     print("All pods are running in the namespace:", helm_config['namespace'])
 
 
-@pytest.mark.tags("default.yaml")
+@pytest.mark.tags(
+        "default.yaml",
+        "node_affinity.yaml",
+        "node_taint.yaml")
 def test_config_map(kube_client, helm_config):
     """
     This test does the following:
@@ -106,7 +114,10 @@ def test_config_map(kube_client, helm_config):
 
     print("ConfigMap 'observe-agent' with token value verified.")
 
-@pytest.mark.tags("default.yaml")
+@pytest.mark.tags(
+        "default.yaml",
+        "node_affinity.yaml",
+        "node_taint.yaml")
 def test_secrets(kube_client, helm_config):
     """
     This test does the following:

--- a/integration/scripts/test_logs.py
+++ b/integration/scripts/test_logs.py
@@ -7,7 +7,10 @@ import re
 import time
 
 
-@pytest.mark.tags("default.yaml")
+@pytest.mark.tags(
+        "default.yaml",
+        "node_affinity.yaml",
+        "node_taint.yaml")
 def test_errors_logs(kube_client, helm_config):
 
     """_summary_

--- a/integration/scripts/test_nodes.py
+++ b/integration/scripts/test_nodes.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+
+import pytest
+import base64
+import json, yaml
+import re
+
+
+
+
+@pytest.mark.tags(
+        "node_affinity.yaml")
+def test_node_affinity(kube_client, helm_config):
+    """
+    This test does the following:
+    - Check that the pod 'cluster-events' is scheduled on a node with label 'node-type=useme' using affinity
+
+    *Note*:
+    -  Because we use "requiredDuringSchedulingIgnoredDuringExecution", the pod MUST be scheduled onto the node with label
+    -  See https://yuminlee2.medium.com/kubernetes-node-selector-and-node-affinity-ecb3a4d69165
+    """
+
+    key="node-type"
+    operator="In"
+    value="useme"
+    label_selector = "app.kubernetes.io/name=cluster-events"
+
+    print(f"Checking node affinity for pod containing '{label_selector}' ")
+
+    #Get the pod with label 'app.kubernetes.io/name=cluster-events'
+    pod = kube_client.list_namespaced_pod(namespace=helm_config['namespace'], label_selector=label_selector)
+    assert pod.items, f"No pods found with label {label_selector} in namespace {helm_config['namespace']}"
+    assert len(pod.items) == 1, f"Expected 1 pod with label {label_selector}, but found {len(pod.items)}"
+    print(f"Found 1 pod with label {label_selector}")
+
+    pod = pod.items[0] #There should only be one cluster-events pod
+
+     # Assert that the pod has the specific affinity
+    assert pytest.helpers.has_affinity(pod, key, operator, value), \
+     f"Pod: {pod.metadata.name}, Namespace: {pod.metadata.namespace} does not have the expected affinity {key}={value}:{operator}"
+    print(f"Pod {pod.metadata.name} has the expected affinity '{key}={value}:{operator}'")
+
+
+    node_name = pod.spec.node_name
+    node = kube_client.read_node(name=node_name) #Get the node name where the pod is scheduled on
+
+    # Check the node where the pod is scheduled on to have the affinity desired
+
+    assert node.metadata.labels.get("node-type") == "useme", \
+        (f"Pod {pod.metadata.name} is not scheduled on a node {node.metadata.name }with label 'node-type=useme'")
+    print(f"Pod {pod.metadata.name} is correctly scheduled on a node {node.metadata.name} with label 'node-type=useme'")
+
+
+@pytest.mark.tags(
+        "node_taint.yaml")
+def test_node_taint(kube_client, helm_config):
+
+    """
+    This test does the following:
+    - Check that the pod with defined toleration has the expected toleration
+    - Check that the tainted node only containts the tolerated pod or none at all
+
+    *Note*:
+    Tolerations allow the scheduler to schedule pods with matching taints.
+    Tolerations allow scheduling but DON'T GUARANTEE scheduling.
+    See https://yuminlee2.medium.com/kubernetes-node-selector-and-node-affinity-ecb3a4d69165
+
+    """
+
+    toleration_key = "deployObserve"
+    toleration_value = "notAllowed"
+    toleration_effect = 'NoSchedule'
+    label_selector = "app.kubernetes.io/name=cluster-events"
+
+    print(f"Checking node taints for pod containing '{label_selector}'")
+
+    #Get the pod with label 'app.kubernetes.io/name=cluster-events'
+    pods = kube_client.list_namespaced_pod(namespace=helm_config['namespace'], label_selector=label_selector)
+    assert pods.items, f"No pods found with label {label_selector} in namespace {helm_config['namespace']}"
+    assert len(pods.items) == 1, f"Expected 1 pod with label {label_selector}, but found {len(pods.items)}"
+    print(f"Found 1 pod with label {label_selector}")
+
+    pod = pods.items[0] #There should only be one cluster-events pod
+
+    # Assert that the pod has the specific toleration
+    assert pytest.helpers.has_toleration(pod, toleration_key, toleration_value, toleration_effect), \
+     f"Pod: {pod.metadata.name}, Namespace: {pod.metadata.namespace} does not have the toleration {toleration_key}={toleration_value}:{toleration_effect}"
+    print(f"Pod {pod.metadata.name} has the expected toleration {toleration_key}={toleration_value}:{toleration_effect}")
+
+
+    #Find the node with taint
+    nodes = kube_client.list_node()
+    for node in nodes.items:
+        if(pytest.helpers.has_taint(node, toleration_key, toleration_value, toleration_effect)):
+            tainted_node=node
+            tainted_node_name = tainted_node.metadata.name
+
+    #Ensure no other pods on this node are scheduled except *possibly* one we had selected with toleration
+    pods = kube_client.list_namespaced_pod(namespace=helm_config['namespace'])
+    pods_on_node = [
+        pod for pod in pods.items
+        if pod.spec.node_name == tainted_node_name #Filter by node name
+    ]
+    assert len(pods_on_node) <= 1, f"Expected at most 1 pod on node {tainted_node_name} in namespace {helm_config['namespace']}, but found {len(pods_on_node)}."
+    if len(pods_on_node) == 1:
+    # If a pod is found, ensure it is the expected pod
+        assert pods_on_node[0].metadata.name == pod.metadata.name, \
+            f"Expected pod {pod.metadata.name} on node '{tainted_node_name}', but found {pods_on_node[0].metadata.name}."
+        print(f"Pod {pod.metadata.name} was correctly scheduled on Node '{tainted_node_name}'")
+        print(f"No other pods were scheduled on tainted node '{tainted_node_name}")
+    else:
+        print(f"No pods were scheduled on tainted node '{tainted_node_name}' in namespace {helm_config['namespace']} as expected")

--- a/integration/tests/integration.tftest.hcl
+++ b/integration/tests/integration.tftest.hcl
@@ -1,5 +1,6 @@
 # We have the ability to create variables specific for test and let it be controlled on a per test level
 # For now, we'll let these variables be controlled either from tests.auto.tfvars or via TF_VAR variables
+# See README.md
 
 // variables {
 //   cluster_config_path = "~/.kube/config" #Global var for provider
@@ -14,12 +15,12 @@ variables {
 
 provider "helm" {
   kubernetes {
-    config_path = pathexpand(var.cluster_config_path) #Needed by deploy_helm, root level value
+    config_path = pathexpand(var.cluster_config_path) #Needed by deploy_helm/setup_addnl_kubernetes, root level value
   }
 }
 
 provider "kubernetes" {
-  config_path = pathexpand(var.cluster_config_path) #Needed by deploy_helm, root level value
+  config_path = pathexpand(var.cluster_config_path) #Needed by deploy_helm/setup_addnl_kubernetes, root level value
 }
 
 
@@ -29,6 +30,12 @@ run "setup_kind_cluster" {
   }
   module {
     source = "./modules/setup_kind_cluster"
+  }
+}
+
+run "setup_addnl_kubernetes" {
+  module {
+    source = "./modules/setup_addnl_kubernetes"
   }
 }
 
@@ -46,7 +53,7 @@ run "test_basic" {
   }
 
   variables {
-    command = "pytest ./scripts/test_basic.py -v --tags ${run.deploy_helm.helm_chart_agent_test_values_file}"
+    command = "pytest ./scripts/test_basic.py --tags ${run.deploy_helm.helm_chart_agent_test_values_file}"
     env_vars = {
       HELM_NAMESPACE = run.deploy_helm.helm_chart_agent_test_namespace
     }
@@ -56,7 +63,6 @@ run "test_basic" {
     condition     = output.error == ""
     error_message = "Error in test_basic"
   }
-
 }
 
 run "test_logs" {
@@ -66,7 +72,7 @@ run "test_logs" {
   }
 
   variables {
-    command = "pytest ./scripts/test_logs.py -v --tags ${run.deploy_helm.helm_chart_agent_test_values_file}"
+    command = "pytest ./scripts/test_logs.py --tags ${run.deploy_helm.helm_chart_agent_test_values_file}"
     env_vars = {
       HELM_NAMESPACE = run.deploy_helm.helm_chart_agent_test_namespace
     }
@@ -76,5 +82,24 @@ run "test_logs" {
     condition     = output.error == ""
     error_message = "Error in test_logs"
   }
+}
 
+
+run "test_nodes" {
+  module {
+    source  = "observeinc/collection/aws//modules/testing/exec"
+    version = "2.9.0"
+  }
+
+  variables {
+    command = "pytest ./scripts/test_nodes.py --tags ${run.deploy_helm.helm_chart_agent_test_values_file}"
+    env_vars = {
+      HELM_NAMESPACE = run.deploy_helm.helm_chart_agent_test_namespace
+    }
+  }
+
+  assert {
+    condition     = output.error == ""
+    error_message = "Error in test_nodes"
+  }
 }


### PR DESCRIPTION
- Adds matrixing of values files for parallel testing of various helm chart configurations (node_affinity, node_taint)
- Adds additional testing for configs 

We now support testing of:
- Node Taints 
- Node Affinity (toleration) 
- Namespace (not-observe) 


See: 
- https://observe.atlassian.net/browse/OB-36072
- https://github.com/observeinc/helm-charts/pull/217 (addon for this) 