### PR TITLE
feat: OB-36954 Add cronJobName and cronJobUid facets to Job events

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent
 description: Chart to install K8s collection stack based on Observe Agent
 type: application
-version: 0.20.3
+version: 0.21.0
 appVersion: "1.1.0"
 dependencies:
   - name: opentelemetry-collector

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -1,6 +1,6 @@
 # agent
 
-![Version: 0.20.3](https://img.shields.io/badge/Version-0.20.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
+![Version: 0.21.0](https://img.shields.io/badge/Version-0.21.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
 
 > [!CAUTION]
 > This chart is under active development and is not meant to be installed yet.

--- a/charts/agent/templates/_cluster-events-config.tpl
+++ b/charts/agent/templates/_cluster-events-config.tpl
@@ -215,6 +215,8 @@ processors:
         statements:
           - set(attributes["observe_transform"]["identifiers"]["jobName"], body["metadata"]["name"])
           - set(attributes["observe_transform"]["identifiers"]["jobUid"], body["metadata"]["uid"])
+          - set(attributes["observe_transform"]["facets"]["cronJobName"], body["metadata"]["ownerReferences"][0]["name"]) where body["metadata"]["ownerReferences"][0]["kind"] == "CronJob"
+          - set(attributes["observe_transform"]["facets"]["cronJobUid"], body["metadata"]["ownerReferences"][0]["uid"]) where body["metadata"]["ownerReferences"][0]["kind"] == "CronJob"
           # spec
           - set(attributes["observe_transform"]["facets"]["completions"], body["spec"]["completions"])
           - set(attributes["observe_transform"]["facets"]["parallelism"], body["spec"]["parallelism"])


### PR DESCRIPTION
Such facets are needed to identify the CronJob that owns a Job (when the Job is not a standalone Job).