### PR TITLE
fix: lower memory-limiter to 80

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent
 description: Chart to install K8s collection stack based on Observe Agent
 type: application
-version: 0.53.0
+version: 0.53.1
 appVersion: "2.2.1"
 dependencies:
   - name: opentelemetry-collector

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -1,6 +1,6 @@
 # agent
 
-![Version: 0.53.0](https://img.shields.io/badge/Version-0.53.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.1](https://img.shields.io/badge/AppVersion-2.2.1-informational?style=flat-square)
+![Version: 0.53.1](https://img.shields.io/badge/Version-0.53.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.1](https://img.shields.io/badge/AppVersion-2.2.1-informational?style=flat-square)
 
 Chart to install K8s collection stack based on Observe Agent
 

--- a/charts/agent/templates/_config-processors.tpl
+++ b/charts/agent/templates/_config-processors.tpl
@@ -81,22 +81,9 @@ resource/observe_common:
 {{- define "config.processors.memory_limiter" -}}
 # https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/memorylimiterprocessor/README.md
 memory_limiter:
-  # check_interval is the time between measurements of memory usage for the
-  # purposes of avoiding going over the limits. Defaults to zero, so no
-  # checks will be performed. Values below 1 second are not recommended since
-  # it can result in unnecessary CPU consumption.
   check_interval: 5s
-  # limit_percentage (default = 0): Maximum amount of total memory targeted to be allocated by the process heap.
-  # This configuration is supported on Linux systems with cgroups and it's intended to be used in dynamic platforms like docker.
-  # This option is used to calculate memory_limit from the total available memory.
-  # For instance setting of 75% with the total memory of 1GiB will result in the limit of 750 MiB.
-  # The fixed memory setting (limit_mib) takes precedence over the percentage configuration.
-  limit_percentage: 90
-  # spike_limit_percentage (default = 0): Maximum spike expected between the measurements of memory usage.
-  # The value must be less than limit_percentage.
-  # This option is used to calculate spike_limit_mib from the total available memory.
-  # For instance setting of 25% with the total memory of 1GiB will result in the spike limit of 250MiB.
-  # This option is intended to be used only with limit_percentage.
+  # GOMEMLIMIT gets automatically set to 80% of the Kube resources so this should be 80% total as well
+  limit_percentage: 80
   spike_limit_percentage: 15
 {{- end -}}
 


### PR DESCRIPTION
GOMEMLIMIT gets automatically set to 80% of the Kube resources so this should be 80% total as well