### PR TITLE
fix: Do not read logs from tmp files

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent
 description: Chart to install K8s collection stack based on Observe Agent
 type: application
-version: 0.30.6
+version: 0.30.7
 appVersion: "1.1.0"
 dependencies:
   - name: opentelemetry-collector

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -1,6 +1,6 @@
 # agent
 
-![Version: 0.30.6](https://img.shields.io/badge/Version-0.30.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
+![Version: 0.30.7](https://img.shields.io/badge/Version-0.30.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
 
 > [!CAUTION]
 > This chart is under active development and is not meant to be installed yet.
@@ -342,7 +342,7 @@ Chart to install K8s collection stack based on Observe Agent
 | node-logs-metrics.serviceAccount.name | string | `"observe-agent-service-account"` |  |
 | node-logs-metrics.tolerations | list | `[]` |  |
 | node.containers.logs.enabled | bool | `true` |  |
-| node.containers.logs.exclude | string | `"[\"/var/log/pods/*/*/*.log.*.gz\"]"` |  |
+| node.containers.logs.exclude | string | `"[\"/var/log/pods/*/*/*.log.*.gz\", \"/var/log/pods/*/*/*.tmp\"]"` |  |
 | node.containers.logs.include | string | `"[\"/var/log/pods/*/*/*.log\", \"/var/log/pods/*/*/*.log.*\", \"/var/log/kube-apiserver-audit.log\"]"` |  |
 | node.containers.logs.lookbackPeriod | string | `"24h"` |  |
 | node.containers.logs.maxLogSize | string | `"512kb"` |  |

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -65,7 +65,7 @@ node:
       include: '["/var/log/pods/*/*/*.log", "/var/log/pods/*/*/*.log.*", "/var/log/kube-apiserver-audit.log"]'
       # A list of file glob patterns to exclude from reading. This is applied against the paths matched by include. Need to put inside of '' to avoid helm stripping commas and quotes.
       #  Log rotation exclude glob assumes files previously rotated and renamed are zipped after 1.4.0 rotated file is created
-      exclude: '["/var/log/pods/*/*/*.log.*.gz"]'
+      exclude: '["/var/log/pods/*/*/*.log.*.gz", "/var/log/pods/*/*/*.tmp"]'
       # time unit 1m, 1h
       lookbackPeriod: 24h
       # At startup, where to start reading logs from the file. Options are beginning or end.


### PR DESCRIPTION
Files that end with *.tmp are present due to various reasons, including (but not limited to):
 - Corrupted files
 - Temporary files written while performing log rotation

These files contain binary data, which we cannot parse as logs anyways These files also cause errors when processed by the receiver, since filelog cannot recognize the log format due to their binary encoding.