### PR TITLE
fix: Remove container id for cluster metrics

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent
 description: Chart to install K8s collection stack based on Observe Agent
 type: application
-version: 0.63.0
+version: 0.63.1
 appVersion: "2.5.0"
 dependencies:
   - name: opentelemetry-collector

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -1,6 +1,6 @@
 # agent
 
-![Version: 0.63.0](https://img.shields.io/badge/Version-0.63.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.5.0](https://img.shields.io/badge/AppVersion-2.5.0-informational?style=flat-square)
+![Version: 0.63.1](https://img.shields.io/badge/Version-0.63.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.5.0](https://img.shields.io/badge/AppVersion-2.5.0-informational?style=flat-square)
 
 Chart to install K8s collection stack based on Observe Agent
 

--- a/charts/agent/templates/_cluster-metrics-config.tpl
+++ b/charts/agent/templates/_cluster-metrics-config.tpl
@@ -33,7 +33,8 @@ processors:
 
 {{- include "config.processors.batch" . | nindent 2 }}
 
-{{- include "config.processors.attributes.k8sattributes" . | nindent 2 }}
+{{- include "config.processors.attributes.k8sattributes" (merge . (dict "target" "cluster_metrics")) | nindent 2 }}
+{{- include "config.processors.attributes.drop_container_info" . | nindent 2 }}
 
 {{- include "config.processors.resource.observe_common" . | nindent 2 }}
 
@@ -58,7 +59,7 @@ service:
   pipelines:
       metrics:
         receivers: [k8s_cluster]
-        processors: [memory_limiter, k8sattributes, batch, resource/observe_common, attributes/debug_source_cluster_metrics]
+        processors: [memory_limiter, k8sattributes, batch, resource/observe_common, resource/drop_container_info, attributes/debug_source_cluster_metrics]
         exporters: [{{ join ", " $metricsExporters }}]
 {{- if and (eq .Values.application.prometheusScrape.enabled true) (eq .Values.application.prometheusScrape.independentDeployment false) }}
       metrics/pod_metrics:

--- a/charts/agent/templates/_config-processors.tpl
+++ b/charts/agent/templates/_config-processors.tpl
@@ -35,7 +35,9 @@ k8sattributes:
       - k8s.pod.uid
       - k8s.cluster.uid
       - k8s.container.name
+      {{- if ne .target "cluster_metrics" }}
       - container.id
+      {{- end }}
       - service.namespace
       - service.name
       - service.version
@@ -93,4 +95,11 @@ attributes/debug_source_pod_metrics:
     - key: debug_source
       action: insert
       value: pod_metrics
+{{- end -}}
+
+{{- define "config.processors.attributes.drop_container_info" -}}
+resource/drop_container_info:
+  attributes:
+    - key: container.id
+      action: delete
 {{- end -}}


### PR DESCRIPTION
`k8s_container_restarts` / `k8s.container.restarts` and similar metrics are broken when container.id is part of the labels. In general, it's largely just adding extra dimensionality without much benefit. Hence remove completely from cluster metrics.

Fixes OB-44943