### PR TITLE
fix: Remove container information from pod metrics

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent
 description: Chart to install K8s collection stack based on Observe Agent
 type: application
-version: 0.63.1
+version: 0.63.2
 appVersion: "2.5.0"
 dependencies:
   - name: opentelemetry-collector

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -1,6 +1,6 @@
 # agent
 
-![Version: 0.63.1](https://img.shields.io/badge/Version-0.63.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.5.0](https://img.shields.io/badge/AppVersion-2.5.0-informational?style=flat-square)
+![Version: 0.63.2](https://img.shields.io/badge/Version-0.63.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.5.0](https://img.shields.io/badge/AppVersion-2.5.0-informational?style=flat-square)
 
 Chart to install K8s collection stack based on Observe Agent
 

--- a/charts/agent/templates/_cluster-metrics-config.tpl
+++ b/charts/agent/templates/_cluster-metrics-config.tpl
@@ -34,7 +34,7 @@ processors:
 {{- include "config.processors.batch" . | nindent 2 }}
 
 {{- include "config.processors.attributes.k8sattributes" (merge . (dict "target" "cluster_metrics")) | nindent 2 }}
-{{- include "config.processors.attributes.drop_container_info" . | nindent 2 }}
+{{- include "config.processors.attributes.drop_container_info" (merge . (dict "target" "cluster_metrics")) | nindent 2 }}
 
 {{- include "config.processors.resource.observe_common" . | nindent 2 }}
 
@@ -64,7 +64,7 @@ service:
 {{- if and (eq .Values.application.prometheusScrape.enabled true) (eq .Values.application.prometheusScrape.independentDeployment false) }}
       metrics/pod_metrics:
         receivers: [prometheus/pod_metrics]
-        processors: [memory_limiter, k8sattributes, batch, resource/observe_common, attributes/debug_source_pod_metrics]
+        processors: [memory_limiter, k8sattributes, batch, resource/observe_common, resource/drop_container_info, attributes/debug_source_pod_metrics]
         exporters: [{{ join ", " $metricsExporters }}]
 {{- end }}
 {{- include "config.service.telemetry" . | nindent 2 }}

--- a/charts/agent/templates/_config-processors.tpl
+++ b/charts/agent/templates/_config-processors.tpl
@@ -34,9 +34,11 @@ k8sattributes:
       - k8s.pod.name
       - k8s.pod.uid
       - k8s.cluster.uid
+      {{- if (ne .target "pod_metrics") }}
       - k8s.container.name
-      {{- if ne .target "cluster_metrics" }}
+      {{- if (ne .target "cluster_metrics") }}
       - container.id
+      {{- end }}
       {{- end }}
       - service.namespace
       - service.name
@@ -102,4 +104,8 @@ resource/drop_container_info:
   attributes:
     - key: container.id
       action: delete
+{{- if eq .target "pod_metrics" }}
+    - key: k8s.container.name
+      action: delete
+{{- end }}
 {{- end -}}

--- a/charts/agent/templates/_prometheus-scraper-config.tpl
+++ b/charts/agent/templates/_prometheus-scraper-config.tpl
@@ -14,11 +14,13 @@ processors:
 
 {{- include "config.processors.batch" . | nindent 2 }}
 
-{{- include "config.processors.attributes.k8sattributes" . | nindent 2 }}
+{{- include "config.processors.attributes.k8sattributes" (merge . (dict "target" "pod_metrics")) | nindent 2 }}
+{{- include "config.processors.attributes.drop_container_info" (merge . (dict "target" "pod_metrics")) | nindent 2 }}
 
 {{- include "config.processors.resource.observe_common" . | nindent 2 }}
 
 {{- include "config.processors.attributes.pod_metrics" . | nindent 2 }}
+
 
 # Set up receivers
 {{- $podMetricsReceivers := (list "prometheus/pod_metrics") -}}
@@ -39,8 +41,8 @@ service:
   pipelines:
     metrics/pod_metrics:
       receivers: [{{ join ", " $podMetricsReceivers }}]
-      processors: [memory_limiter, k8sattributes, batch, resource/observe_common, attributes/debug_source_pod_metrics]
+      processors: [memory_limiter, k8sattributes, batch, resource/observe_common, resource/drop_container_info, attributes/debug_source_pod_metrics]
       exporters: [{{ join ", " $podMetricsExporters }}]
 {{- include "config.service.telemetry" . | nindent 2 }}
 
- {{- end }}
+{{- end }}


### PR DESCRIPTION
Container information currently is not reliable, a random container id / name is being discovered, which can lead to confusion at best and labels/attributes dimensionality explosion at worst.

It should be possible to uniquely identify the container based on the pod, but I couldn't get this to work. That would still be the ideal solution - we can always add this back if we manage to get that to work. For now, better to remove the information completely.

Fixes OB-45911