### PR TITLE
fix: Remove problematic k8sattributes config

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent
 description: Chart to install K8s collection stack based on Observe Agent
 type: application
-version: 0.30.4
+version: 0.30.5
 appVersion: "1.1.0"
 dependencies:
   - name: opentelemetry-collector

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -1,6 +1,6 @@
 # agent
 
-![Version: 0.30.4](https://img.shields.io/badge/Version-0.30.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
+![Version: 0.30.5](https://img.shields.io/badge/Version-0.30.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
 
 > [!CAUTION]
 > This chart is under active development and is not meant to be installed yet.

--- a/charts/agent/templates/_config-processors.tpl
+++ b/charts/agent/templates/_config-processors.tpl
@@ -35,9 +35,9 @@ k8sattributes:
   - sources:
     - from: resource_attribute
       name: k8s.pod.ip
-  - sources:
-    - from: resource_attribute
-      name: k8s.container.restart_count
+  # - sources:
+  #   - from: resource_attribute
+  #     name: k8s.container.restart_count
   - sources:
     - from: resource_attribute
       name: k8s.pod.uid


### PR DESCRIPTION
We don't know how or why, but this bit of config made the associations worse, removing associations on deployments, replicasets and other stuff.