### PR TITLE
fix: only check for trace sampling to be enabled when the gateway is enabled

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent
 description: Chart to install K8s collection stack based on Observe Agent
 type: application
-version: 0.70.0
+version: 0.70.1
 appVersion: "2.8.1"
 dependencies:
   - name: opentelemetry-collector

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -1,6 +1,6 @@
 # agent
 
-![Version: 0.70.0](https://img.shields.io/badge/Version-0.70.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.1](https://img.shields.io/badge/AppVersion-2.8.1-informational?style=flat-square)
+![Version: 0.70.1](https://img.shields.io/badge/Version-0.70.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.1](https://img.shields.io/badge/AppVersion-2.8.1-informational?style=flat-square)
 
 Chart to install K8s collection stack based on Observe Agent
 

--- a/charts/agent/templates/_config-pipelines.tpl
+++ b/charts/agent/templates/_config-pipelines.tpl
@@ -14,7 +14,7 @@ traces/spanmetrics:
     {{- if ne .Values.node.forwarder.traces.maxSpanDuration "none" }}
     - filter/drop_long_spans
     {{- end }}
-    {{- if not .Values.gatewayDeployment.traceSampling.enabled }}
+    {{- if (or (not .Values.gatewayDeployment.enabled) (not .Values.gatewayDeployment.traceSampling.enabled)) }}
     # This drops RED metric data for span kinds that are not relevant to Service Explorer. When we sample spans, we want to
     # to generate RED metrics for all span kinds to ensure we have full visibility into the span data.
     - filter/drop_span_kinds_other_than_server_and_consumer_and_peer_client

--- a/charts/agent/templates/_config-processors.tpl
+++ b/charts/agent/templates/_config-processors.tpl
@@ -197,7 +197,7 @@ transform/remove_service_name_for_peer_metrics:
   metric_statements:
     - delete_key(resource.attributes, "service.name") where datapoint.attributes["peer.db.name"] != nil or datapoint.attributes["peer.messaging.system"] != nil
 
-{{- if not .Values.gatewayDeployment.traceSampling.enabled }}
+{{- if (or (not .Values.gatewayDeployment.enabled) (not .Values.gatewayDeployment.traceSampling.enabled)) }}
 # This drops spans (and thus RED metric data) for span kinds that are not relevant to Service Explorer. When we sample spans, we want to
 # to generate RED metrics for all span kinds to ensure we have full visibility into the span data.
 filter/drop_span_kinds_other_than_server_and_consumer_and_peer_client:

--- a/charts/agent/templates/cluster-role.yaml
+++ b/charts/agent/templates/cluster-role.yaml
@@ -32,14 +32,6 @@ rules:
     - get
     - list
     - watch
-  - apiGroups:
-    - ""
-    resources:
-    - endpoints
-    verbs:
-    - list
-    - watch
-    - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
The default for trace sampling is true, so we always need to check whether or not the gateway is enabled before checking for trace sampling.