### PR TITLE
feat: Add key for fetching ingress class

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent
 description: Chart to install K8s collection stack based on Observe Agent
 type: application
-version: 0.29.0
+version: 0.30.0
 appVersion: "1.1.0"
 dependencies:
   - name: opentelemetry-collector

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -1,6 +1,6 @@
 # agent
 
-![Version: 0.29.0](https://img.shields.io/badge/Version-0.29.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
+![Version: 0.30.0](https://img.shields.io/badge/Version-0.30.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
 
 > [!CAUTION]
 > This chart is under active development and is not meant to be installed yet.

--- a/charts/agent/templates/_cluster-events-config.tpl
+++ b/charts/agent/templates/_cluster-events-config.tpl
@@ -350,6 +350,7 @@ processors:
           - set(attributes["observe_transform"]["identifiers"]["ingressUid"], body["metadata"]["uid"])
           # spec
           - set(attributes["observe_transform"]["facets"]["class"], body["spec"]["ingressClassName"])
+          - set(attributes["observe_transform"]["facets"]["class"], body["metadata"]["annotations"]["kubernetes.io/ingress.class"]) where attributes["observe_transform"]["facets"]["class"] == nil
       - context: log
         conditions:
           - body["kind"] == "RoleBinding"


### PR DESCRIPTION
Try fetching ingress class from the deprecated annotation "kubernetes.io/ingress.class", which might still contain the ingress class for outdated Ingress manifests.