### PR TITLE
fix: Swap custom and transform processors in pipeline

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent
 description: Chart to install K8s collection stack based on Observe Agent
 type: application
-version: 0.30.3
+version: 0.30.4
 appVersion: "1.1.0"
 dependencies:
   - name: opentelemetry-collector

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -1,6 +1,6 @@
 # agent
 
-![Version: 0.30.3](https://img.shields.io/badge/Version-0.30.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
+![Version: 0.30.4](https://img.shields.io/badge/Version-0.30.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
 
 > [!CAUTION]
 > This chart is under active development and is not meant to be installed yet.

--- a/charts/agent/templates/_cluster-events-config.tpl
+++ b/charts/agent/templates/_cluster-events-config.tpl
@@ -429,7 +429,7 @@ service:
   pipelines:
       logs/objects:
         receivers: [k8sobjects/objects]
-        processors: [memory_limiter, batch, resource/observe_common, transform/object, observek8sattributes]
+        processors: [memory_limiter, batch, resource/observe_common, observek8sattributes, transform/object]
         exporters: [otlphttp/observe/entity, debug/override]
       logs/cluster:
         receivers: [k8sobjects/cluster]

--- a/charts/agent/templates/_config-processors.tpl
+++ b/charts/agent/templates/_config-processors.tpl
@@ -82,7 +82,8 @@ memory_limiter:
   spike_limit_percentage: 25
 {{- end -}}
 
+# This processor might edit the log body in-place, which might affect the output of transform/object.
+# Therefore, this processor must always be placed before transform/object in the pipeline.
 {{- define "config.processors.attributes.observek8sattributes" -}}
-# needs to come after transform/watch_objects in pipelines
 observek8sattributes:
 {{- end -}}


### PR DESCRIPTION
The reason is that the custom processor might edit the log body in-place and the transform processor will copy parts of the body over to the facets. Since the transform processor is more flexible, we want to edit things first and eventually add them as facets once they are modified.

Example: secrets obfuscation. We want to redact the secrets' values that can show up in the annotations. The transform processor blindly copies the annotations to facets. So we don't want the secrets to show up in the facets un-redacted.