### PR TITLE
fix: improve RED metric attribute naming

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent
 description: Chart to install K8s collection stack based on Observe Agent
 type: application
-version: 0.67.1
+version: 0.67.2
 appVersion: "2.5.0"
 dependencies:
   - name: opentelemetry-collector

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -1,6 +1,6 @@
 # agent
 
-![Version: 0.67.1](https://img.shields.io/badge/Version-0.67.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.5.0](https://img.shields.io/badge/AppVersion-2.5.0-informational?style=flat-square)
+![Version: 0.67.2](https://img.shields.io/badge/Version-0.67.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.5.0](https://img.shields.io/badge/AppVersion-2.5.0-informational?style=flat-square)
 
 Chart to install K8s collection stack based on Observe Agent
 

--- a/charts/agent/templates/_config-connectors.tpl
+++ b/charts/agent/templates/_config-connectors.tpl
@@ -8,13 +8,13 @@ spanmetrics:
     exponential:
       max_size: 100
   dimensions:
-    # This connector implicitly adds: service.name, span.name, span.kind, and status.code (which we rename to response_status)
+    # This connector implicitly adds: service.name, span.name, span.kind, and status.code (which we rename to otel.status_code)
     # https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/connector.go#L528-L540
     {{- range $tag := $spanmetricsResourceAttributes }}
     - name: {{ $tag }}
     {{- end }}
     - name: peer.db.name
     - name: peer.messaging.system
-    - name: status.message
-    - name: status_code
+    - name: otel.status_description
+    - name: observe.status_code
 {{- end -}}

--- a/charts/agent/templates/_config-processors.tpl
+++ b/charts/agent/templates/_config-processors.tpl
@@ -143,11 +143,11 @@ resource/add_empty_service_attributes:
 transform/add_span_status_code:
   error_mode: ignore
   trace_statements:
-    - set(span.attributes["status_code"], Int(span.attributes["rpc.grpc.status_code"])) where span.attributes["status_code"] == nil and span.attributes["rpc.grpc.status_code"] != nil
-    - set(span.attributes["status_code"], Int(span.attributes["grpc.status_code"])) where span.attributes["status_code"] == nil and span.attributes["grpc.status_code"] != nil
-    - set(span.attributes["status_code"], Int(span.attributes["rpc.status_code"])) where span.attributes["status_code"] == nil and span.attributes["rpc.status_code"] != nil
-    - set(span.attributes["status_code"], Int(span.attributes["http.status_code"])) where span.attributes["status_code"] == nil and span.attributes["http.status_code"] != nil
-    - set(span.attributes["status_code"], Int(span.attributes["http.response.status_code"])) where span.attributes["status_code"] == nil and span.attributes["http.response.status_code"] != nil
+    - set(span.attributes["observe.status_code"], Int(span.attributes["rpc.grpc.status_code"])) where span.attributes["status_code"] == nil and span.attributes["rpc.grpc.status_code"] != nil
+    - set(span.attributes["observe.status_code"], Int(span.attributes["grpc.status_code"])) where span.attributes["status_code"] == nil and span.attributes["grpc.status_code"] != nil
+    - set(span.attributes["observe.status_code"], Int(span.attributes["rpc.status_code"])) where span.attributes["status_code"] == nil and span.attributes["rpc.status_code"] != nil
+    - set(span.attributes["observe.status_code"], Int(span.attributes["http.status_code"])) where span.attributes["status_code"] == nil and span.attributes["http.status_code"] != nil
+    - set(span.attributes["observe.status_code"], Int(span.attributes["http.response.status_code"])) where span.attributes["status_code"] == nil and span.attributes["http.response.status_code"] != nil
 {{- end -}}
 
 {{- define "config.processors.RED_metrics" -}}
@@ -170,7 +170,7 @@ transform/shape_spans_for_red_metrics:
     # deployment.environment = coalesce(deployment.environment, deployment.environment.name)
     - set(resource.attributes["deployment.environment"], resource.attributes["deployment.environment.name"]) where resource.attributes["deployment.environment"] == nil and resource.attributes["deployment.environment.name"] != nil
     # Needed because `spanmetrics` connector can only operate on attributes or resource attributes.
-    - set(span.attributes["status.message"], span.status.message) where span.status.message != ""
+    - set(span.attributes["otel.status_description"], span.status.message) where span.status.message != ""
 
 # This regroups the metrics by the peer attributes so we can remove `service.name` from the resource when these metric attributes are present
 # NB: these will be deleted from the metric attributes and added to the resource.
@@ -214,6 +214,7 @@ transform/fix_red_metrics_resource_attributes:
     - delete_matching_keys(datapoint.attributes, "^(service.name|{{ join "|" $spanmetricsResourceAttributes }})")
 
     # Rename status.code to response_status to be consistent with Trace Explorer and disambiguate from status_code (with an underscore).
-    - set(datapoint.attributes["response_status"], datapoint.attributes["status.code"])
+    - set(datapoint.attributes["otel.status_code"], "OK") where datapoint.attributes["status.code"] == "STATUS_CODE_OK"
+    - set(datapoint.attributes["otel.status_code"], "ERROR") where datapoint.attributes["status.code"] == "STATUS_CODE_ERROR"
     - delete_key(datapoint.attributes, "status.code")
 {{- end -}}


### PR DESCRIPTION
Renames:
  - `attributes[response_status]` —> `attributes[otel.status_code]` Semconv: https://opentelemetry.io/docs/specs/semconv/registry/attributes/otel/#otel-status-code
      - The values will be fixed as well:
          - `"STATUS_CODE_ERROR"` —> `"ERROR"`
          - `"STATUS_CODE_OK"` —> `"OK"`
          - `"STATUS_CODE_UNSET"` —> `null`
  - `attributes[status.message]` —> `attributes[otel.status_description]` Semconv: https://opentelemetry.io/docs/specs/semconv/registry/attributes/otel/#otel-status-description
  - `attributes[status_code]` —> `attributes[observe.status_code]` (no semconv, this is custom)
      - This is computed strictly by looking at five other OTel status_code attributes and coalescing