### PR TITLE
fix: Move k8s.cluster.name to resource_attributes

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent
 description: Chart to install K8s collection stack based on Observe Agent
 type: application
-version: 0.25.0
+version: 0.25.1
 appVersion: "1.3.0"
 dependencies:
   - name: opentelemetry-collector

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -1,6 +1,6 @@
 # agent
 
-![Version: 0.25.0](https://img.shields.io/badge/Version-0.25.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.0](https://img.shields.io/badge/AppVersion-1.3.0-informational?style=flat-square)
+![Version: 0.25.1](https://img.shields.io/badge/Version-0.25.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.0](https://img.shields.io/badge/AppVersion-1.3.0-informational?style=flat-square)
 
 > [!CAUTION]
 > This chart is under active development and is not meant to be installed yet.

--- a/charts/agent/templates/_cluster-events-config.tpl
+++ b/charts/agent/templates/_cluster-events-config.tpl
@@ -75,7 +75,7 @@ processors:
 
 {{- include "config.processors.batch" . | nindent 2 }}
 
-{{- include "config.processors.attributes.observe_common" . | nindent 2 }}
+{{- include "config.processors.resource.observe_common" . | nindent 2 }}
 
 {{- include "config.processors.attributes.observek8sattributes" . | nindent 2 }}
 
@@ -99,10 +99,8 @@ processors:
           - set(attributes["observe_transform"]["control"]["isDelete"], false) where attributes["observe_transform"]["control"]["isDelete"] == nil
           - set(attributes["observe_transform"]["control"]["version"], body["metadata"]["resourceVersion"])
           # identifiers
-          - set(attributes["observe_transform"]["identifiers"]["clusterName"], attributes["k8s.cluster.name"])
-          - set(attributes["observe_transform"]["identifiers"]["clusterUid"], attributes["k8s.cluster.uid"])
-          - set(resource.attributes["clusterName"], attributes["k8s.cluster.name"])
-          - set(resource.attributes["clusterUid"], attributes["k8s.cluster.uid"])
+          - set(attributes["observe_transform"]["identifiers"]["clusterName"], resource.attributes["k8s.cluster.name"])
+          - set(attributes["observe_transform"]["identifiers"]["clusterUid"], resource.attributes["k8s.cluster.uid"])
           - set(attributes["observe_transform"]["identifiers"]["kind"], body["kind"])
           - set(attributes["observe_transform"]["identifiers"]["name"], body["metadata"]["name"])
           - set(attributes["observe_transform"]["identifiers"]["namespaceName"], body["metadata"]["namespace"])
@@ -415,10 +413,8 @@ processors:
           - set(attributes["observe_transform"]["control"]["isDelete"], false) where attributes["observe_transform"]["control"]["isDelete"] == nil
           - set(attributes["observe_transform"]["control"]["version"], body["metadata"]["resourceVersion"])
           # identifiers
-          - set(attributes["observe_transform"]["identifiers"]["clusterName"], attributes["k8s.cluster.name"])
-          - set(attributes["observe_transform"]["identifiers"]["clusterUid"], attributes["k8s.cluster.uid"])
-          - set(resource.attributes["clusterName"], attributes["k8s.cluster.name"])
-          - set(resource.attributes["clusterUid"], attributes["k8s.cluster.uid"])
+          - set(attributes["observe_transform"]["identifiers"]["clusterName"], resource.attributes["k8s.cluster.name"])
+          - set(attributes["observe_transform"]["identifiers"]["clusterUid"], resource.attributes["k8s.cluster.uid"])
           - set(attributes["observe_transform"]["identifiers"]["uid"], attributes["k8s.cluster.uid"])
           - set(attributes["observe_transform"]["identifiers"]["kind"], "Cluster")
           - set(attributes["observe_transform"]["identifiers"]["name"], attributes["k8s.cluster.name"])
@@ -434,20 +430,20 @@ service:
   pipelines:
       logs/objects:
         receivers: [k8sobjects/objects]
-        processors: [memory_limiter, batch, attributes/observe_common, transform/object, observek8sattributes]
+        processors: [memory_limiter, batch, resource/observe_common, transform/object, observek8sattributes]
         exporters: [otlphttp/observe/base, debug/override]
       logs/cluster:
         receivers: [k8sobjects/cluster]
-        processors: [memory_limiter, batch, attributes/observe_common, filter/cluster, transform/cluster]
+        processors: [memory_limiter, batch, resource/observe_common, filter/cluster, transform/cluster]
         exporters: [otlphttp/observe/base, debug/override]
       {{ if .Values.observe.entityToken.use  -}}
       logs/entity:
         receivers: [k8sobjects/objects]
-        processors: [memory_limiter, batch, attributes/observe_common, transform/object, observek8sattributes]
+        processors: [memory_limiter, batch, resource/observe_common, transform/object, observek8sattributes]
         exporters: [otlphttp/observe/entity, debug/override]
       logs/cluster/entity:
         receivers: [k8sobjects/cluster]
-        processors: [memory_limiter, batch, attributes/observe_common, filter/cluster, transform/cluster]
+        processors: [memory_limiter, batch, resource/observe_common, filter/cluster, transform/cluster]
         exporters: [otlphttp/observe/entity, debug/override]
       {{- end }}
 

--- a/charts/agent/templates/_cluster-metrics-config.tpl
+++ b/charts/agent/templates/_cluster-metrics-config.tpl
@@ -151,7 +151,7 @@ processors:
 
 {{- include "config.processors.attributes.k8sattributes" . | nindent 2 }}
 
-{{- include "config.processors.attributes.observe_common" . | nindent 2 }}
+{{- include "config.processors.resource.observe_common" . | nindent 2 }}
 
   # attributes to append to objects
   attributes/debug_source_cluster_metrics:
@@ -170,12 +170,12 @@ service:
   pipelines:
       metrics:
         receivers: [k8s_cluster]
-        processors: [memory_limiter, k8sattributes, batch, attributes/observe_common, attributes/debug_source_cluster_metrics]
+        processors: [memory_limiter, k8sattributes, batch, resource/observe_common, attributes/debug_source_cluster_metrics]
         exporters: [prometheusremotewrite, debug/override]
       {{- if .Values.application.prometheusScrape.enabled }}
       metrics/pod_metrics:
         receivers: [prometheus/pod_metrics]
-        processors: [memory_limiter, k8sattributes, batch, attributes/observe_common, attributes/debug_source_pod_metrics]
+        processors: [memory_limiter, k8sattributes, batch, resource/observe_common, attributes/debug_source_pod_metrics]
         exporters: [prometheusremotewrite, debug/override]
       {{ end -}}
 {{- include "config.service.telemetry" . | nindent 2 }}

--- a/charts/agent/templates/_config-processors.tpl
+++ b/charts/agent/templates/_config-processors.tpl
@@ -28,6 +28,7 @@ k8sattributes:
     - k8s.cluster.uid
     - k8s.node.name
     - k8s.node.uid
+    - k8s.container.name
   passthrough: false
   pod_association:
   - sources:
@@ -35,14 +36,17 @@ k8sattributes:
       name: k8s.pod.ip
   - sources:
     - from: resource_attribute
+      name: k8s.container.restart_count
+  - sources:
+    - from: resource_attribute
       name: k8s.pod.uid
   - sources:
     - from: connection
 {{- end -}}
 
-{{- define "config.processors.attributes.observe_common" -}}
-attributes/observe_common:
-  actions:
+{{- define "config.processors.resource.observe_common" -}}
+resource/observe_common:
+  attributes:
     - key: k8s.cluster.name
       action: insert
       value: ${env:OBSERVE_CLUSTER_NAME}

--- a/charts/agent/templates/_monitor-config.tpl
+++ b/charts/agent/templates/_monitor-config.tpl
@@ -58,7 +58,7 @@ processors:
 
 {{- include "config.processors.attributes.k8sattributes" . | nindent 2 }}
 
-{{- include "config.processors.attributes.observe_common" . | nindent 2 }}
+{{- include "config.processors.resource.observe_common" . | nindent 2 }}
 
   # attributes to append to objects
   attributes/debug_source_agent_monitor:
@@ -72,7 +72,7 @@ service:
   pipelines:
       metrics:
         receivers: [prometheus/collector]
-        processors: [memory_limiter, k8sattributes, batch, attributes/observe_common, attributes/debug_source_agent_monitor]
+        processors: [memory_limiter, k8sattributes, batch, resource/observe_common, attributes/debug_source_agent_monitor]
         exporters: [prometheusremotewrite]
 {{- include "config.service.telemetry" . | nindent 2 }}
 

--- a/charts/agent/templates/_node-logs-metrics-config.tpl
+++ b/charts/agent/templates/_node-logs-metrics-config.tpl
@@ -144,7 +144,7 @@ processors:
 
 {{- include "config.processors.attributes.k8sattributes" . | nindent 2 }}
 
-{{- include "config.processors.attributes.observe_common" . | nindent 2 }}
+{{- include "config.processors.resource.observe_common" . | nindent 2 }}
   # attributes to append to objects
   attributes/debug_source_pod_logs:
     actions:
@@ -168,19 +168,19 @@ service:
       {{- if .Values.node.containers.logs.enabled }}
       logs:
         receivers: [filelog]
-        processors: [memory_limiter, k8sattributes, batch, resourcedetection/cloud, attributes/observe_common, attributes/debug_source_pod_logs]
+        processors: [memory_limiter, k8sattributes, batch, resourcedetection/cloud, resource/observe_common, attributes/debug_source_pod_logs]
         exporters: [otlphttp/observe/base, debug/override]
       {{- end -}}
       {{- if .Values.node.metrics.enabled }}
       metrics/hostmetrics:
         receivers: [hostmetrics]
-        processors: [memory_limiter, k8sattributes, batch, resourcedetection/cloud, attributes/observe_common, attributes/debug_source_hostmetrics]
+        processors: [memory_limiter, k8sattributes, batch, resourcedetection/cloud, resource/observe_common, attributes/debug_source_hostmetrics]
         exporters: [prometheusremotewrite, debug/override]
       {{- end -}}
       {{- if .Values.node.containers.metrics.enabled }}
       metrics/kubeletstats:
         receivers: [kubeletstats]
-        processors: [memory_limiter, k8sattributes, batch, resourcedetection/cloud, attributes/observe_common, attributes/debug_source_kubletstats_metrics]
+        processors: [memory_limiter, k8sattributes, batch, resourcedetection/cloud, resource/observe_common, attributes/debug_source_kubletstats_metrics]
         exporters: [prometheusremotewrite, debug/override]
       {{- end -}}
 {{- include "config.service.telemetry" . | nindent 2 }}


### PR DESCRIPTION
Move observe_common attributes (k8s.cluster.name, k8s.cluster.uid) from attributes to resource_attributes for otellogs.