### PR TITLE
feat: allow custom otel config to be injected to services

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent
 description: Chart to install K8s collection stack based on Observe Agent
 type: application
-version: 0.30.8
+version: 0.31.0
 appVersion: "1.1.0"
 dependencies:
   - name: opentelemetry-collector

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -1,6 +1,6 @@
 # agent
 
-![Version: 0.30.8](https://img.shields.io/badge/Version-0.30.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
+![Version: 0.31.0](https://img.shields.io/badge/Version-0.31.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
 
 > [!CAUTION]
 > This chart is under active development and is not meant to be installed yet.
@@ -26,6 +26,8 @@ Chart to install K8s collection stack based on Observe Agent
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| agent.config.clusterEvents | string | `nil` |  |
+| agent.config.clusterMetrics | string | `nil` |  |
 | agent.config.global.debug.verbosity | string | `"basic"` |  |
 | agent.config.global.exporters.retryOnFailure.enabled | bool | `true` |  |
 | agent.config.global.exporters.retryOnFailure.initialInterval | string | `"1s"` |  |
@@ -37,6 +39,8 @@ Chart to install K8s collection stack based on Observe Agent
 | agent.config.global.service.telemetry.loggingEncoding | string | `"console"` |  |
 | agent.config.global.service.telemetry.loggingLevel | string | `"WARN"` |  |
 | agent.config.global.service.telemetry.metricsLevel | string | `"normal"` |  |
+| agent.config.monitor | string | `nil` |  |
+| agent.config.nodeLogsMetrics | string | `nil` |  |
 | agent.selfMonitor.enabled | bool | `true` |  |
 | application.prometheusScrape.enabled | bool | `false` |  |
 | application.prometheusScrape.interval | string | `"60s"` |  |

--- a/charts/agent/templates/_config.tpl
+++ b/charts/agent/templates/_config.tpl
@@ -1,0 +1,27 @@
+{{- define "observe.deployment.applyClusterEventsConfig" -}}
+{{- $values := deepCopy .Values }}
+{{- $data := dict "Values" $values | mustMergeOverwrite (deepCopy .) }}
+{{- $config := mustMergeOverwrite ( include "observe.deployment.clusterEvents.config" $data |  fromYaml ) ($values.agent.config.clusterEvents) -}}
+{{- toYaml $config | indent 2 }}
+{{- end }}
+
+{{- define "observe.deployment.applyClusterMetricsConfig" -}}
+{{- $values := deepCopy .Values }}
+{{- $data := dict "Values" $values | mustMergeOverwrite (deepCopy .) }}
+{{- $config := mustMergeOverwrite ( include "observe.deployment.clusterMetrics.config" $data |  fromYaml ) ($values.agent.config.clusterMetrics) -}}
+{{- toYaml $config | indent 2 }}
+{{- end }}
+
+{{- define "observe.daemonset.applyNodeLogsMetricsConfig" -}}
+{{- $values := deepCopy .Values }}
+{{- $data := dict "Values" $values | mustMergeOverwrite (deepCopy .) }}
+{{- $config := mustMergeOverwrite ( include "observe.daemonset.logsMetrics.config" $data |  fromYaml ) ($values.agent.config.nodeLogsMetrics) -}}
+{{- toYaml $config | indent 2 }}
+{{- end }}
+
+{{- define "observe.deployment.applyAgentMonitorConfig" -}}
+{{- $values := deepCopy .Values }}
+{{- $data := dict "Values" $values | mustMergeOverwrite (deepCopy .) }}
+{{- $config := mustMergeOverwrite ( include "observe.deployment.agentMonitor.config" $data |  fromYaml ) ($values.agent.config.monitor) -}}
+{{- toYaml $config | indent 2 }}
+{{- end }}

--- a/charts/agent/templates/agent-monitor-configmap.yaml
+++ b/charts/agent/templates/agent-monitor-configmap.yaml
@@ -6,5 +6,5 @@ metadata:
   namespace: {{ template "observe-agent.namespace" . }}
 data:
   relay: |
-      {{- include "observe.deployment.agentMonitor.config" . | nindent 4 -}}
+      {{- include "observe.deployment.applyAgentMonitorConfig" . | nindent 4 -}}
 {{ end -}}

--- a/charts/agent/templates/cluster-events-configmap.yaml
+++ b/charts/agent/templates/cluster-events-configmap.yaml
@@ -6,5 +6,5 @@ metadata:
   namespace: {{ template "observe-agent.namespace" . }}
 data:
   relay: |
-      {{- include "observe.deployment.clusterEvents.config" . | nindent 4 -}}
+      {{- include "observe.deployment.applyClusterEventsConfig" . | nindent 4 -}}
 {{ end -}}

--- a/charts/agent/templates/cluster-metrics-configmap.yaml
+++ b/charts/agent/templates/cluster-metrics-configmap.yaml
@@ -6,5 +6,5 @@ metadata:
   namespace: {{ template "observe-agent.namespace" . }}
 data:
   relay: |
-      {{- include "observe.deployment.clusterMetrics.config" . | nindent 4 -}}
+      {{- include "observe.deployment.applyClusterMetricsConfig" . | nindent 4 -}}
 {{ end -}}

--- a/charts/agent/templates/node-logs-metrics-configmap.yaml
+++ b/charts/agent/templates/node-logs-metrics-configmap.yaml
@@ -6,5 +6,5 @@ metadata:
   namespace: {{ template "observe-agent.namespace" . }}
 data:
   relay: |
-      {{- include "observe.daemonset.logsMetrics.config" . | nindent 4 -}}
+      {{- include "observe.daemonset.applyNodeLogsMetricsConfig" . | nindent 4 -}}
 {{ end -}}

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -122,6 +122,14 @@ agent:
       debug:
         # values basic, normal, detailed
         verbosity: basic
+    # additional otel collector config for cluster-events deployment
+    clusterEvents:
+    # additional otel collector config for cluster-metrics deployment
+    clusterMetrics:
+    # additional otel collector config for node-logs-metrics daemonset
+    nodeLogsMetrics:
+    # additional otel collector config for monitor deployment
+    monitor:
   selfMonitor:
     enabled: true
 
@@ -181,7 +189,6 @@ cluster-events:
   networkPolicy:
     enabled: true
     egressRules: [{}]
-
 
   podAnnotations: {
     # This stops optional prometheus scrape config from picking up these pods

--- a/examples/agent/additionalOTELConfiguration/README.md
+++ b/examples/agent/additionalOTELConfiguration/README.md
@@ -1,0 +1,17 @@
+# Additional OTEL Configuration
+This example shows how to inject additional OTEL Config to the Observe Agent(s) that are running in the deployments and daemonsets. The additional config can add new instances of components such as receivers, processors, and exporters as well as to define new pipelines using those components. In addition, new pipelines can also use existing components from the default config.
+
+## Values.yaml
+In the helm chart, there are 3 deployments of Observe Agent and 1 daemonset. Each of these can have additional config injected. Each service has a corresponding field `agent.config.<service>` where the additional config can be added. The value of this field is a valid OTEL configuration in yaml format. The example values.yaml provided shows where custom OTEL config can be added for each of the four services.
+
+## Config Overriding
+When provided, the custom config for each service will be merged with the existing default config with precedence given to the custom config. This means that if a component is defined in both the default and custom config, the instance defined in the custom config will override the default instance. Otherwise, the two configs are merged and all components and pipelines defined in either will be present in the final resolved config. Generally, the existing default components shouldn't need to be overwritten as they can be disabled from the top level `values.yaml` config as well.
+
+## Workflow
+In order to determine what the final config after resolution is, users can run the following helm command to execute the helm chart with their values.yaml.
+
+```
+helm template observe/agent -f values.yaml > output.yaml
+```
+
+The contents of output.yaml will contain all of the kubernetes entity definitions; to see the final config, users can look at the matching config map for the service they provided custom OTEL configuration for. Users can then make modifications to their `values.yaml` and then rerun the template function to see the effect of their changes. Once the final config is ready, users can then install the helm chart as normal.

--- a/examples/agent/additionalOTELConfiguration/additional-otel-config-values.yaml
+++ b/examples/agent/additionalOTELConfiguration/additional-otel-config-values.yaml
@@ -1,0 +1,49 @@
+agent:
+  config:
+    nodeLogsMetrics:
+      # This config specifies both a new receiver and exporter and sets up a new metrics pipeline with them
+      receivers:
+        otlp/custom:
+          protocols:
+            grpc:
+              endpoint: ${env:MY_POD_IP}:4317
+            http:
+              endpoint: ${env:MY_POD_IP}:4318
+      exporters:
+        otlphttp/custom:
+          endpoint: "CUSTOM_URL"
+      service:
+        pipelines:
+          metrics/custom:
+            receivers: [otlp/custom]
+            exporters: [otlp/additional]
+    clusterEvents:
+      # Here we configure a separate exporter and reuse an existing component from the default config as the receiver
+      exporters:
+        otlphttp/custom:
+          endpoint: "CUSTOM_URL"
+      service:
+        pipelines:
+          logs/custom:
+            receivers: [k8sobjects/cluster]
+            exporters: [otlp/additional]
+    clusterMetrics:
+      # Here we configure a separate exporter and reuse an existing component from the default config as the receiver
+      exporters:
+        otlphttp/custom:
+          endpoint: "CUSTOM_URL"
+      service:
+        pipelines:
+          metrics/custom:
+            receivers: [k8s_cluster]
+            exporters: [otlphttp/custom]
+    monitor:
+      # Here we configure a separate exporter and reuse an existing component from the default config as the receiver
+      exporters:
+        otlphttp/custom:
+          endpoint: "CUSTOM_URL"
+      service:
+        pipelines:
+          metrics/custom:
+            receivers: [prometheus/collector]
+            exporters: [otlphttp/custom]


### PR DESCRIPTION
This change allows for additional OTEL Config to be provided for each of the 4 deployments of the Observe Agent in the Helm chart. The custom config will be take precedence and will be merged with the config generated from the chart templates for each of the services. 