### PR TITLE
fix: handle null service resource attributes in RED metrics

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent
 description: Chart to install K8s collection stack based on Observe Agent
 type: application
-version: 0.67.0
+version: 0.67.1
 appVersion: "2.5.0"
 dependencies:
   - name: opentelemetry-collector

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -1,6 +1,6 @@
 # agent
 
-![Version: 0.67.0](https://img.shields.io/badge/Version-0.67.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.5.0](https://img.shields.io/badge/AppVersion-2.5.0-informational?style=flat-square)
+![Version: 0.67.1](https://img.shields.io/badge/Version-0.67.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.5.0](https://img.shields.io/badge/AppVersion-2.5.0-informational?style=flat-square)
 
 Chart to install K8s collection stack based on Observe Agent
 

--- a/charts/agent/templates/_config-pipelines.tpl
+++ b/charts/agent/templates/_config-pipelines.tpl
@@ -17,6 +17,7 @@ traces/spanmetrics:
     - filter/drop_span_kinds_other_than_server_and_consumer_and_peer_client
     - transform/shape_spans_for_red_metrics
     - transform/add_span_status_code
+    - resource/add_empty_service_attributes
     - k8sattributes
   exporters: [{{ join ", " $tracesSpanmetricsExporters }}]
 metrics/spanmetrics:

--- a/charts/agent/templates/_config-processors.tpl
+++ b/charts/agent/templates/_config-processors.tpl
@@ -125,6 +125,20 @@ filter/drop_long_spans:
 {{- end }}
 {{- end -}}
 
+{{- define "config.processors.attributes.add_empty_service_attributes" -}}
+resource/add_empty_service_attributes:
+    attributes:
+        - action: insert
+          key: service.name
+          value: ""
+        - action: insert
+          key: service.namespace
+          value: ""
+        - action: insert
+          key: deployment.environment
+          value: ""
+{{- end -}}
+
 {{- define "config.processors.transform.add_span_status_code" -}}
 transform/add_span_status_code:
   error_mode: ignore

--- a/charts/agent/templates/_forwarder-config.tpl
+++ b/charts/agent/templates/_forwarder-config.tpl
@@ -30,6 +30,7 @@ processors:
 {{- include "config.processors.resource.observe_common" . | nindent 2 }}
 {{- include "config.processors.filter.drop_long_spans" . | nindent 2 }}
 {{- include "config.processors.transform.add_span_status_code" . | nindent 2 }}
+{{- include "config.processors.attributes.add_empty_service_attributes" . | nindent 2 }}
 
 {{- if .Values.application.REDMetrics.enabled }}
 {{- include "config.processors.RED_metrics" . | nindent 2 }}
@@ -88,6 +89,7 @@ service:
         {{- end }}
         - memory_limiter
         - transform/add_span_status_code
+        - resource/add_empty_service_attributes
         - k8sattributes
         - batch
         - resourcedetection/cloud


### PR DESCRIPTION
Using empty string instead of null greatly simplifies the OPAL handling.

Agent PR: https://github.com/observeinc/observe-agent/pull/239