### PR TITLE
feat: OB-37318 Add container ID attribute

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agent
 description: Chart to install K8s collection stack based on Observe Agent
 type: application
-version: 0.26.0
-appVersion: "1.3.0"
+version: 0.27.0
+appVersion: "1.1.0"
 dependencies:
   - name: opentelemetry-collector
     version: 0.101.1

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -1,6 +1,6 @@
 # agent
 
-![Version: 0.26.0](https://img.shields.io/badge/Version-0.26.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.0](https://img.shields.io/badge/AppVersion-1.3.0-informational?style=flat-square)
+![Version: 0.27.0](https://img.shields.io/badge/Version-0.27.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
 
 > [!CAUTION]
 > This chart is under active development and is not meant to be installed yet.

--- a/charts/agent/templates/_cluster-events-config.tpl
+++ b/charts/agent/templates/_cluster-events-config.tpl
@@ -77,6 +77,8 @@ processors:
 
 {{- include "config.processors.resource.observe_common" . | nindent 2 }}
 
+{{- include "config.processors.attributes.k8sattributes" . | nindent 2 }}
+
 {{- include "config.processors.attributes.observek8sattributes" . | nindent 2 }}
 
   # transform for k8s objects

--- a/charts/agent/templates/_cluster-metrics-config.tpl
+++ b/charts/agent/templates/_cluster-metrics-config.tpl
@@ -29,119 +29,117 @@ receivers:
 
   {{- if .Values.application.prometheusScrape.enabled }}
   prometheus/pod_metrics:
-      config:
-        scrape_configs:
-        - job_name: pod-metrics
-          scrape_interval: {{.Values.application.prometheusScrape.interval}}
-          honor_labels: true
-          kubernetes_sd_configs:
-          - role: pod
-          relabel_configs:
-          # this is defaulted to keep so we start with everything
+    config:
+      scrape_configs:
+      - job_name: pod-metrics
+        scrape_interval: {{.Values.application.prometheusScrape.interval}}
+        honor_labels: true
+        kubernetes_sd_configs:
+        - role: pod
+        relabel_configs:
+        # this is defaulted to keep so we start with everything
+        - action: keep
+
+        # Drop anything matching the configured namespace.
+        - action: 'drop'
+          source_labels: ['__meta_kubernetes_namespace']
+          regex: {{.Values.application.prometheusScrape.namespaceDropRegex}}
+
+        # Drop anything not matching the configured namespace.
+        - action: 'keep'
+          source_labels: ['__meta_kubernetes_namespace']
+          regex: {{.Values.application.prometheusScrape.namespaceKeepRegex}}
+
+        # Drop endpoints without one of: a port name suffixed with the configured regex, or an explicit prometheus port annotation.
+        - action: 'keep'
+          source_labels: ['__meta_kubernetes_pod_container_port_name', '__meta_kubernetes_pod_annotation_prometheus_io_port']
+          regex: '({{.Values.application.prometheusScrape.portKeepRegex}};|.*;\d+)'
+
+        # Drop pods with phase Succeeded or Failed.
+        - action: 'drop'
+          regex: 'Succeeded|Failed'
+          source_labels: ['__meta_kubernetes_pod_phase']
+
+        ################################################################
+        # Drop anything annotated with 'observeinc.com.scrape=false' or 'observeinc_com_scrape=false' .
+        - action: 'drop'
+          regex: 'false'
+          source_labels: ['__meta_kubernetes_pod_annotation_observeinc_com_scrape']
+
+        ################################################################
+        # Prometheus Configs
+        # Drop anything annotated with 'prometheus.io.scrape=false'.
+        - action: 'drop'
+          regex: 'false'
+          source_labels: ['__meta_kubernetes_pod_annotation_prometheus_io_scrape']
+
+        # Allow pods to override the scrape scheme with 'prometheus.io.scheme=https'.
+        - action: 'replace'
+          regex: '(https?)'
+          replacement: '$1'
+          source_labels: ['__meta_kubernetes_pod_annotation_prometheus_io_scheme']
+          target_label: '__scheme__'
+
+        # Allow service to override the scrape path with 'prometheus.io.path=/other_metrics_path'.
+        - action: 'replace'
+          regex: '(.+)'
+          replacement: '$1'
+          source_labels: ['__meta_kubernetes_pod_annotation_prometheus_io_path']
+          target_label: '__metrics_path__'
+
+        # Allow services to override the scrape port with 'prometheus.io.port=1234'.
+        - action: 'replace'
+          regex: '(.+?)(\:\d+)?;(\d+)'
+          replacement: '$1:$3'
+          source_labels: ['__address__', '__meta_kubernetes_pod_annotation_prometheus_io_port']
+          target_label: '__address__'
+
+
+        ################################################################
+
+        #podAnnotations: {
+        #  observeinc_com_scrape: 'true',
+        #  observeinc_com_path: '/metrics',
+        #  observeinc_com_port: '8080',
+        #}
+
+        # set metrics_path (default is /metrics) to the metrics path specified in "observeinc_com_path: <metric path>" annotation.
+        - source_labels: [__meta_kubernetes_pod_annotation_observeinc_com_path]
+          action: replace
+          target_label: __metrics_path__
+          regex: (.+)
+
+        # set the scrapping port to the port specified in "observeinc_com_port: <port>" annotation and set address accordingly.
+        - source_labels: [__address__, __meta_kubernetes_pod_annotation_observeinc_com_port]
+          action: replace
+          regex: ([^:]+)(?::\d+)?;(\d+)
+          replacement: '$1:$2'
+          target_label: __address__
+        ################################################################
+
+        # Maps all Kubernetes pod labels to Prometheus labels with the prefix removed (e.g., __meta_kubernetes_pod_label_app becomes app).
+        - action: labelmap
+          regex: __meta_kubernetes_pod_label_(.+)
+
+        # adds new label
+        - source_labels: [__meta_kubernetes_namespace]
+          action: replace
+          target_label: kubernetes_namespace
+
+        # adds new label
+        - source_labels: [__meta_kubernetes_pod_name]
+          action: replace
+          target_label: kubernetes_pod_name
+
+        metric_relabel_configs:
+          - action: drop
+            regex: {{.Values.application.prometheusScrape.metricDropRegex}}
+            source_labels:
+              - __name__
           - action: keep
-
-          # Drop anything matching the configured namespace.
-          - action: 'drop'
-            source_labels: ['__meta_kubernetes_namespace']
-            regex: {{.Values.application.prometheusScrape.namespaceDropRegex}}
-
-          # Drop anything not matching the configured namespace.
-          - action: 'keep'
-            source_labels: ['__meta_kubernetes_namespace']
-            regex: {{.Values.application.prometheusScrape.namespaceKeepRegex}}
-
-          # Drop endpoints without one of: a port name suffixed with the configured regex, or an explicit prometheus port annotation.
-          - action: 'keep'
-            source_labels: ['__meta_kubernetes_pod_container_port_name', '__meta_kubernetes_pod_annotation_prometheus_io_port']
-            regex: '({{.Values.application.prometheusScrape.portKeepRegex}};|.*;\d+)'
-
-          # Drop pods with phase Succeeded or Failed.
-          - action: 'drop'
-            regex: 'Succeeded|Failed'
-            source_labels: ['__meta_kubernetes_pod_phase']
-
-          ################################################################
-          # Drop anything annotated with 'observeinc.com.scrape=false' or 'observeinc_com_scrape=false' .
-          - action: 'drop'
-            regex: 'false'
-            source_labels: ['__meta_kubernetes_pod_annotation_observeinc_com_scrape']
-
-          ################################################################
-          # Prometheus Configs
-          # Drop anything annotated with 'prometheus.io.scrape=false'.
-          - action: 'drop'
-            regex: 'false'
-            source_labels: ['__meta_kubernetes_pod_annotation_prometheus_io_scrape']
-
-          # Allow pods to override the scrape scheme with 'prometheus.io.scheme=https'.
-          - action: 'replace'
-            regex: '(https?)'
-            replacement: '$1'
-            source_labels: ['__meta_kubernetes_pod_annotation_prometheus_io_scheme']
-            target_label: '__scheme__'
-
-          # Allow service to override the scrape path with 'prometheus.io.path=/other_metrics_path'.
-          - action: 'replace'
-            regex: '(.+)'
-            replacement: '$1'
-            source_labels: ['__meta_kubernetes_pod_annotation_prometheus_io_path']
-            target_label: '__metrics_path__'
-
-          # Allow services to override the scrape port with 'prometheus.io.port=1234'.
-          - action: 'replace'
-            regex: '(.+?)(\:\d+)?;(\d+)'
-            replacement: '$1:$3'
-            source_labels: ['__address__', '__meta_kubernetes_pod_annotation_prometheus_io_port']
-            target_label: '__address__'
-
-
-          ################################################################
-
-          #podAnnotations: {
-          #  observeinc_com_scrape: 'true',
-          #  observeinc_com_path: '/metrics',
-          #  observeinc_com_port: '8080',
-          #}
-
-          # set metrics_path (default is /metrics) to the metrics path specified in "observeinc_com_path: <metric path>" annotation.
-          - source_labels: [__meta_kubernetes_pod_annotation_observeinc_com_path]
-            action: replace
-            target_label: __metrics_path__
-            regex: (.+)
-
-          # set the scrapping port to the port specified in "observeinc_com_port: <port>" annotation and set address accordingly.
-          - source_labels: [__address__, __meta_kubernetes_pod_annotation_observeinc_com_port]
-            action: replace
-            regex: ([^:]+)(?::\d+)?;(\d+)
-            replacement: '$1:$2'
-            target_label: __address__
-          ################################################################
-
-          # Maps all Kubernetes pod labels to Prometheus labels with the prefix removed (e.g., __meta_kubernetes_pod_label_app becomes app).
-          - action: labelmap
-            regex: __meta_kubernetes_pod_label_(.+)
-
-          # adds new label
-          - source_labels: [__meta_kubernetes_namespace]
-            action: replace
-            target_label: kubernetes_namespace
-
-          # adds new label
-          - source_labels: [__meta_kubernetes_pod_name]
-            action: replace
-            target_label: kubernetes_pod_name
-
-          metric_relabel_configs:
-            - action: drop
-              regex: {{.Values.application.prometheusScrape.metricDropRegex}}
-              source_labels:
-                - __name__
-            - action: keep
-              regex: {{.Values.application.prometheusScrape.metricKeepRegex}}
-              source_labels:
-                - __name__
-
-
+            regex: {{.Values.application.prometheusScrape.metricKeepRegex}}
+            source_labels:
+              - __name__
   {{ end }}
 
 processors:

--- a/charts/agent/templates/_config-processors.tpl
+++ b/charts/agent/templates/_config-processors.tpl
@@ -29,6 +29,7 @@ k8sattributes:
     - k8s.node.name
     - k8s.node.uid
     - k8s.container.name
+    - container.id
   passthrough: false
   pod_association:
   - sources:

--- a/charts/agent/templates/_node-logs-metrics-config.tpl
+++ b/charts/agent/templates/_node-logs-metrics-config.tpl
@@ -115,6 +115,8 @@ receivers:
         enabled: true
       k8s.pod.uptime:
         enabled: true
+    extra_metadata_labels:
+      - container.id
   {{ end -}}
   {{- if .Values.node.containers.logs.enabled }}
   filelog:


### PR DESCRIPTION
Collect container id for both metrics and logs.

 - metrics: use kubeletstats receiver's "extra_metadata_labels"
 - logs: use resource processor to take the container ID from the log.file.path (attribute added by the filelog receiver)