### PR TITLE
ci: add xml reporting(experimental)

### DIFF
--- a/.github/workflows/tests-integration.yaml
+++ b/.github/workflows/tests-integration.yaml
@@ -15,6 +15,8 @@ permissions:
     id-token: write
     contents: write
     pull-requests: write
+    actions: write
+    checks: write
 
 env:
     TF_VAR_observe_url: ${{secrets.OBSERVE_URL}}
@@ -23,9 +25,8 @@ env:
 
 
 jobs:
-
   helm-charts-agent-integration-tests:
-    name: helm-charts-agent-integration-tests-${{ matrix.namespace }}-${{ matrix.values }}
+    name: ns-${{ matrix.namespace }}+values-${{ matrix.values }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -41,7 +42,7 @@ jobs:
               namespace: not-observe
     defaults:
         run:
-            working-directory: integration #Terrafrom commands and tests are ran from integration directory
+            working-directory: integration #Terraform commands and tests are ran from integration directory
     steps:
         - name: Checkout code
           uses: actions/checkout@v4
@@ -64,8 +65,8 @@ jobs:
 
         - name: Setup Terraform
           uses: hashicorp/setup-terraform@v3
-          with:
-            terraform_version: 1.9.5
+          with: #Use alpha version which has experimental Junit feature.
+            terraform_version: "1.10.0-alpha20240918"
 
         - name: Terraform Init
           id: init
@@ -78,4 +79,17 @@ jobs:
         - name: Terraform Test
           id: test
           run: |
-            terraform test -verbose
+            terraform test -verbose -junit-xml=results-ns-${{ matrix.namespace }}+values-${{ matrix.values }}.xml
+
+        - name: Upload Test Results
+          uses: actions/upload-artifact@v4
+          if: success() || failure()
+          with:
+            name: results-ns-${{ matrix.namespace }}+values-${{ matrix.values }}
+            path: ${{ github.workspace }}/integration/*.xml
+
+        - name: Publish Test Summary #Parses *xml file and sends summary to Github Summary Page.
+          uses: test-summary/action@v2
+          with:
+            paths: ${{ github.workspace }}/integration/*.xml
+          if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ terraform.tfvars
 tfplan
 .terraform.lock.hcl
 *_override.tf
+*.xml
 
 #python
 venv


### PR DESCRIPTION
- Addresses https://observe.atlassian.net/browse/OB-37007 

Why?
- We want better reporting for terraform tests in PRs. It's currently hard to see in CI what specific test failed in which job.
- This change makes it easier to see which test failed and the error the test surfaced without scrolling through logs. 
- We use summary markdown from junit xml file to render the failure in summary screen
- We also change the naming convention for jobs to better identify things.

Other References:

Collapsing parallel github jobs (to make our CI tests less noisy in PR checks) is coming!
https://github.com/orgs/community/discussions/26246 

See example:
<img width="1249" alt="Screenshot 2024-11-06 at 3 11 03 PM" src="https://github.com/user-attachments/assets/1840ea9e-7f51-41a2-8223-17c8e13c03bb">

Scrolling....

We can see exactly what test failed, where and the output logs without having to scroll through each job logs manually. 


<img width="1249" alt="Screenshot 2024-11-06 at 3 11 23 PM" src="https://github.com/user-attachments/assets/9d87368e-e83f-44a1-b5ff-8005e1837746">


Another example showing that `test_basic` had failed 

<img width="908" alt="Screenshot 2024-11-06 at 3 31 02 PM" src="https://github.com/user-attachments/assets/f7c1c5b0-efab-47d3-8f54-d16d6f39171a">
