### PR TITLE
feat: Add overrides for excludeTargets and includeTargets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 *.tgz
 demo
 .kubeconfig
-
+.idea
 
 #terraform
 integration/.terraform

--- a/charts/events/Chart.yaml
+++ b/charts/events/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: events
 description: Observe kubernetes event collection
 type: application
-version: 0.1.26
+version: 0.2.0
 appVersion: v0.11.1
 dependencies:
   - name: endpoint

--- a/charts/events/README.md
+++ b/charts/events/README.md
@@ -1,6 +1,6 @@
 # events
 
-![Version: 0.1.26](https://img.shields.io/badge/Version-0.1.26-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.11.1](https://img.shields.io/badge/AppVersion-v0.11.1-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.11.1](https://img.shields.io/badge/AppVersion-v0.11.1-informational?style=flat-square)
 
 Observe kubernetes event collection
 
@@ -22,6 +22,8 @@ Observe kubernetes event collection
 |-----|------|---------|-------------|
 | affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key | string | `"observeinc.com/unschedulable"` |  |
 | affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].operator | string | `"DoesNotExist"` |  |
+| containerOverrides.excludeTargets | list | `[]` |  |
+| containerOverrides.includeTargets | list | `[]` |  |
 | customLabels | object | `{}` |  |
 | global.observe | object | `{}` |  |
 | image.kube_cluster_info.pullPolicy | string | `"Always"` |  |

--- a/charts/events/templates/deployment.yaml
+++ b/charts/events/templates/deployment.yaml
@@ -47,6 +47,18 @@ spec:
           image: {{ .Values.image.kube_state_events.repository }}:{{ default .Chart.AppVersion .Values.image.kube_state_events.tag }}
           imagePullPolicy: {{ .Values.image.kube_state_events.pullPolicy }}
           args:
+            # Include excludeTags if defined
+            {{- if .Values.containerOverrides.excludeTargets }}
+            {{- range .Values.containerOverrides.excludeTargets }}
+            - -exclude-target={{ . }}
+            {{- end }}
+            {{- end }}
+            # Include includeTags if defined
+            {{- if .Values.containerOverrides.includeTargets }}
+            {{- range .Values.containerOverrides.includeTargets }}
+            - -include-target={{ . }}
+            {{- end }}
+            {{- end }}
             - -healthz-addr=:5171
             - -metrics-addr=:9090
             - -o={{ include "observe.collectionEndpointWithToken" . }}/v1/http/kubernetes/events?clusterUid=$(OBSERVE_CLUSTER)

--- a/charts/events/values.yaml
+++ b/charts/events/values.yaml
@@ -26,6 +26,12 @@ serviceAccount:
   annotations: {}
   name:
 
+# Override exclude or include resources matching pattern from being watched. View resources with `kubectl api-resources`
+# Does not work for "Core" APIs. Values must be in format <group>/<version>/<resource>. example "events.k8s.io/v1/events"
+containerOverrides:
+  excludeTargets: []
+  includeTargets: []
+
 resources:
   limits:
     cpu: 50m

--- a/charts/stack/Chart.lock
+++ b/charts/stack/Chart.lock
@@ -7,12 +7,12 @@ dependencies:
   version: 0.3.25
 - name: events
   repository: file://../events
-  version: 0.1.26
+  version: 0.2.0
 - name: proxy
   repository: file://../proxy
   version: 0.1.8
 - name: traces
   repository: file://../traces
   version: 1.0.6
-digest: sha256:0b0eeefbe2ee2ca0698adccdfe5e306976365ced30fe1da7cf83ed4bfb6d3572
-generated: "2024-09-23T14:41:25.299168-07:00"
+digest: sha256:6df6b041f08a4cbf0c1c4b6100adb097531bcb721f2802b8fa37a2b3ae83f7cf
+generated: "2024-10-02T16:27:16.536402-04:00"

--- a/charts/stack/Chart.yaml
+++ b/charts/stack/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: stack
 description: Observe Kubernetes agent stack
 type: application
-version: 1.0.6
+version: 1.1.0
 dependencies:
   - name: logs
     version: 0.1.33
@@ -13,7 +13,7 @@ dependencies:
     repository: file://../metrics
     condition: metrics.enabled
   - name: events
-    version: 0.1.26
+    version: 0.2.0
     repository: file://../events
     condition: events.enabled
   - name: proxy

--- a/charts/stack/README.md
+++ b/charts/stack/README.md
@@ -1,6 +1,6 @@
 # stack
 
-![Version: 1.0.6](https://img.shields.io/badge/Version-1.0.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Observe Kubernetes agent stack
 
@@ -14,7 +14,7 @@ Observe Kubernetes agent stack
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../events | events | 0.1.26 |
+| file://../events | events | 0.2.0 |
 | file://../logs | logs | 0.1.33 |
 | file://../metrics | metrics | 0.3.25 |
 | file://../proxy | proxy | 0.1.8 |

--- a/charts/stack/ci/test-values.yaml
+++ b/charts/stack/ci/test-values.yaml
@@ -22,3 +22,10 @@ metrics:
           memory: 256Mi
         requests:
           memory: 256Mi
+
+events:
+  containerOverrides:
+    excludeTargets:
+      - apps/v1/replicasets
+    includeTargets:
+      - apps/v1/deployments


### PR DESCRIPTION
Adding option to override [kube-state-events](https://github.com/observeinc/kube-state-events/tree/main) container with [include-target](https://github.com/observeinc/kube-state-events/blob/6d6b1d1e1fa39f843db75e387b1d7126a68fb132/cmd/kube-state-events/main.go#L111) and [exclude-target](https://github.com/observeinc/kube-state-events/blob/6d6b1d1e1fa39f843db75e387b1d7126a68fb132/cmd/kube-state-events/main.go#L116).

Validated with following test values:
```
containerOverrides:
  excludeTargets:
    - events.k8s.io/v1/events
    - apps/v1/replicasets
  includeTargets:
    - apps/v1/deployments
```