### PR TITLE
fix: populate service.name correctly on scraped prometheus metrics

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent
 description: Chart to install K8s collection stack based on Observe Agent
 type: application
-version: 0.64.2
+version: 0.64.3
 appVersion: "2.5.0"
 dependencies:
   - name: opentelemetry-collector

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -1,6 +1,6 @@
 # agent
 
-![Version: 0.64.2](https://img.shields.io/badge/Version-0.64.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.5.0](https://img.shields.io/badge/AppVersion-2.5.0-informational?style=flat-square)
+![Version: 0.64.3](https://img.shields.io/badge/Version-0.64.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.5.0](https://img.shields.io/badge/AppVersion-2.5.0-informational?style=flat-square)
 
 Chart to install K8s collection stack based on Observe Agent
 

--- a/charts/agent/templates/_cluster-metrics-config.tpl
+++ b/charts/agent/templates/_cluster-metrics-config.tpl
@@ -35,6 +35,7 @@ processors:
 
 {{- include "config.processors.attributes.k8sattributes" (merge . (dict "target" "cluster_metrics")) | nindent 2 }}
 {{- include "config.processors.attributes.drop_container_info" . | nindent 2 }}
+{{- include "config.processors.attributes.drop_service_name" . | nindent 2 }}
 
 {{- include "config.processors.resource.observe_common" . | nindent 2 }}
 
@@ -64,7 +65,8 @@ service:
 {{- if and (eq .Values.application.prometheusScrape.enabled true) (eq .Values.application.prometheusScrape.independentDeployment false) }}
       metrics/pod_metrics:
         receivers: [prometheus/pod_metrics]
-        processors: [memory_limiter, k8sattributes, batch, resource/observe_common, attributes/debug_source_pod_metrics]
+        # Drop the service.name resource attribute (which is set to the prom scrape job name) before the k8sattributes processor
+        processors: [memory_limiter, resource/drop_service_name, k8sattributes, batch, resource/observe_common, attributes/debug_source_pod_metrics]
         exporters: [{{ join ", " $metricsExporters }}]
 {{- end }}
 {{- include "config.service.telemetry" . | nindent 2 }}

--- a/charts/agent/templates/_config-processors.tpl
+++ b/charts/agent/templates/_config-processors.tpl
@@ -103,3 +103,10 @@ resource/drop_container_info:
     - key: container.id
       action: delete
 {{- end -}}
+
+{{- define "config.processors.attributes.drop_service_name" -}}
+resource/drop_service_name:
+  attributes:
+    - action: delete
+      key: service.name
+{{- end -}}

--- a/charts/agent/templates/_monitor-config.tpl
+++ b/charts/agent/templates/_monitor-config.tpl
@@ -55,6 +55,8 @@ processors:
 
 {{- include "config.processors.attributes.k8sattributes" . | nindent 2 }}
 
+{{- include "config.processors.attributes.drop_service_name" . | nindent 2 }}
+
 {{- include "config.processors.resource.observe_common" . | nindent 2 }}
 
   # attributes to append to objects
@@ -74,8 +76,9 @@ service:
   pipelines:
       metrics:
         receivers: [prometheus/collector]
-        processors: [memory_limiter, k8sattributes, batch, resource/observe_common, attributes/debug_source_agent_monitor]
+        # Drop the service.name resource attribute (which is set to the prom scrape job name) before the k8sattributes processor
+        processors: [memory_limiter, resource/drop_service_name, k8sattributes, batch, resource/observe_common, attributes/debug_source_agent_monitor]
         exporters: [{{ join ", " $metricsExporters }}]
 {{- include "config.service.telemetry" . | nindent 2 }}
 
- {{- end }}
+{{- end }}

--- a/charts/agent/templates/_prometheus-scraper-config.tpl
+++ b/charts/agent/templates/_prometheus-scraper-config.tpl
@@ -21,6 +21,8 @@ processors:
 
 {{- include "config.processors.attributes.pod_metrics" . | nindent 2 }}
 
+{{- include "config.processors.attributes.drop_service_name" . | nindent 2 }}
+
   attributes/debug_source_cadvisor_metrics:
     actions:
       - key: debug_source
@@ -46,7 +48,8 @@ service:
   pipelines:
     metrics/pod_metrics:
       receivers: [{{ join ", " $podMetricsReceivers }}]
-      processors: [memory_limiter, k8sattributes, batch, resource/observe_common, attributes/debug_source_pod_metrics]
+      # Drop the service.name resource attribute (which is set to the prom scrape job name) before the k8sattributes processor
+      processors: [memory_limiter, resource/drop_service_name, k8sattributes, batch, resource/observe_common, attributes/debug_source_pod_metrics]
       exporters: [{{ join ", " $podMetricsExporters }}]
     {{- if .Values.node.metrics.cadvisor.enabled }}
     metrics/cadvisor:


### PR DESCRIPTION
Currently the prometheus receiver is setting the prom scrape job name as `service.name`:
https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.128.0/receiver/prometheusreceiver/internal/prom_to_otlp.go#L53

We need to delete this so `service.name` is set properly by `k8sattributes` processor.