### PR TITLE
ci: update test logs for json error parsing

### DIFF
--- a/integration/scripts/test_logs.py
+++ b/integration/scripts/test_logs.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import pytest
+import warnings
 
 @pytest.mark.tags(
         "default.yaml",
@@ -11,23 +12,10 @@ def test_errors_logs(kube_client, helm_config):
     """_summary_
 
     This test does the following:
-    - Check that all pods in the cluster's namespace have no errors/warnings in their logs
-    - Ignore expected errors
+    - Check that all pods in the cluster's namespace have no 'level': 'error' in their json logs
     - Check that all pods have the expected logs
     """
 
-
-    ignore_error_patterns = [
-        "failed to retrieve ConfigMap kube-system/aws-auth",
-        "Exporting failed. Will retry the request after interval",
-        "The resourceVersion for the provided watch is too old",
-        # Sometimes the container operator of filelog doesn't understand the logs' format
-        # This most likely happens when the log is corrupted or in a weird state
-        # Let's prevent these errors from blocking integration tests.
-        "failed to detect a valid container log format: entry cannot be parsed as container logs",
-        # containerID is empty when a container is just created.
-        " has an empty containerID"
-    ]
     expected_good_logs = [
         "Starting observe-agent"
     ]
@@ -38,9 +26,9 @@ def test_errors_logs(kube_client, helm_config):
     for pod in pods.items: #For each pod
         pod_name = pod.metadata.name
         print(f"\nChecking Logs in Pod: {pod_name}")
+
         try:
             pod_logs = kube_client.read_namespaced_pod_log(name=pod_name, namespace=helm_config['namespace'])
-            pod_logs_lines=pod_logs.splitlines()[:250]  #Get the first 250 lines
 
             for pattern in expected_good_logs:    # Check that some expected logs exist
                 if pattern in pod_logs:
@@ -48,12 +36,15 @@ def test_errors_logs(kube_client, helm_config):
                 else:
                     pytest.fail(f"Expected log '{pattern}' not found in logs of pod {pod_name}")
 
-            for line in pod_logs_lines:  #For each line in pod logs
-                if "error" in line.lower() or "failed" in line.lower(): #Check for error or failed in log line
-                    if any(pattern in line for pattern in ignore_error_patterns):
-                        print(f"Ignoring expected error pattern log line: {line}") #Ignore expected errors
-                    else:
-                        pytest.fail(f"Generic error found in logs of pod {pod_name}: {line}")
+            parsed_logs=pytest.helpers.parseLogs(pod_logs) #Parse logs to json
+
+            for entry in parsed_logs:
+                if entry.get("level") == "error":  #Explicity check for {'level':'error', .....}
+                    pytest.fail(f"Found error entry in logs of pod {pod_name}: {entry}")
+                if entry.get("level") == "warn":  #Explicity check for {'level':'warn', .....}
+                   warnings.warn(UserWarning(f"Found warning entry in logs of pod {pod_name}: {entry}"))
 
         except pytest.helpers.ApiException() as e:
             pytest.fail(f"Could not retrieve logs for pod {pod_name}: {e}")
+
+        print(f"No 'level': 'error' found in logs of pod {pod_name}")


### PR DESCRIPTION
Addresses https://observe.atlassian.net/browse/OB-38641

`test_logs.py` has been updated to parse logs as JSON (they are set as JSON in debug) and extract `level: <>` information for checks 