### PR TITLE
feat: add default routing headers

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent
 description: Chart to install K8s collection stack based on Observe Agent
 type: application
-version: 0.49.1
+version: 0.50.0
 appVersion: "2.2.1"
 dependencies:
   - name: opentelemetry-collector

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -1,6 +1,6 @@
 # agent
 
-![Version: 0.49.1](https://img.shields.io/badge/Version-0.49.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.1](https://img.shields.io/badge/AppVersion-2.2.1-informational?style=flat-square)
+![Version: 0.50.0](https://img.shields.io/badge/Version-0.50.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.1](https://img.shields.io/badge/AppVersion-2.2.1-informational?style=flat-square)
 
 Chart to install K8s collection stack based on Observe Agent
 

--- a/charts/agent/templates/_config-exporters.tpl
+++ b/charts/agent/templates/_config-exporters.tpl
@@ -5,6 +5,7 @@ otlphttp/observe/base:
     endpoint: "${env:OBSERVE_OTEL_ENDPOINT}"
     headers:
         authorization: "${env:OBSERVE_AUTHORIZATION_HEADER}"
+        x-observe-target-package: "Kubernetes Explorer"
     sending_queue:
       enabled: {{ .Values.agent.config.global.exporters.sendingQueue.enabled }}
     retry_on_failure:
@@ -22,6 +23,7 @@ otlphttp/observe/entity:
     logs_endpoint: "${env:OBSERVE_COLLECTOR_URL}/v1/kubernetes/v1/entity"
     headers:
       authorization: "${env:OBSERVE_AUTHORIZATION_HEADER}"
+      x-observe-target-package: "Kubernetes Explorer"
     sending_queue:
       enabled: {{ .Values.agent.config.global.exporters.sendingQueue.enabled }}
     retry_on_failure:
@@ -39,6 +41,7 @@ otlphttp/observe/forward/trace:
     endpoint: "${env:OBSERVE_OTEL_ENDPOINT}"
     headers:
         authorization: "Bearer ${env:TRACE_TOKEN}"
+        x-observe-target-package: "Tracing"
     sending_queue:
       enabled: {{ .Values.agent.config.global.exporters.sendingQueue.enabled }}
     retry_on_failure:
@@ -56,6 +59,7 @@ prometheusremotewrite/observe:
     endpoint: "${env:OBSERVE_PROMETHEUS_ENDPOINT}"
     headers:
         authorization: "${env:OBSERVE_AUTHORIZATION_HEADER}"
+        x-observe-target-package: "Kubernetes Explorer"
     resource_to_telemetry_conversion:
         enabled: true # Convert resource attributes to metric labels
     send_metadata: true


### PR DESCRIPTION
In order for the out of box routing to work, send all traces to shared "Tracing" package and all other data to host connection specific "Kubernetes Explorer".

In the future those will be configurable.