### PR TITLE
feat: OB-37317 add config options to cluster metrics

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent
 description: Chart to install K8s collection stack based on Observe Agent
 type: application
-version: 0.20.3
+version: 0.21.0
 appVersion: "1.1.0"
 dependencies:
   - name: opentelemetry-collector

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -1,6 +1,6 @@
 # agent
 
-![Version: 0.20.3](https://img.shields.io/badge/Version-0.20.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
+![Version: 0.21.0](https://img.shields.io/badge/Version-0.21.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
 
 > [!CAUTION]
 > This chart is under active development and is not meant to be installed yet.
@@ -27,14 +27,14 @@ Chart to install K8s collection stack based on Observe Agent
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | agent.config.global.debug.verbosity | string | `"basic"` |  |
-| agent.config.global.processors.batch.send_batch_max_size | int | `100` |  |
-| agent.config.global.processors.batch.send_batch_size | int | `100` |  |
+| agent.config.global.processors.batch.send_batch_max_size | int | `4096` |  |
+| agent.config.global.processors.batch.send_batch_size | int | `4096` |  |
 | agent.config.global.service.telemetry.logging_encoding | string | `"console"` |  |
 | agent.config.global.service.telemetry.logging_level | string | `"WARN"` |  |
 | agent.config.global.service.telemetry.metrics_level | string | `"normal"` |  |
 | agent.selfMonitor.enabled | bool | `true` |  |
 | application.prometheusScrape.enabled | bool | `false` |  |
-| application.prometheusScrape.interval | string | `"10s"` |  |
+| application.prometheusScrape.interval | string | `"60s"` |  |
 | application.prometheusScrape.metricDropRegex | string | `".*bucket"` |  |
 | application.prometheusScrape.metricKeepRegex | string | `"(.*)"` |  |
 | application.prometheusScrape.namespaceDropRegex | string | `"(.*istio.*|.*ingress.*|kube-system)"` |  |
@@ -108,6 +108,7 @@ Chart to install K8s collection stack based on Observe Agent
 | cluster-events.resources | object | `{"requests":{"cpu":"250m","memory":"256Mi"}}` | --------------------------------------- # Same for each deployment/daemonset      # |
 | cluster-events.serviceAccount.create | bool | `false` |  |
 | cluster-events.serviceAccount.name | string | `"observe-agent-service-account"` |  |
+| cluster-events.tolerations | list | `[]` |  |
 | cluster-metrics.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key | string | `"observeinc.com/unschedulable"` |  |
 | cluster-metrics.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].operator | string | `"DoesNotExist"` |  |
 | cluster-metrics.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[1].key | string | `"kubernetes.io/os"` |  |
@@ -172,9 +173,11 @@ Chart to install K8s collection stack based on Observe Agent
 | cluster-metrics.resources | object | `{"requests":{"cpu":"250m","memory":"256Mi"}}` | --------------------------------------- # Same for each deployment/daemonset      # |
 | cluster-metrics.serviceAccount.create | bool | `false` |  |
 | cluster-metrics.serviceAccount.name | string | `"observe-agent-service-account"` |  |
+| cluster-metrics.tolerations | list | `[]` |  |
 | cluster.events.enabled | bool | `true` |  |
 | cluster.events.pullInterval | string | `"20m"` |  |
 | cluster.metrics.enabled | bool | `true` |  |
+| cluster.metrics.interval | string | `"60s"` |  |
 | cluster.name | string | `"observe-agent-monitored-cluster"` |  |
 | cluster.namespaceOverride.value | string | `"observe"` |  |
 | cluster.uidOverride.value | string | `""` |  |
@@ -242,6 +245,7 @@ Chart to install K8s collection stack based on Observe Agent
 | monitor.resources | object | `{"requests":{"cpu":"250m","memory":"256Mi"}}` | --------------------------------------- # Same for each deployment/daemonset      # |
 | monitor.serviceAccount.create | bool | `false` |  |
 | monitor.serviceAccount.name | string | `"observe-agent-service-account"` |  |
+| monitor.tolerations | list | `[]` |  |
 | node-logs-metrics.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key | string | `"observeinc.com/unschedulable"` |  |
 | node-logs-metrics.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].operator | string | `"DoesNotExist"` |  |
 | node-logs-metrics.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[1].key | string | `"kubernetes.io/os"` |  |
@@ -331,6 +335,7 @@ Chart to install K8s collection stack based on Observe Agent
 | node-logs-metrics.securityContext.runAsUser | int | `0` |  |
 | node-logs-metrics.serviceAccount.create | bool | `false` |  |
 | node-logs-metrics.serviceAccount.name | string | `"observe-agent-service-account"` |  |
+| node-logs-metrics.tolerations | list | `[]` |  |
 | node.containers.logs.enabled | bool | `true` |  |
 | node.containers.logs.exclude | string | `"[]"` |  |
 | node.containers.logs.include | string | `"[\"/var/log/pods/*/*/*.log\", \"/var/log/kube-apiserver-audit.log\"]"` |  |
@@ -342,8 +347,12 @@ Chart to install K8s collection stack based on Observe Agent
 | node.containers.logs.retryOnFailure.maxInterval | string | `"30s"` |  |
 | node.containers.logs.startAt | string | `"end"` |  |
 | node.containers.metrics.enabled | bool | `true` |  |
+| node.containers.metrics.interval | string | `"60s"` |  |
 | node.enabled | bool | `true` |  |
 | node.metrics.enabled | bool | `true` |  |
+| node.metrics.fileSystem.excludeMountPoints | string | `"[\"/dev/*\",\"/proc/*\",\"/sys/*\",\"/run/k3s/containerd/*\",\"/var/lib/docker/*\",\"/var/lib/kubelet/*\",\"/snap/*\"]"` |  |
+| node.metrics.fileSystem.rootPath | string | `"/hostfs"` |  |
+| node.metrics.interval | string | `"60s"` |  |
 | observe.collectionEndpoint.value | string | `""` |  |
 | observe.entityToken.create | bool | `false` |  |
 | observe.entityToken.use | bool | `false` |  |

--- a/charts/agent/templates/_cluster-metrics-config.tpl
+++ b/charts/agent/templates/_cluster-metrics-config.tpl
@@ -10,6 +10,8 @@ exporters:
 receivers:
   # https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/k8sclusterreceiver/documentation.md
   k8s_cluster:
+    collection_interval: {{.Values.cluster.metrics.interval}}
+    metadata_collection_interval: 5m
     auth_type: serviceAccount
     node_conditions_to_report:
     - Ready
@@ -20,6 +22,7 @@ receivers:
     - memory
     - storage
     - ephemeral-storage
+    # defaults and optional - https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/k8sclusterreceiver/documentation.md
     metrics:
       k8s.node.condition:
         enabled: true

--- a/charts/agent/templates/_config-exporters.tpl
+++ b/charts/agent/templates/_config-exporters.tpl
@@ -19,6 +19,8 @@ prometheusremotewrite:
         authorization: "${env:OBSERVE_TOKEN}"
     resource_to_telemetry_conversion:
         enabled: true # Convert resource attributes to metric labels
+    send_metadata: true
+
 {{- end -}}
 
 {{- define "config.exporters.debug" -}}

--- a/charts/agent/templates/_node-logs-metrics-config.tpl
+++ b/charts/agent/templates/_node-logs-metrics-config.tpl
@@ -15,9 +15,10 @@ exporters:
 {{ end }}
 receivers:
   {{- if .Values.node.metrics.enabled }}
+  # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver
   hostmetrics:
-    collection_interval: 10s
-    root_path: /hostfs
+    collection_interval: {{.Values.node.metrics.interval}}
+    root_path: {{.Values.node.metrics.fileSystem.rootPath}}
     scrapers:
       cpu: null
       disk: null
@@ -50,21 +51,14 @@ receivers:
           match_type: strict
         exclude_mount_points:
           match_type: regexp
-          mount_points:
-          - /dev/*
-          - /proc/*
-          - /sys/*
-          - /run/k3s/containerd/*
-          - /var/lib/docker/*
-          - /var/lib/kubelet/*
-          - /snap/*
+          mount_points: {{.Values.node.metrics.fileSystem.excludeMountPoints}}
       load: null
       memory: null
       network: null
   {{ end -}}
   {{- if .Values.node.containers.metrics.enabled }}
   kubeletstats:
-    collection_interval: 10s
+    collection_interval: {{.Values.node.containers.metrics.interval}}
     auth_type: 'serviceAccount'
     endpoint: '${env:K8S_NODE_NAME}:10250'
     node: '${env:K8S_NODE_NAME}'

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -1,10 +1,13 @@
+# This section is for configuring agent to send data to Observe endpoints
+# we recommend using --set token.value=YOUR_TOKEN for values you want to keep secret
+# supplying a token creates a secret on your cluster
 observe:
   # If create = false it is assumed that a secret named agent-credentials with key: OBSERVE_TOKEN already exists
   token:
     create: true
     value: ""
-  # ex -  https://12345678.collect.observeinc.com
   collectionEndpoint:
+    # ex -  https://12345678.collect.observeinc.com
     value: ""
   # this is temporary and will be removed
   entityToken:
@@ -15,42 +18,36 @@ observe:
     use: false
 
 cluster:
+  # name given to your cluster
   name: observe-agent-monitored-cluster
+  # configure the collection of resources and events
   events:
+    # how often to pull resources from cluster
     pullInterval: 20m
     enabled: true
+  # cluster-level metrics and entity events (as metrics) from the Kubernetes API server. It uses the K8s API to listen for updates.
   metrics:
     enabled: true
-
+    interval: 60s
+  # namespace to use/create
   namespaceOverride:
-    # ! This needs to have same value as namespaceOverride in deployments and daemonsets below
+    # !!! IMPORTANT !!! This needs to have same value as namespaceOverride in deployments and daemonsets below
     value: observe
+  # typically the clusterUid is set to kube-system namespace uid - if you need a different value use this override
   uidOverride:
     value: ""
 
-application:
-  # use this option to scrape prometheus metrics from pods
-  # cluster.metrics.enabled must be set to true
-  prometheusScrape:
-    enabled: false
-    interval: 10s
-    # namespaces to exclude from scraping
-    # drop is processed first so all namespaces that match regex will be dropped
-    namespaceDropRegex: (.*istio.*|.*ingress.*|kube-system)
-    # namespaces to explicity include for scraping - can use or (ns1|ns2)
-    # keep is processed after drop so only remaining namespaces that match regex will be kept
-    namespaceKeepRegex: (.*)
-    # port names to scrape from - can use or .*metrics|otherportname
-    portKeepRegex: .*metrics
-    # metrics to drop
-    metricDropRegex: .*bucket
-    # metrics to keep
-    metricKeepRegex: (.*)
-
 node:
+  # enables agent for collection of node logs and metrics
+  # what nodes metrics and logs are collected from is configured with affinity in node-logs-metrics section below
   enabled: true
+  # collects host level metrics from node
   metrics:
     enabled: true
+    interval: 60s
+    fileSystem:
+      rootPath: /hostfs
+      excludeMountPoints: '["/dev/*","/proc/*","/sys/*","/run/k3s/containerd/*","/var/lib/docker/*","/var/lib/kubelet/*","/snap/*"]'
   containers:
     logs:
       enabled: true
@@ -73,17 +70,39 @@ node:
       lookbackPeriod: 24h
       # At startup, where to start reading logs from the file. Options are beginning or end.
       startAt: end
-
+    # pulls node, pod, and container metrics from the API server on a kubelet and sends it down the metric pipeline for further processing.
     metrics:
       enabled: true
+      interval: 60s
+
+application:
+  # use this option to scrape prometheus metrics from pods
+  # !!! IMPORTANT !!! cluster.metrics.enabled must be set to true
+  # To enable/disable auto discovery of metrics - besides option below - you can annotate your pods
+  # See helm-charts/examples/agent/pod_metrics for more information
+  prometheusScrape:
+    enabled: false
+    interval: 60s
+    # namespaces to exclude from scraping
+    # drop is processed first so all namespaces that match regex will be dropped
+    namespaceDropRegex: (.*istio.*|.*ingress.*|kube-system)
+    # namespaces to explicity include for scraping - can use or (ns1|ns2)
+    # keep is processed after drop so only remaining namespaces that match regex will be kept
+    namespaceKeepRegex: (.*)
+    # port names to scrape from - can use or .*metrics|otherportname
+    portKeepRegex: .*metrics
+    # metrics to drop
+    metricDropRegex: .*bucket
+    # metrics to keep
+    metricKeepRegex: (.*)
 
 agent:
   config:
     global:
       processors:
         batch:
-          send_batch_size: 100
-          send_batch_max_size: 100
+          send_batch_size: 4096
+          send_batch_max_size: 4096
       service:
         telemetry:
           metrics_level: normal
@@ -103,6 +122,7 @@ cluster-events:
   # ----------------------------------------- #
   # Different for each deployment/daemonset #
   nameOverride: "cluster-events"
+  # !!! IMPORTANT !!! This needs to have same value as namespaceOverride in cluster above
   namespaceOverride: "observe"
 
   configMap:
@@ -176,6 +196,8 @@ cluster-events:
                 operator: NotIn
                 values: [windows]
 
+  tolerations: []
+
   ports:
     metrics:
       # The metrics port is disabled by default. However you need to enable the port
@@ -239,6 +261,7 @@ cluster-metrics:
   # ----------------------------------------- #
   # Different for each deployment/daemonset #
   nameOverride: "cluster-metrics"
+  # !!! IMPORTANT !!! This needs to have same value as namespaceOverride in cluster above
   namespaceOverride: "observe"
 
   configMap:
@@ -311,6 +334,8 @@ cluster-metrics:
                 operator: NotIn
                 values: [windows]
 
+  tolerations: []
+
   ports:
     metrics:
       # The metrics port is disabled by default. However you need to enable the port
@@ -367,6 +392,7 @@ node-logs-metrics:
   # ----------------------------------------- #
   # Different for each deployment/daemonset #
   nameOverride: "node-logs-metrics"
+  # !!! IMPORTANT !!! This needs to have same value as namespaceOverride in cluster above
   namespaceOverride: "observe"
 
   configMap:
@@ -438,6 +464,8 @@ node-logs-metrics:
               - key: kubernetes.io/os
                 operator: NotIn
                 values: [windows]
+
+  tolerations: []
 
   ports:
     metrics:
@@ -528,6 +556,7 @@ monitor:
   # ----------------------------------------- #
   # Different for each deployment/daemonset #
   nameOverride: "monitor"
+  # !!! IMPORTANT !!! This needs to have same value as namespaceOverride in cluster above
   namespaceOverride: "observe"
 
   configMap:
@@ -599,6 +628,8 @@ monitor:
               - key: kubernetes.io/os
                 operator: NotIn
                 values: [windows]
+
+  tolerations: []
 
   ports:
     metrics:

--- a/examples/agent/logs/node-logs-values.yaml
+++ b/examples/agent/logs/node-logs-values.yaml
@@ -17,7 +17,8 @@ node:
       # log lines above this size will be truncated
       maxLogSize: 512kb
       # If true, the receiver will pause reading a file and attempt to resend the current batch of logs if it encounters an error from downstream components.
-      retryOnFailure: true
+      retryOnFailure:
+        enabled: true
       # A list of file glob patterns that match the file paths to be read.
       include: '["/var/log/pods/*/*/*.log", "/var/log/kube-apiserver-audit.log"]'
       # A list of file glob patterns to exclude from reading. This is applied against the paths matched by include.


### PR DESCRIPTION
- Default metric collection interval to 60s for all metrics collection with interval option in values file and related configs
- Added rootPath and excludeMountPoints config for host metrics
- Add comments for clarity to various section of values and template files
- Add sending metadata and write ahead log (wal) config
- Add default empty tolerations option for pods