### PR TITLE
feat: add option to enable RED metrics generation from spans

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent
 description: Chart to install K8s collection stack based on Observe Agent
 type: application
-version: 0.65.0
+version: 0.66.0
 appVersion: "2.5.0"
 dependencies:
   - name: opentelemetry-collector

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -73,6 +73,7 @@ This service is a *single-instance deployment*. It's critical that this service 
 | agent.config.prometheusScraper | string | `nil` |  |
 | agent.selfMonitor.enabled | bool | `true` |  |
 | agent.selfMonitor.metrics.scrapeInterval | string | `"60s"` |  |
+| application.REDMetrics.enabled | bool | `false` | Whether to enable generating RED metrics from spans. See https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/spanmetricsconnector#overview |
 | application.prometheusScrape.enabled | bool | `false` |  |
 | application.prometheusScrape.independentDeployment | bool | `false` |  |
 | application.prometheusScrape.interval | string | `"60s"` |  |
@@ -112,7 +113,7 @@ This service is a *single-instance deployment*. It's critical that this service 
 | cluster-events.extraVolumes[0].configMap.items[0].path | string | `"observe-agent.yaml"` |  |
 | cluster-events.extraVolumes[0].configMap.name | string | `"observe-agent"` |  |
 | cluster-events.extraVolumes[0].name | string | `"observe-agent-deployment-config"` |  |
-| cluster-events.image | object | `{"pullPolicy":"IfNotPresent","repository":"observeinc/observe-agent","tag":"2.5.0"}` | --------------------------------------- # Same for each deployment/daemonset      # |
+| cluster-events.image | object | `{"pullPolicy":"IfNotPresent","repository":"observeinc/observe-agent","tag":"2.6.0"}` | --------------------------------------- # Same for each deployment/daemonset      # |
 | cluster-events.initContainers[0].env[0].name | string | `"NAMESPACE"` |  |
 | cluster-events.initContainers[0].env[0].valueFrom.fieldRef.fieldPath | string | `"metadata.namespace"` |  |
 | cluster-events.initContainers[0].image | string | `"observeinc/kube-cluster-info:v0.11.5"` |  |
@@ -178,7 +179,7 @@ This service is a *single-instance deployment*. It's critical that this service 
 | cluster-metrics.extraVolumes[0].configMap.items[0].path | string | `"observe-agent.yaml"` |  |
 | cluster-metrics.extraVolumes[0].configMap.name | string | `"observe-agent"` |  |
 | cluster-metrics.extraVolumes[0].name | string | `"observe-agent-deployment-config"` |  |
-| cluster-metrics.image | object | `{"pullPolicy":"IfNotPresent","repository":"observeinc/observe-agent","tag":"2.5.0"}` | --------------------------------------- # Same for each deployment/daemonset      # |
+| cluster-metrics.image | object | `{"pullPolicy":"IfNotPresent","repository":"observeinc/observe-agent","tag":"2.6.0"}` | --------------------------------------- # Same for each deployment/daemonset      # |
 | cluster-metrics.initContainers[0].env[0].name | string | `"NAMESPACE"` |  |
 | cluster-metrics.initContainers[0].env[0].valueFrom.fieldRef.fieldPath | string | `"metadata.namespace"` |  |
 | cluster-metrics.initContainers[0].image | string | `"observeinc/kube-cluster-info:v0.11.5"` |  |
@@ -256,7 +257,7 @@ This service is a *single-instance deployment*. It's critical that this service 
 | forwarder.extraVolumes[0].configMap.items[0].path | string | `"observe-agent.yaml"` |  |
 | forwarder.extraVolumes[0].configMap.name | string | `"observe-agent"` |  |
 | forwarder.extraVolumes[0].name | string | `"observe-agent-deployment-config"` |  |
-| forwarder.image | object | `{"pullPolicy":"IfNotPresent","repository":"observeinc/observe-agent","tag":"2.5.0"}` | --------------------------------------- # Same for each deployment/daemonset      # |
+| forwarder.image | object | `{"pullPolicy":"IfNotPresent","repository":"observeinc/observe-agent","tag":"2.6.0"}` | --------------------------------------- # Same for each deployment/daemonset      # |
 | forwarder.initContainers[0].env[0].name | string | `"NAMESPACE"` |  |
 | forwarder.initContainers[0].env[0].valueFrom.fieldRef.fieldPath | string | `"metadata.namespace"` |  |
 | forwarder.initContainers[0].image | string | `"observeinc/kube-cluster-info:v0.11.5"` |  |
@@ -324,7 +325,7 @@ This service is a *single-instance deployment*. It's critical that this service 
 | monitor.extraVolumes[0].configMap.items[0].path | string | `"observe-agent.yaml"` |  |
 | monitor.extraVolumes[0].configMap.name | string | `"observe-agent"` |  |
 | monitor.extraVolumes[0].name | string | `"observe-agent-deployment-config"` |  |
-| monitor.image | object | `{"pullPolicy":"IfNotPresent","repository":"observeinc/observe-agent","tag":"2.5.0"}` | --------------------------------------- # Same for each deployment/daemonset      # |
+| monitor.image | object | `{"pullPolicy":"IfNotPresent","repository":"observeinc/observe-agent","tag":"2.6.0"}` | --------------------------------------- # Same for each deployment/daemonset      # |
 | monitor.initContainers[0].env[0].name | string | `"NAMESPACE"` |  |
 | monitor.initContainers[0].env[0].valueFrom.fieldRef.fieldPath | string | `"metadata.namespace"` |  |
 | monitor.initContainers[0].image | string | `"observeinc/kube-cluster-info:v0.11.5"` |  |
@@ -419,7 +420,7 @@ This service is a *single-instance deployment*. It's critical that this service 
 | node-logs-metrics.extraVolumes[3].name | string | `"varlibotelcol"` |  |
 | node-logs-metrics.extraVolumes[4].hostPath.path | string | `"/"` |  |
 | node-logs-metrics.extraVolumes[4].name | string | `"hostfs"` |  |
-| node-logs-metrics.image | object | `{"pullPolicy":"IfNotPresent","repository":"observeinc/observe-agent","tag":"2.5.0"}` | --------------------------------------- # Same for each deployment/daemonset      # |
+| node-logs-metrics.image | object | `{"pullPolicy":"IfNotPresent","repository":"observeinc/observe-agent","tag":"2.6.0"}` | --------------------------------------- # Same for each deployment/daemonset      # |
 | node-logs-metrics.initContainers[0].env[0].name | string | `"NAMESPACE"` |  |
 | node-logs-metrics.initContainers[0].env[0].valueFrom.fieldRef.fieldPath | string | `"metadata.namespace"` |  |
 | node-logs-metrics.initContainers[0].image | string | `"observeinc/kube-cluster-info:v0.11.5"` |  |
@@ -478,7 +479,6 @@ This service is a *single-instance deployment*. It's critical that this service 
 | node.forwarder.logs.enabled | bool | `true` |  |
 | node.forwarder.metrics.enabled | bool | `true` |  |
 | node.forwarder.metrics.outputFormat | string | `"prometheus"` | The format of the outbound metrics from the forwarder to Observe. Valid values are "prometheus" and "otel" |
-| node.forwarder.redMetrics.enabled | bool | `false` | Whether to enable generating RED metrics from spans. See https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/spanmetricsconnector#overview |
 | node.forwarder.traces.enabled | bool | `true` |  |
 | node.forwarder.traces.maxSpanDuration | string | `"1h"` | The max span duration to be considered by the agent, or "none" for no limit. Any span over this limit will be dropped. Durations must be a number with a valid time unit: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/ottl/ottlfuncs/README.md#duration |
 | node.kubeletstats.useNodeIp | bool | `false` |  |
@@ -527,7 +527,7 @@ This service is a *single-instance deployment*. It's critical that this service 
 | prometheus-scraper.extraVolumes[0].configMap.items[0].path | string | `"observe-agent.yaml"` |  |
 | prometheus-scraper.extraVolumes[0].configMap.name | string | `"observe-agent"` |  |
 | prometheus-scraper.extraVolumes[0].name | string | `"observe-agent-deployment-config"` |  |
-| prometheus-scraper.image | object | `{"pullPolicy":"IfNotPresent","repository":"observeinc/observe-agent","tag":"2.5.0"}` | --------------------------------------- # Same for each deployment/daemonset      # |
+| prometheus-scraper.image | object | `{"pullPolicy":"IfNotPresent","repository":"observeinc/observe-agent","tag":"2.6.0"}` | --------------------------------------- # Same for each deployment/daemonset      # |
 | prometheus-scraper.initContainers[0].env[0].name | string | `"NAMESPACE"` |  |
 | prometheus-scraper.initContainers[0].env[0].valueFrom.fieldRef.fieldPath | string | `"metadata.namespace"` |  |
 | prometheus-scraper.initContainers[0].image | string | `"observeinc/kube-cluster-info:v0.11.5"` |  |

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -478,6 +478,7 @@ This service is a *single-instance deployment*. It's critical that this service 
 | node.forwarder.logs.enabled | bool | `true` |  |
 | node.forwarder.metrics.enabled | bool | `true` |  |
 | node.forwarder.metrics.outputFormat | string | `"prometheus"` | The format of the outbound metrics from the forwarder to Observe. Valid values are "prometheus" and "otel" |
+| node.forwarder.redMetrics.enabled | bool | `false` | Whether to enable generating RED metrics from spans. See https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/spanmetricsconnector#overview |
 | node.forwarder.traces.enabled | bool | `true` |  |
 | node.forwarder.traces.maxSpanDuration | string | `"1h"` | The max span duration to be considered by the agent, or "none" for no limit. Any span over this limit will be dropped. Durations must be a number with a valid time unit: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/ottl/ottlfuncs/README.md#duration |
 | node.kubeletstats.useNodeIp | bool | `false` |  |

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -1,6 +1,6 @@
 # agent
 
-![Version: 0.65.0](https://img.shields.io/badge/Version-0.65.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.5.0](https://img.shields.io/badge/AppVersion-2.5.0-informational?style=flat-square)
+![Version: 0.66.0](https://img.shields.io/badge/Version-0.66.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.5.0](https://img.shields.io/badge/AppVersion-2.5.0-informational?style=flat-square)
 
 Chart to install K8s collection stack based on Observe Agent
 

--- a/charts/agent/ci/test-values.yaml
+++ b/charts/agent/ci/test-values.yaml
@@ -9,6 +9,8 @@ application:
   prometheusScrape:
     enabled: true
     independentDeployment: true
+  REDMetrics:
+    enabled: true
 
 node:
   forwarder:

--- a/charts/agent/templates/_forwarder-config.tpl
+++ b/charts/agent/templates/_forwarder-config.tpl
@@ -2,7 +2,7 @@
 
 {{- $spanmetricsResourceAttributes := (list "service.namespace" "service.version" "deployment.environment" "k8s.pod.name" "k8s.cluster.uid" "k8s.namespace.name") -}}
 
-{{- if .Values.node.forwarder.redMetrics.enabled }}
+{{- if .Values.application.REDMetrics.enabled }}
 connectors:
   spanmetrics:
     aggregation_temporality: AGGREGATION_TEMPORALITY_DELTA
@@ -48,7 +48,7 @@ processors:
 {{- fail "Invalid maxSpanDuration for forwarder red metrics, valid values are 'none' or a number with a valid time unit: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/ottl/ottlfuncs/README.md#duration" }}
 {{- end }}
 
-{{- if .Values.node.forwarder.redMetrics.enabled }}
+{{- if .Values.application.REDMetrics.enabled }}
   attributes/debug_source_span_metrics:
     actions:
       - action: insert
@@ -202,7 +202,7 @@ service:
       receivers: [otlp/app-telemetry]
       processors:  [{{ join ", " $metricsProcessors }}]
       exporters: [{{ join ", " $metricsExporters }}]
-    {{- if .Values.node.forwarder.redMetrics.enabled }}
+    {{- if .Values.application.REDMetrics.enabled }}
     traces/spanmetrics:
       receivers:
         - otlp/app-telemetry

--- a/charts/agent/templates/_forwarder-config.tpl
+++ b/charts/agent/templates/_forwarder-config.tpl
@@ -1,5 +1,23 @@
 {{- define "observe.daemonset.forwarder.config" -}}
 
+{{- $spanmetricsResourceAttributes := (list "service.namespace" "service.version" "deployment.environment" "k8s.pod.name" "k8s.cluster.uid" "k8s.namespace.name") -}}
+
+{{- if .Values.node.forwarder.redMetrics.enabled }}
+connectors:
+  spanmetrics:
+    aggregation_temporality: AGGREGATION_TEMPORALITY_DELTA
+    histogram:
+      exponential:
+        max_size: 100
+    dimensions:
+      {{- range $tag := $spanmetricsResourceAttributes }}
+      - name: {{ $tag }}
+      {{- end }}
+      - name: peer.db.name
+      - name: peer.messaging.system
+      - name: status.message
+{{- end }}
+
 exporters:
 {{- include "config.exporters.debug" . | nindent 2 }}
 {{- include "config.exporters.otlphttp.observe.base" . | nindent 2 }}
@@ -27,6 +45,52 @@ processors:
         - (span.end_time - span.start_time) > Duration("{{ .Values.node.forwarder.traces.maxSpanDuration }}")
 {{- else }}
 {{- fail "Invalid maxSpanDuration for forwarder red metrics, valid values are 'none' or a number with a valid time unit: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/ottl/ottlfuncs/README.md#duration" }}
+{{- end }}
+
+{{- if .Values.node.forwarder.redMetrics.enabled }}
+  # This handles schema normalization as well as moving status to attributes so it can be a dimension in spanmetrics
+  transform/shape_spans_for_red_metrics:
+    error_mode: ignore
+    trace_statements:
+      - set(span.attributes["peer.db.name"], span.attributes["db.system.name"]) where span.attributes["peer.db.name"] == nil and span.attributes["db.system.name"] != nil
+      - set(span.attributes["peer.db.name"], span.attributes["db.system"]) where span.attributes["peer.db.name"] == nil and span.attributes["db.system"] != nil
+      - set(span.attributes["status.message"], span.status.message) where span.status.message != ""
+
+  # This removes service.name for generated RED metrics associated with peer systems.
+  transform/remove_service_name_for_peer_metrics:
+    error_mode: ignore
+    metric_statements:
+      - delete_key(datapoint.attributes, "service.name") where datapoint.attributes["peer.db.name"] != nil or datapoint.attributes["peer.messaging.system"] != nil
+      - delete_key(resource.attributes, "service.name") where datapoint.attributes["peer.db.name"] != nil or datapoint.attributes["peer.messaging.system"] != nil
+
+  attributes/debug_source_span_metrics:
+    actions:
+      - action: insert
+        key: debug_source
+        value: span_metrics
+
+  # This drops spans that are not relevant for Service Explorer RED metrics.
+  filter/drop_span_kinds_other_than_server_and_consumer_and_peer_client:
+    error_mode: ignore
+    traces:
+      span:
+        - span.kind == SPAN_KIND_CLIENT and span.attributes["peer.messaging.system"] == nil and span.attributes["peer.db.name"] == nil
+        - span.kind == SPAN_KIND_UNSPECIFIED
+        - span.kind == SPAN_KIND_INTERNAL
+        - span.kind == SPAN_KIND_PRODUCER
+
+  transform/fix_red_metrics_resource_attributes:
+    error_mode: ignore
+    metric_statements:
+      # Drop all resource attributes that aren't dimensions in the spanmetrics connector.
+      {{/* The service.name is implicit in the spanmetrics connector, so don't include it in spanmetricsResourceAttributes. */}}
+      - keep_matching_keys(resource.attributes, "^(service.name|{{ join "|" $spanmetricsResourceAttributes }})")
+      # NB: the connector also sets these as resource attributes (because it copies all resource attributes from the first span in the aggregated batch).
+      #     If the connector ever changes, we need to explicitly add them back via the following:
+      # - set(resource.attributes["service.name"], datapoint.attributes["service.name"])
+
+      # Drop all attributes that are resource_attributes in the spans.
+      - delete_matching_keys(datapoint.attributes, "^(service.name|{{ join "|" $spanmetricsResourceAttributes }})")
 {{- end }}
 
 {{- include "config.processors.memory_limiter" . | nindent 2 }}
@@ -70,6 +134,8 @@ processors:
 {{- $traceExporters := (list "otlphttp/observe/forward/trace") -}}
 {{- $logsExporters := (list "otlphttp/observe/base") -}}
 {{- $metricsExporters := (list) -}}
+{{- $tracesSpanmetricsExporters := (list "spanmetrics") -}}
+{{- $metricsSpanmetricsExporters := (list "otlphttp/observe/otel_metrics") -}}
 
 {{ if eq .Values.node.forwarder.metrics.outputFormat "prometheus" -}}
   {{- $metricsExporters = concat $metricsExporters ( list "prometheusremotewrite/observe" ) | uniq }}
@@ -81,6 +147,8 @@ processors:
   {{- $traceExporters = concat $traceExporters ( list "debug/override" ) | uniq }}
   {{- $logsExporters = concat $logsExporters ( list "debug/override" ) | uniq }}
   {{- $metricsExporters = concat $metricsExporters ( list "debug/override" ) | uniq }}
+  {{- $tracesSpanmetricsExporters = concat $tracesSpanmetricsExporters ( list "debug/override" ) | uniq }}
+  {{- $metricsSpanmetricsExporters = concat $metricsSpanmetricsExporters ( list "debug/override" ) | uniq }}
 {{- end }}
 
 {{- $metricsProcessors := (list) -}}
@@ -117,6 +185,33 @@ service:
       receivers: [otlp/app-telemetry]
       processors:  [{{ join ", " $metricsProcessors }}]
       exporters: [{{ join ", " $metricsExporters }}]
+    {{- if .Values.node.forwarder.redMetrics.enabled }}
+    traces/spanmetrics:
+      receivers:
+        - otlp/app-telemetry
+      processors:
+        - memory_limiter
+        {{- if ne .Values.node.forwarder.traces.maxSpanDuration "none" }}
+        - filter/drop_long_spans
+        {{- end }}
+        # Normalize the schema before dropping spans.
+        - transform/shape_spans_for_red_metrics
+        - filter/drop_span_kinds_other_than_server_and_consumer_and_peer_client
+        - k8sattributes
+        - resource/observe_common
+      exporters: [{{ join ", " $tracesSpanmetricsExporters }}]
+    metrics/spanmetrics:
+      receivers:
+        - spanmetrics
+      processors:
+        - memory_limiter
+        - transform/remove_service_name_for_peer_metrics
+        - transform/fix_red_metrics_resource_attributes
+        - batch
+        - resource/observe_common
+        - attributes/debug_source_span_metrics
+      exporters: [{{ join ", " $metricsSpanmetricsExporters }}]
+    {{- end }}
 
 {{- include "config.service.telemetry" . | nindent 2 }}
 

--- a/charts/agent/templates/_forwarder-config.tpl
+++ b/charts/agent/templates/_forwarder-config.tpl
@@ -61,8 +61,11 @@ processors:
   transform/shape_spans_for_red_metrics:
     error_mode: ignore
     trace_statements:
+      # peer.db.name = coalesce(peer.db.name, db.system.name, db.system)
       - set(span.attributes["peer.db.name"], span.attributes["db.system.name"]) where span.attributes["peer.db.name"] == nil and span.attributes["db.system.name"] != nil
       - set(span.attributes["peer.db.name"], span.attributes["db.system"]) where span.attributes["peer.db.name"] == nil and span.attributes["db.system"] != nil
+      # deployment.environment = coalesce(deployment.environment, deployment.environment.name)
+      - set(resource.attributes["deployment.environment"], resource.attributes["deployment.environment.name"]) where resource.attributes["deployment.environment"] == nil and resource.attributes["deployment.environment.name"] != nil
       # Needed because `spanmetrics` connector can only operate on attributes or resource attributes.
       - set(span.attributes["status.message"], span.status.message) where span.status.message != ""
 

--- a/charts/agent/templates/_forwarder-config.tpl
+++ b/charts/agent/templates/_forwarder-config.tpl
@@ -1,6 +1,6 @@
 {{- define "observe.daemonset.forwarder.config" -}}
 
-{{- $spanmetricsResourceAttributes := (list "service.namespace" "service.version" "deployment.environment" "k8s.pod.name" "k8s.cluster.uid" "k8s.namespace.name") -}}
+{{- $spanmetricsResourceAttributes := (list "service.namespace" "service.version" "deployment.environment" "k8s.pod.name" "k8s.namespace.name") -}}
 
 {{- if .Values.application.REDMetrics.enabled }}
 connectors:
@@ -10,6 +10,8 @@ connectors:
       exponential:
         max_size: 100
     dimensions:
+      # This connector implicitly adds: service.name, span.name, span.kind, and status.code (which we rename to response_status)
+      # https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/connector.go#L528-L540
       {{- range $tag := $spanmetricsResourceAttributes }}
       - name: {{ $tag }}
       {{- end }}

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -105,9 +105,6 @@ node:
       outputFormat: "prometheus"
     logs:
       enabled: true
-    redMetrics:
-      # -- (bool) Whether to enable generating RED metrics from spans. See https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/spanmetricsconnector#overview
-      enabled: false
 
 application:
   # use this option to scrape prometheus metrics from pods
@@ -131,6 +128,9 @@ application:
     metricDropRegex: ""
     # metrics to keep
     metricKeepRegex: (.*)
+  REDMetrics:
+    # -- (bool) Whether to enable generating RED metrics from spans. See https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/spanmetricsconnector#overview
+    enabled: false
 
 agent:
   config:
@@ -206,7 +206,7 @@ cluster-events:
   # Same for each deployment/daemonset      #
   image:
     repository: observeinc/observe-agent
-    tag: 2.5.0
+    tag: 2.6.0
     pullPolicy: IfNotPresent
 
   command:
@@ -338,7 +338,7 @@ cluster-metrics:
   # Same for each deployment/daemonset      #
   image:
     repository: observeinc/observe-agent
-    tag: 2.5.0
+    tag: 2.6.0
     pullPolicy: IfNotPresent
 
   command:
@@ -469,7 +469,7 @@ prometheus-scraper:
   # Same for each deployment/daemonset      #
   image:
     repository: observeinc/observe-agent
-    tag: 2.5.0
+    tag: 2.6.0
     pullPolicy: IfNotPresent
 
   command:
@@ -600,7 +600,7 @@ node-logs-metrics:
   # Same for each deployment/daemonset      #
   image:
     repository: observeinc/observe-agent
-    tag: 2.5.0
+    tag: 2.6.0
     pullPolicy: IfNotPresent
 
   command:
@@ -782,7 +782,7 @@ monitor:
   # Same for each deployment/daemonset      #
   image:
     repository: observeinc/observe-agent
-    tag: 2.5.0
+    tag: 2.6.0
     pullPolicy: IfNotPresent
 
   command:
@@ -912,7 +912,7 @@ forwarder:
   # Same for each deployment/daemonset      #
   image:
     repository: observeinc/observe-agent
-    tag: 2.5.0
+    tag: 2.6.0
     pullPolicy: IfNotPresent
 
   command:

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -105,6 +105,9 @@ node:
       outputFormat: "prometheus"
     logs:
       enabled: true
+    redMetrics:
+      # -- (bool) Whether to enable generating RED metrics from spans. See https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/spanmetricsconnector#overview
+      enabled: false
 
 application:
   # use this option to scrape prometheus metrics from pods

--- a/integration/scripts/benchmark/log_generator.py
+++ b/integration/scripts/benchmark/log_generator.py
@@ -48,7 +48,7 @@ def _make_loggenerator_daemonset(
     rate = math.ceil(cluster_rate / float(num_nodes))
 
     container = client.V1Container(
-        image="460044344528.dkr.ecr.us-west-2.amazonaws.com/observemattc/loggenerator:latest",
+        image="observemattc/loggenerator:latest",
         name="loggenerator",
         command=[
             "/loggenerator",

--- a/integration/scripts/benchmark/metrics_generator.py
+++ b/integration/scripts/benchmark/metrics_generator.py
@@ -45,7 +45,7 @@ def _make_otelgen_metrics_daemonset(
     rate = math.ceil(cluster_rate / float(num_nodes))
 
     container = client.V1Container(
-        image="460044344528.dkr.ecr.us-west-2.amazonaws.com/observemattc/otelgen-test:latest",
+        image="observemattc/otelgen-test:latest",
         name="sum-metrics",
         command=[
             "/otelgen",

--- a/integration/scripts/benchmark/trace_generator.py
+++ b/integration/scripts/benchmark/trace_generator.py
@@ -48,7 +48,7 @@ def _make_otelgen_trace_daemonset(
     rate = math.ceil(cluster_rate / float(num_nodes))
 
     container = client.V1Container(
-        image="460044344528.dkr.ecr.us-west-2.amazonaws.com/observemattc/otelgen-test:latest",
+        image="observemattc/otelgen-test:latest",
         name="basic-traces",
         command=[
             "/otelgen",

--- a/integration/scripts/test_benchmark.py
+++ b/integration/scripts/test_benchmark.py
@@ -76,7 +76,7 @@ def test_benchmark(
     sample_offset_seconds = 5
 
     cluster_volume_level = VolumeLevel.LOW
-    trace_volume_level = VolumeLevel.LOW
+    trace_volume_level = VolumeLevel.MEDIUM
     metrics_volume_level = VolumeLevel.LOW
     log_volume_level = VolumeLevel.LOW
     # ================================================================================
@@ -90,12 +90,15 @@ def test_benchmark(
         pod.metadata.name for pod in pods.items if "agent" in pod.metadata.name
     ]
     agent_pods = sorted(agent_pods)
-    # The num nodes is computed assuming `num_pods = 3 + 2*num_nodes`
-    if len(agent_pods) < 5 or len(agent_pods) % 2 == 0:
+    num_deployments = 3
+    num_daemonsets = 2
+    # The num nodes is computed assuming `num_pods = num_deployments + num_daemonsets * num_nodes`
+    if len(agent_pods) < (num_deployments + num_daemonsets) or (len(agent_pods) - num_deployments) % num_daemonsets != 0:
         raise Exception(
-            "Expected to have three singleton agent deployments plus two agent daemonsets"
+            "Expected to have %d singleton agent deployments plus %d agent daemonsets, saw %d pods."
+            % (num_deployments, num_daemonsets, len(agent_pods))
         )
-    num_nodes = (len(agent_pods) - 3) // 2
+    num_nodes = (len(agent_pods) - num_deployments) // num_daemonsets
     csv = get_csv_header(agent_pods)
 
     print(


### PR DESCRIPTION
This adds an option to generate RED metrics from spans in the agent forwarder. These will be used to power our Service Explorer and eventually allow standardized trace sampling.

I ran the benchmarking test with the medium volume trace data and low for everything else. The quick results show about a ~10% difference in CPU usage and <2% increase in RAM usage.