### PR TITLE
fix: Replace kubeletstats to use node IP address - (OBSSD-482)

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent
 description: Chart to install K8s collection stack based on Observe Agent
 type: application
-version: 0.50.0
+version: 0.50.1
 appVersion: "2.2.1"
 dependencies:
   - name: opentelemetry-collector

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -1,6 +1,6 @@
 # agent
 
-![Version: 0.50.0](https://img.shields.io/badge/Version-0.50.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.1](https://img.shields.io/badge/AppVersion-2.2.1-informational?style=flat-square)
+![Version: 0.50.1](https://img.shields.io/badge/Version-0.50.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.1](https://img.shields.io/badge/AppVersion-2.2.1-informational?style=flat-square)
 
 Chart to install K8s collection stack based on Observe Agent
 
@@ -347,14 +347,16 @@ Chart to install K8s collection stack based on Observe Agent
 | node-logs-metrics.extraEnvs[1].valueFrom.configMapKeyRef.name | string | `"cluster-info"` |  |
 | node-logs-metrics.extraEnvs[2].name | string | `"K8S_NODE_NAME"` |  |
 | node-logs-metrics.extraEnvs[2].valueFrom.fieldRef.fieldPath | string | `"spec.nodeName"` |  |
-| node-logs-metrics.extraEnvs[3].name | string | `"TOKEN"` |  |
-| node-logs-metrics.extraEnvs[3].valueFrom.secretKeyRef.key | string | `"OBSERVE_TOKEN"` |  |
-| node-logs-metrics.extraEnvs[3].valueFrom.secretKeyRef.name | string | `"agent-credentials"` |  |
-| node-logs-metrics.extraEnvs[3].valueFrom.secretKeyRef.optional | bool | `true` |  |
-| node-logs-metrics.extraEnvs[4].name | string | `"TRACES_TOKEN"` |  |
-| node-logs-metrics.extraEnvs[4].valueFrom.secretKeyRef.key | string | `"TRACES_TOKEN"` |  |
+| node-logs-metrics.extraEnvs[3].name | string | `"K8S_NODE_IP"` |  |
+| node-logs-metrics.extraEnvs[3].valueFrom.fieldRef.fieldPath | string | `"status.hostIP"` |  |
+| node-logs-metrics.extraEnvs[4].name | string | `"TOKEN"` |  |
+| node-logs-metrics.extraEnvs[4].valueFrom.secretKeyRef.key | string | `"OBSERVE_TOKEN"` |  |
 | node-logs-metrics.extraEnvs[4].valueFrom.secretKeyRef.name | string | `"agent-credentials"` |  |
 | node-logs-metrics.extraEnvs[4].valueFrom.secretKeyRef.optional | bool | `true` |  |
+| node-logs-metrics.extraEnvs[5].name | string | `"TRACES_TOKEN"` |  |
+| node-logs-metrics.extraEnvs[5].valueFrom.secretKeyRef.key | string | `"TRACES_TOKEN"` |  |
+| node-logs-metrics.extraEnvs[5].valueFrom.secretKeyRef.name | string | `"agent-credentials"` |  |
+| node-logs-metrics.extraEnvs[5].valueFrom.secretKeyRef.optional | bool | `true` |  |
 | node-logs-metrics.extraVolumeMounts[0].mountPath | string | `"/observe-agent-conf"` |  |
 | node-logs-metrics.extraVolumeMounts[0].name | string | `"observe-agent-deployment-config"` |  |
 | node-logs-metrics.extraVolumeMounts[1].mountPath | string | `"/var/log/pods"` |  |
@@ -441,6 +443,7 @@ Chart to install K8s collection stack based on Observe Agent
 | node.forwarder.logs.enabled | bool | `true` |  |
 | node.forwarder.metrics.enabled | bool | `true` |  |
 | node.forwarder.traces.enabled | bool | `true` |  |
+| node.kubeletstats.useNodeIp | bool | `false` |  |
 | node.metrics.enabled | bool | `true` |  |
 | node.metrics.fileSystem.excludeMountPoints | string | `"[\"/dev/*\",\"/proc/*\",\"/sys/*\",\"/run/k3s/containerd/*\",\"/var/lib/docker/*\",\"/var/lib/kubelet/*\",\"/snap/*\"]"` |  |
 | node.metrics.fileSystem.rootPath | string | `"/hostfs"` |  |

--- a/charts/agent/templates/_node-logs-metrics-config.tpl
+++ b/charts/agent/templates/_node-logs-metrics-config.tpl
@@ -64,7 +64,7 @@ receivers:
   kubeletstats:
     collection_interval: {{.Values.node.containers.metrics.interval}}
     auth_type: 'serviceAccount'
-    endpoint: '${env:K8S_NODE_NAME}:10250'
+    endpoint: {{ if .Values.node.kubeletstats.useNodeIp }}"${env:K8S_NODE_IP}:10250"{{ else }}"${env:K8S_NODE_NAME}:10250"{{ end }}
     node: '${env:K8S_NODE_NAME}'
     insecure_skip_verify: true
     k8s_api_config:

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -79,6 +79,10 @@ node:
     metrics:
       enabled: true
       interval: 60s
+  kubeletstats:
+    # Explicitly toggles between K8S_NODE_IP and K8S_NODE_NAME. When set to false, it uses the default value of K8S_NODE_NAME from open-telemetry/opentelemetry-collector-contrib.
+    # this resolves issues similar to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/26481#issuecomment-1720797914 for `no such host` or `connection refused`.
+    useNodeIp: false
   forwarder:
     enabled: true
     traces:
@@ -539,6 +543,10 @@ node-logs-metrics:
       valueFrom:
         fieldRef:
           fieldPath: spec.nodeName
+    - name: K8S_NODE_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.hostIP
     - name: TOKEN
       valueFrom:
         secretKeyRef:


### PR DESCRIPTION
This PR addresses an issue where the `kubeletstats` receiver in the agent fails to scrape metrics, resulting in a `connection refused` error. The failure occurs because the current configuration uses the node's hostname (via `K8S_NODE_NAME`), which resolves to the loopback address (`127.0.1.1`) instead of the node's actual IP. This prevents the receiver from reaching the kubelet’s `/stats/summary` endpoint on port 10250.

Added an override in for `node.kubeletstats.useNodeIp: true` to update the endpoint to use `K8S_NODE_IP` if set or default to `K8S_NODE_NAME`.




