### PR TITLE
fix: only create prometheus scraper configmap when the deployment is enabled

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent
 description: Chart to install K8s collection stack based on Observe Agent
 type: application
-version: 0.66.0
+version: 0.66.1
 appVersion: "2.5.0"
 dependencies:
   - name: opentelemetry-collector

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -1,6 +1,6 @@
 # agent
 
-![Version: 0.66.0](https://img.shields.io/badge/Version-0.66.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.5.0](https://img.shields.io/badge/AppVersion-2.5.0-informational?style=flat-square)
+![Version: 0.66.1](https://img.shields.io/badge/Version-0.66.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.5.0](https://img.shields.io/badge/AppVersion-2.5.0-informational?style=flat-square)
 
 Chart to install K8s collection stack based on Observe Agent
 

--- a/charts/agent/templates/prometheus-scraper-configmap.yaml
+++ b/charts/agent/templates/prometheus-scraper-configmap.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.cluster.metrics.enabled }}
+{{ if .Values.application.prometheusScrape.independentDeployment }}
 apiVersion: v1
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
I think this was a copy paste error.