### PR TITLE
fix: Save ourselves an if condition in helm

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent
 description: Chart to install K8s collection stack based on Observe Agent
 type: application
-version: 0.23.0
+version: 0.23.1
 appVersion: "1.1.0"
 dependencies:
   - name: opentelemetry-collector

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -1,6 +1,6 @@
 # agent
 
-![Version: 0.23.0](https://img.shields.io/badge/Version-0.23.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
+![Version: 0.23.1](https://img.shields.io/badge/Version-0.23.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
 
 > [!CAUTION]
 > This chart is under active development and is not meant to be installed yet.

--- a/charts/agent/templates/_cluster-events-config.tpl
+++ b/charts/agent/templates/_cluster-events-config.tpl
@@ -180,7 +180,7 @@ processors:
           - set(attributes["observe_transform"]["facets"]["selector"], body["spec"]["selector"]["matchLabels"])
           - set(attributes["observe_transform"]["facets"]["desiredReplicas"], body["spec"]["replicas"])
           # custom
-          - set(attributes["observe_transform"]["facets"]["status"], "Healthy") where attributes["observe_transform"]["facets"]["readyReplicas"] == attributes["observe_transform"]["facets"]["desiredReplicas"]
+          - set(attributes["observe_transform"]["facets"]["status"], "Healthy")
           - set(attributes["observe_transform"]["facets"]["status"], "Unhealthy") where attributes["observe_transform"]["facets"]["readyReplicas"] != attributes["observe_transform"]["facets"]["desiredReplicas"]
       # ReplicaSet
       - context: log
@@ -196,7 +196,7 @@ processors:
           - set(attributes["observe_transform"]["facets"]["availableReplicas"], body["status"]["availableReplicas"])
           - set(attributes["observe_transform"]["facets"]["readyReplicas"], body["status"]["readyReplicas"])
           - set(attributes["observe_transform"]["facets"]["readyReplicas"], 0) where attributes["observe_transform"]["facets"]["readyReplicas"] == nil
-          - set(attributes["observe_transform"]["facets"]["status"], "Healthy") where attributes["observe_transform"]["facets"]["readyReplicas"] == attributes["observe_transform"]["facets"]["desiredReplicas"]
+          - set(attributes["observe_transform"]["facets"]["status"], "Healthy")
           - set(attributes["observe_transform"]["facets"]["status"], "Unhealthy") where attributes["observe_transform"]["facets"]["readyReplicas"] != attributes["observe_transform"]["facets"]["desiredReplicas"]
       # Event
       - context: log
@@ -263,7 +263,7 @@ processors:
           - set(attributes["observe_transform"]["facets"]["numberAvailable"], body["status"]["numberAvailable"])
           - set(attributes["observe_transform"]["facets"]["numberUnavailable"], body["status"]["numberUnavailable"])
           - set(attributes["observe_transform"]["facets"]["numberMisscheduled"], body["status"]["numberMisscheduled"])
-          - set(attributes["observe_transform"]["facets"]["status"], "Healthy") where attributes["observe_transform"]["facets"]["numberReady"] == attributes["observe_transform"]["facets"]["desiredNumberScheduled"]
+          - set(attributes["observe_transform"]["facets"]["status"], "Healthy")
           - set(attributes["observe_transform"]["facets"]["status"], "Unhealthy") where attributes["observe_transform"]["facets"]["numberReady"] != attributes["observe_transform"]["facets"]["desiredNumberScheduled"]
       # StatefulSet
       - context: log
@@ -281,7 +281,7 @@ processors:
           # status
           - set(attributes["observe_transform"]["facets"]["currentReplicas"], body["status"]["currentReplicas"])
           - set(attributes["observe_transform"]["facets"]["readyReplicas"], body["status"]["readyReplicas"])
-          - set(attributes["observe_transform"]["facets"]["status"], "Healthy") where attributes["observe_transform"]["facets"]["readyReplicas"] == attributes["observe_transform"]["facets"]["desiredReplicas"]
+          - set(attributes["observe_transform"]["facets"]["status"], "Healthy")
           - set(attributes["observe_transform"]["facets"]["status"], "Unhealthy") where attributes["observe_transform"]["facets"]["readyReplicas"] != attributes["observe_transform"]["facets"]["desiredReplicas"]
       - context: log
         conditions:


### PR DESCRIPTION
We don't need to use the same "where" clause twice with opposite conditions. Instead, set the facet to "Healthy" and check if we need to change it to "Unhealthy"