### PR TITLE
feat: Populate metric unit of cpu metrics

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent
 description: Chart to install K8s collection stack based on Observe Agent
 type: application
-version: 0.30.6
+version: 0.31.0
 appVersion: "1.1.0"
 dependencies:
   - name: opentelemetry-collector

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -1,6 +1,6 @@
 # agent
 
-![Version: 0.30.6](https://img.shields.io/badge/Version-0.30.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
+![Version: 0.31.0](https://img.shields.io/badge/Version-0.31.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
 
 > [!CAUTION]
 > This chart is under active development and is not meant to be installed yet.

--- a/charts/agent/templates/_cluster-metrics-config.tpl
+++ b/charts/agent/templates/_cluster-metrics-config.tpl
@@ -151,6 +151,8 @@ processors:
 
 {{- include "config.processors.resource.observe_common" . | nindent 2 }}
 
+{{- include "config.processors.transform.metrics" . | nindent 2 }}
+
   # attributes to append to objects
   attributes/debug_source_cluster_metrics:
     actions:
@@ -163,19 +165,20 @@ processors:
         action: insert
         value: pod_metrics
 
+
 service:
   extensions: [health_check]
   pipelines:
       metrics:
         receivers: [k8s_cluster]
-        processors: [memory_limiter, k8sattributes, batch, resource/observe_common, attributes/debug_source_cluster_metrics]
+        processors: [memory_limiter, k8sattributes, batch, resource/observe_common, attributes/debug_source_cluster_metrics, transform/metrics]
         exporters: [prometheusremotewrite, debug/override]
       {{- if .Values.application.prometheusScrape.enabled }}
       metrics/pod_metrics:
         receivers: [prometheus/pod_metrics]
-        processors: [memory_limiter, k8sattributes, batch, resource/observe_common, attributes/debug_source_pod_metrics]
+        processors: [memory_limiter, k8sattributes, batch, resource/observe_common, attributes/debug_source_pod_metrics, transform/metrics]
         exporters: [prometheusremotewrite, debug/override]
       {{ end -}}
 {{- include "config.service.telemetry" . | nindent 2 }}
 
- {{- end }}
+{{- end }}

--- a/charts/agent/templates/_config-processors.tpl
+++ b/charts/agent/templates/_config-processors.tpl
@@ -87,3 +87,13 @@ memory_limiter:
 {{- define "config.processors.attributes.observek8sattributes" -}}
 observek8sattributes:
 {{- end -}}
+
+{{- define "config.processors.transform.metrics" -}}
+transform/metrics:
+  metric_statements:
+    - context: metric
+      statements:
+        - set(unit, "test")
+        # - set(unit, "cores") where unit == ""
+        # - set(unit, "cores") where IsMatch(name, ".*cpu.*")
+{{- end -}}


### PR DESCRIPTION
Set the unit to "CPU" when the metric name contains *cpu* and the unit is not already set.