### PR TITLE
feat: add optional max span duration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,10 @@ bump-version:
 		fi; \
 	done
 
+.PHONY: pre-commit
+pre-commit:
+	pre-commit run --show-diff-on-failure --color=always --all-files
+
 .PHONY: validate-chart-version
 validate-chart-version:
 	@for chart in $(CHARTS); do \

--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent
 description: Chart to install K8s collection stack based on Observe Agent
 type: application
-version: 0.63.1
+version: 0.64.0
 appVersion: "2.5.0"
 dependencies:
   - name: opentelemetry-collector

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -1,6 +1,6 @@
 # agent
 
-![Version: 0.63.1](https://img.shields.io/badge/Version-0.63.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.5.0](https://img.shields.io/badge/AppVersion-2.5.0-informational?style=flat-square)
+![Version: 0.64.0](https://img.shields.io/badge/Version-0.64.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.5.0](https://img.shields.io/badge/AppVersion-2.5.0-informational?style=flat-square)
 
 Chart to install K8s collection stack based on Observe Agent
 
@@ -479,6 +479,7 @@ This service is a *single-instance deployment*. It's critical that this service 
 | node.forwarder.metrics.enabled | bool | `true` |  |
 | node.forwarder.metrics.outputFormat | string | `"prometheus"` | The format of the outbound metrics from the forwarder to Observe. Valid values are "prometheus" and "otel" |
 | node.forwarder.traces.enabled | bool | `true` |  |
+| node.forwarder.traces.maxSpanDuration | string | `"1h"` | The max span duration to be considered by the agent, or "none" for no limit. Any span over this limit will be dropped. Durations must be a number with a valid time unit: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/ottl/ottlfuncs/README.md#duration |
 | node.kubeletstats.useNodeIp | bool | `false` |  |
 | node.metrics.cadvisor.enabled | bool | `false` |  |
 | node.metrics.enabled | bool | `true` |  |

--- a/charts/agent/ci/test-values.yaml
+++ b/charts/agent/ci/test-values.yaml
@@ -5,6 +5,17 @@ observe:
     create: true
     value: "fake-token"
 
+application:
+  prometheusScrape:
+    enabled: true
+    independentDeployment: true
+
+node:
+  forwarder:
+    enabled: true
+    metrics:
+      outputFormat: otel
+
 cluster:
   namespaceOverride:
     value: "testing"

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -97,6 +97,8 @@ node:
     enabled: true
     traces:
       enabled: true
+      # -- (string) The max span duration to be considered by the agent, or "none" for no limit. Any span over this limit will be dropped. Durations must be a number with a valid time unit: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/ottl/ottlfuncs/README.md#duration
+      maxSpanDuration: 1h
     metrics:
       enabled: true
       # -- (string) The format of the outbound metrics from the forwarder to Observe. Valid values are "prometheus" and "otel"


### PR DESCRIPTION
This is standard in competitor's agents, and we will need to restrict trace durations when we do tailsampling. The 1 hour default matches our current trace explorer behavior of ignoring spans longer than 1 hour.