### PR TITLE
feat: add status_code attribute to forwarded spans to coalesce various http/rpc status codes

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent
 description: Chart to install K8s collection stack based on Observe Agent
 type: application
-version: 0.64.3
+version: 0.65.0
 appVersion: "2.5.0"
 dependencies:
   - name: opentelemetry-collector

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -1,6 +1,6 @@
 # agent
 
-![Version: 0.64.3](https://img.shields.io/badge/Version-0.64.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.5.0](https://img.shields.io/badge/AppVersion-2.5.0-informational?style=flat-square)
+![Version: 0.65.0](https://img.shields.io/badge/Version-0.65.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.5.0](https://img.shields.io/badge/AppVersion-2.5.0-informational?style=flat-square)
 
 Chart to install K8s collection stack based on Observe Agent
 

--- a/charts/agent/templates/_forwarder-config.tpl
+++ b/charts/agent/templates/_forwarder-config.tpl
@@ -40,6 +40,16 @@ processors:
 {{- include "config.processors.deltatocumulative" . | nindent 2 }}
 
 {{- include "config.processors.resource.observe_common" . | nindent 2 }}
+
+  transform/add_span_status_code:
+    error_mode: ignore
+    trace_statements:
+      - set(span.attributes["status_code"], Int(span.attributes["rpc.grpc.status_code"])) where span.attributes["status_code"] == nil and span.attributes["rpc.grpc.status_code"] != nil
+      - set(span.attributes["status_code"], Int(span.attributes["grpc.status_code"])) where span.attributes["status_code"] == nil and span.attributes["grpc.status_code"] != nil
+      - set(span.attributes["status_code"], Int(span.attributes["rpc.status_code"])) where span.attributes["status_code"] == nil and span.attributes["rpc.status_code"] != nil
+      - set(span.attributes["status_code"], Int(span.attributes["http.status_code"])) where span.attributes["status_code"] == nil and span.attributes["http.status_code"] != nil
+      - set(span.attributes["status_code"], Int(span.attributes["http.response.status_code"])) where span.attributes["status_code"] == nil and span.attributes["http.response.status_code"] != nil
+
   # attributes to append to objects
   attributes/debug_source_app_traces:
     actions:
@@ -92,6 +102,7 @@ service:
         - filter/drop_long_spans
         {{- end }}
         - memory_limiter
+        - transform/add_span_status_code
         - k8sattributes
         - batch
         - resourcedetection/cloud


### PR DESCRIPTION
We do this in a dataset view for trace explorer. We want this same logic present in agent RED metrics calculations, so the plan is to move this to the agent for all spans for consistency.