### PR TITLE
feat: rely on observe-agent config for health check and internal telemetry

### DIFF
--- a/charts/agent/Chart.lock
+++ b/charts/agent/Chart.lock
@@ -1,21 +1,21 @@
 dependencies:
 - name: opentelemetry-collector
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
-  version: 0.101.1
+  version: 0.125.0
 - name: opentelemetry-collector
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
-  version: 0.101.1
+  version: 0.125.0
 - name: opentelemetry-collector
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
-  version: 0.101.1
+  version: 0.125.0
 - name: opentelemetry-collector
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
-  version: 0.101.1
+  version: 0.125.0
 - name: opentelemetry-collector
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
-  version: 0.101.1
+  version: 0.125.0
 - name: opentelemetry-collector
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
-  version: 0.101.1
-digest: sha256:47cfa171b1356ff55f83f00b25b00a3966db06584b438563fa5ac598ee61ea8d
-generated: "2025-05-14T10:56:39.673411-07:00"
+  version: 0.125.0
+digest: sha256:0b36dd6af524a8ecdbadc246cf3e26b7a96972a9a2b24485ee9536f05a39ac24
+generated: "2025-05-20T10:50:52.230945-05:00"

--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -2,36 +2,36 @@ apiVersion: v2
 name: agent
 description: Chart to install K8s collection stack based on Observe Agent
 type: application
-version: 0.57.0
+version: 0.58.0
 appVersion: "2.3.0"
 dependencies:
   - name: opentelemetry-collector
-    version: 0.101.1
+    version: 0.125.0
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
     alias: cluster-events
     condition: cluster.events.enabled
   - name: opentelemetry-collector
-    version: 0.101.1
+    version: 0.125.0
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
     alias: cluster-metrics
     condition: cluster.metrics.enabled
   - name: opentelemetry-collector
-    version: 0.101.1
+    version: 0.125.0
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
     alias: prometheus-scraper
     condition: application.prometheusScrape.independentDeployment
   - name: opentelemetry-collector
-    version: 0.101.1
+    version: 0.125.0
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
     alias: node-logs-metrics
     condition: node.enabled
   - name: opentelemetry-collector
-    version: 0.101.1
+    version: 0.125.0
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
     alias: monitor
     condition: agent.selfMonitor.enabled
   - name: opentelemetry-collector
-    version: 0.101.1
+    version: 0.125.0
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
     alias: forwarder
     condition: node.forwarder.enabled

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -1,6 +1,6 @@
 # agent
 
-![Version: 0.57.0](https://img.shields.io/badge/Version-0.57.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.3.0](https://img.shields.io/badge/AppVersion-2.3.0-informational?style=flat-square)
+![Version: 0.58.0](https://img.shields.io/badge/Version-0.58.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.3.0](https://img.shields.io/badge/AppVersion-2.3.0-informational?style=flat-square)
 
 Chart to install K8s collection stack based on Observe Agent
 
@@ -40,12 +40,12 @@ This service is a *single-instance deployment*. It's critical that this service 
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://open-telemetry.github.io/opentelemetry-helm-charts | cluster-events(opentelemetry-collector) | 0.101.1 |
-| https://open-telemetry.github.io/opentelemetry-helm-charts | cluster-metrics(opentelemetry-collector) | 0.101.1 |
-| https://open-telemetry.github.io/opentelemetry-helm-charts | prometheus-scraper(opentelemetry-collector) | 0.101.1 |
-| https://open-telemetry.github.io/opentelemetry-helm-charts | node-logs-metrics(opentelemetry-collector) | 0.101.1 |
-| https://open-telemetry.github.io/opentelemetry-helm-charts | monitor(opentelemetry-collector) | 0.101.1 |
-| https://open-telemetry.github.io/opentelemetry-helm-charts | forwarder(opentelemetry-collector) | 0.101.1 |
+| https://open-telemetry.github.io/opentelemetry-helm-charts | cluster-events(opentelemetry-collector) | 0.125.0 |
+| https://open-telemetry.github.io/opentelemetry-helm-charts | cluster-metrics(opentelemetry-collector) | 0.125.0 |
+| https://open-telemetry.github.io/opentelemetry-helm-charts | prometheus-scraper(opentelemetry-collector) | 0.125.0 |
+| https://open-telemetry.github.io/opentelemetry-helm-charts | node-logs-metrics(opentelemetry-collector) | 0.125.0 |
+| https://open-telemetry.github.io/opentelemetry-helm-charts | monitor(opentelemetry-collector) | 0.125.0 |
+| https://open-telemetry.github.io/opentelemetry-helm-charts | forwarder(opentelemetry-collector) | 0.125.0 |
 
 ## Values
 

--- a/charts/agent/templates/_cluster-events-config.tpl
+++ b/charts/agent/templates/_cluster-events-config.tpl
@@ -1,8 +1,5 @@
 {{- define "observe.deployment.clusterEvents.config" -}}
 
-extensions:
-{{- include "config.extensions.health_check" . | nindent 2 }}
-
 exporters:
 {{- include "config.exporters.debug" . | nindent 2 }}
 {{- include "config.exporters.otlphttp.observe.entity" . | nindent 2 }}
@@ -439,7 +436,6 @@ processors:
 {{- end }}
 
 service:
-  extensions: [health_check]
   pipelines:
       logs/objects:
         receivers: [k8sobjects/objects]

--- a/charts/agent/templates/_cluster-metrics-config.tpl
+++ b/charts/agent/templates/_cluster-metrics-config.tpl
@@ -1,8 +1,5 @@
 {{- define "observe.deployment.clusterMetrics.config" -}}
 
-extensions:
-{{- include "config.extensions.health_check" . | nindent 2 }}
-
 exporters:
 {{- include "config.exporters.debug" . | nindent 2 }}
 {{- include "config.exporters.prometheusremotewrite" . | nindent 2 }}
@@ -58,7 +55,6 @@ processors:
 {{- end }}
 
 service:
-  extensions: [health_check]
   pipelines:
       metrics:
         receivers: [k8s_cluster]

--- a/charts/agent/templates/_config-extensions.tpl
+++ b/charts/agent/templates/_config-extensions.tpl
@@ -1,10 +1,3 @@
-{{- define "config.extensions.health_check" -}}
-# https://github.com/open-telemetry/opentelemetry-helm-charts/issues/816
-# 0.0.0.0 is hack for ipv6 on eks clusters
-health_check:
-  endpoint: "{{ template "config.local_host"}}:13133"
-{{- end -}}
-
 {{- define "config.extensions.file_storage" -}}
 file_storage:
   create_directory: true

--- a/charts/agent/templates/_config-telemetry.tpl
+++ b/charts/agent/templates/_config-telemetry.tpl
@@ -1,9 +1,5 @@
 {{- define "config.service.telemetry" -}}
 telemetry:
-    metrics:
-      level: {{ .Values.agent.config.global.service.telemetry.metricsLevel }}
-      address: {{ template "config.local_host"}}:8888
     logs:
-      level: {{ .Values.agent.config.global.service.telemetry.loggingLevel }}
       encoding: {{ .Values.agent.config.global.service.telemetry.loggingEncoding }}
 {{- end -}}

--- a/charts/agent/templates/_forwarder-config.tpl
+++ b/charts/agent/templates/_forwarder-config.tpl
@@ -1,8 +1,5 @@
 {{- define "observe.daemonset.forwarder.config" -}}
 
-extensions:
-{{- include "config.extensions.health_check" . | nindent 2 }}
-
 exporters:
 {{- include "config.exporters.debug" . | nindent 2 }}
 {{- include "config.exporters.otlphttp.observe.base" . | nindent 2 }}
@@ -73,7 +70,6 @@ processors:
 {{- end }}
 
 service:
-  extensions: [health_check]
   pipelines:
     traces/observe-forward:
       receivers: [otlp/app-telemetry]

--- a/charts/agent/templates/_monitor-config.tpl
+++ b/charts/agent/templates/_monitor-config.tpl
@@ -1,8 +1,5 @@
 {{- define "observe.deployment.agentMonitor.config" -}}
 
-extensions:
-{{- include "config.extensions.health_check" . | nindent 2 }}
-
 exporters:
 {{- include "config.exporters.debug" . | nindent 2 }}
 {{- include "config.exporters.prometheusremotewrite" . | nindent 2 }}
@@ -74,7 +71,6 @@ processors:
 {{- end }}
 
 service:
-  extensions: [health_check]
   pipelines:
       metrics:
         receivers: [prometheus/collector]

--- a/charts/agent/templates/_node-logs-metrics-config.tpl
+++ b/charts/agent/templates/_node-logs-metrics-config.tpl
@@ -6,7 +6,6 @@ multiline:
 {{- define "observe.daemonset.logsMetrics.config" -}}
 
 extensions:
-{{- include "config.extensions.health_check" . | nindent 2 }}
 {{- include "config.extensions.file_storage" . | nindent 2 }}
 
 exporters:
@@ -184,7 +183,6 @@ processors:
 {{- end }}
 
 service:
-  extensions: [health_check, file_storage]
   pipelines:
       {{- if .Values.node.containers.logs.enabled }}
       logs:

--- a/charts/agent/templates/_observe-agent.tpl
+++ b/charts/agent/templates/_observe-agent.tpl
@@ -4,16 +4,29 @@ token: {{ .Values.observe.token.value }}
 
 debug: false
 
+health_check:
+  enabled: true
+  endpoint: "{{ template "config.local_host"}}:13133"
+  path: "/status"
+
+internal_telemetry:
+  enabled: true
+  metrics:
+    enabled: true
+    host: "{{ template "config.local_host"}}"
+    port: 8888
+    level: {{ .Values.agent.config.global.service.telemetry.metricsLevel }}
+  logs:
+    enabled: true
+    level: {{ .Values.agent.config.global.service.telemetry.loggingLevel }}
+
+
+forwarding:
+  enabled: false
+
 self_monitoring:
   enabled: false
 
 host_monitoring:
   enabled: false
-  logs:
-    enabled: false
-  metrics:
-    host:
-      enabled: false
-    process:
-      enabled: false
 {{- end }}

--- a/charts/agent/templates/_prometheus-scraper-config.tpl
+++ b/charts/agent/templates/_prometheus-scraper-config.tpl
@@ -1,8 +1,5 @@
 {{- define "observe.deployment.prometheusScraper.config" -}}
 
-extensions:
-{{- include "config.extensions.health_check" . | nindent 2 }}
-
 exporters:
 {{- include "config.exporters.debug" . | nindent 2 }}
 {{- include "config.exporters.prometheusremotewrite" . | nindent 2 }}
@@ -39,7 +36,6 @@ processors:
 {{- end }}
 
 service:
-  extensions: [health_check]
   pipelines:
     metrics/pod_metrics:
       receivers: [{{ join ", " $podMetricsReceivers }}]


### PR DESCRIPTION
OB-43962
Putting these values in the agent config makes `observe-agent status` work by default.