### PR TITLE
refactor: Remove k8sattributes from k8s objects agent config

### DIFF
--- a/charts/agent/templates/_cluster-events-config.tpl
+++ b/charts/agent/templates/_cluster-events-config.tpl
@@ -77,8 +77,6 @@ processors:
 
 {{- include "config.processors.resource.observe_common" . | nindent 2 }}
 
-{{- include "config.processors.attributes.k8sattributes" . | nindent 2 }}
-
 {{- include "config.processors.attributes.observek8sattributes" . | nindent 2 }}
 
   # transform for k8s objects


### PR DESCRIPTION
Remove useless k8sattributes processor that was included by mistake