### PR TITLE
feat: add comments to values.yaml detailing how to install the chart in a serverless k8s environment

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent
 description: Chart to install K8s collection stack based on Observe Agent
 type: application
-version: 0.66.1
+version: 0.67.0
 appVersion: "2.5.0"
 dependencies:
   - name: opentelemetry-collector

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -1,6 +1,6 @@
 # agent
 
-![Version: 0.66.1](https://img.shields.io/badge/Version-0.66.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.5.0](https://img.shields.io/badge/AppVersion-2.5.0-informational?style=flat-square)
+![Version: 0.67.0](https://img.shields.io/badge/Version-0.67.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.5.0](https://img.shields.io/badge/AppVersion-2.5.0-informational?style=flat-square)
 
 Chart to install K8s collection stack based on Observe Agent
 
@@ -267,7 +267,7 @@ This service is a *single-instance deployment*. It's critical that this service 
 | forwarder.livenessProbe.httpGet.port | int | `13133` |  |
 | forwarder.livenessProbe.initialDelaySeconds | int | `30` |  |
 | forwarder.livenessProbe.periodSeconds | int | `5` |  |
-| forwarder.mode | string | `"daemonset"` |  |
+| forwarder.mode | string | `"daemonset"` | The forwarder is run as a daemonset by default, but can be run as a deployment by setting mode to "deployment". Deployment mode must be used when running in a serverless environment (ex: EKS Fargate) where daemonsets are not supported. |
 | forwarder.nameOverride | string | `"forwarder"` | --------------------------------------- # Different for each deployment/daemonset # |
 | forwarder.namespaceOverride | string | `"observe"` |  |
 | forwarder.networkPolicy.egressRules[0] | object | `{}` |  |
@@ -285,6 +285,7 @@ This service is a *single-instance deployment*. It's critical that this service 
 | forwarder.readinessProbe.httpGet.port | int | `13133` |  |
 | forwarder.readinessProbe.initialDelaySeconds | int | `30` |  |
 | forwarder.readinessProbe.periodSeconds | int | `5` |  |
+| forwarder.replicaCount | int | `1` | The `replicaCount` is only used when `mode` is set to "deployment". It is ignored when `mode` is set to "daemonset". In deployment mode, this sets the number of replicas (ie the number of forwarder pods to run). |
 | forwarder.resources.limits.memory | string | `"512Mi"` |  |
 | forwarder.resources.requests.cpu | string | `"300m"` |  |
 | forwarder.resources.requests.memory | string | `"512Mi"` |  |
@@ -474,7 +475,7 @@ This service is a *single-instance deployment*. It's critical that this service 
 | node.containers.logs.startAt | string | `"end"` |  |
 | node.containers.metrics.enabled | bool | `true` |  |
 | node.containers.metrics.interval | string | `"60s"` |  |
-| node.enabled | bool | `true` |  |
+| node.enabled | bool | `true` | Enables the node-logs-metrics agent daemonset for collection of node logs and metrics. The nodes on which metrics and logs are collected can be configured via `affinity` in the `node-logs-metrics` section below. This should be set to false to disable the node-log-metrics daemonset when running in a serverless environment (ex: EKS Fargate). |
 | node.forwarder.enabled | bool | `true` |  |
 | node.forwarder.logs.enabled | bool | `true` |  |
 | node.forwarder.metrics.enabled | bool | `true` |  |

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -39,8 +39,9 @@ cluster:
     value: ""
 
 node:
-  # enables agent for collection of node logs and metrics
-  # what nodes metrics and logs are collected from is configured with affinity in node-logs-metrics section below
+  # -- Enables the node-logs-metrics agent daemonset for collection of node logs and metrics.
+  # The nodes on which metrics and logs are collected can be configured via `affinity` in the `node-logs-metrics` section below.
+  # This should be set to false to disable the node-log-metrics daemonset when running in a serverless environment (ex: EKS Fargate).
   enabled: true
   # collects host level metrics from node
   metrics:
@@ -920,7 +921,14 @@ monitor:
   # ----------------------------------------- #
 
 forwarder:
+  # -- The forwarder is run as a daemonset by default, but can be run as a deployment by setting mode to "deployment". Deployment mode
+  # must be used when running in a serverless environment (ex: EKS Fargate) where daemonsets are not supported.
   mode: daemonset
+
+  # -- The `replicaCount` is only used when `mode` is set to "deployment". It is ignored when `mode` is set to "daemonset".
+  # In deployment mode, this sets the number of replicas (ie the number of forwarder pods to run).
+  replicaCount: 1
+
   # ----------------------------------------- #
   # Different for each deployment/daemonset #
   nameOverride: "forwarder"


### PR DESCRIPTION
I ran this locally with the following values file:
```yaml
node:
  enabled: false
  forwarder:
    enabled: true

forwarder:
  mode: deployment
  replicaCount: 2
```

I used `helm template` to diff the generated k8s files, and (with a bit of reordering to help `diff` out), the result is:
```diff
diff --git a/helm/export.yaml b/helm/export.yaml
index bb2a508..a52bf6d 100644
--- a/helm/export.yaml
+++ b/helm/export.yaml
@@ -87,13 +87,13 @@ metadata:
     app.kubernetes.io/instance: observe-agent
     app.kubernetes.io/version: "0.126.0"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: agent-collector
+    app.kubernetes.io/component: standalone-collector
 spec:
   podSelector:
     matchLabels:
       app.kubernetes.io/name: forwarder
       app.kubernetes.io/instance: observe-agent
-      component: agent-collector
+      component: standalone-collector
   ingress:
     - ports:
         - port: 6831
@@ -2033,8 +2033,8 @@ metadata:
     app.kubernetes.io/instance: observe-agent
     app.kubernetes.io/version: "0.126.0"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: agent-collector
-    component: agent-collector
+    app.kubernetes.io/component: standalone-collector
+    component: standalone-collector
 spec:
   type: ClusterIP
   ports:
@@ -2071,8 +2071,8 @@ spec:
   selector:
     app.kubernetes.io/name: forwarder
     app.kubernetes.io/instance: observe-agent
-    component: agent-collector
-  internalTrafficPolicy: Local
+    component: standalone-collector
+  internalTrafficPolicy: Cluster
 ---
 # Source: agent/charts/monitor/templates/service.yaml
 apiVersion: v1
@@ -2180,11 +2180,11 @@ spec:
     component: standalone-collector
   internalTrafficPolicy: Cluster
 ---
-# Source: agent/charts/forwarder/templates/daemonset.yaml
+# Source: agent/charts/forwarder/templates/deployment.yaml
 apiVersion: apps/v1
-kind: DaemonSet
+kind: Deployment
 metadata:
-  name: observe-agent-forwarder-agent
+  name: observe-agent-forwarder
   namespace: observe
   labels:
     helm.sh/chart: forwarder-0.125.0
@@ -2192,14 +2192,16 @@ metadata:
     app.kubernetes.io/instance: observe-agent
     app.kubernetes.io/version: "0.126.0"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: agent-collector
+    app.kubernetes.io/component: standalone-collector
 spec:
+  replicas: 2
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       app.kubernetes.io/name: forwarder
       app.kubernetes.io/instance: observe-agent
-      component: agent-collector
-  updateStrategy:
+      component: standalone-collector
+  strategy:
     type: RollingUpdate
   template:
     metadata:
@@ -2215,7 +2217,7 @@ spec:
       labels:
         app.kubernetes.io/name: forwarder
         app.kubernetes.io/instance: observe-agent
-        component: agent-collector
+        component: standalone-collector
         
     spec:
```

The running pods look like this in minikube (note that I configured 2 forwarder pods to test):
```
$ kubectl -n observe get pods
NAME                                               READY   STATUS    RESTARTS   AGE
observe-agent-cluster-events-cc597475f-kvp6d       1/1     Running   0          62s
observe-agent-cluster-metrics-84448b9945-5bfz4     1/1     Running   0          62s
observe-agent-forwarder-7bf5d995bb-l75bt           1/1     Running   0          62s
observe-agent-forwarder-7bf5d995bb-rhlzb           1/1     Running   0          62s
observe-agent-monitor-578bdb66f7-nsghd             1/1     Running   0          62s
observe-agent-prometheus-scraper-c447546d6-njl6s   1/1     Running   0          62s
```

Trace data still flows with no change needed upstream (ie my OTel demo installation remained the same); the service name doesn't change, and the traffic policy is updated to accept cluster-wide data. The k8s explorer partially functions, but a lot of metrics are missing without the `node-logs-metrics` daemonset.