### PR TITLE
fix: allow cadvisor prometheus pipeline without an independent deployment

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent
 description: Chart to install K8s collection stack based on Observe Agent
 type: application
-version: 0.70.1
+version: 0.70.2
 appVersion: "2.8.1"
 dependencies:
   - name: opentelemetry-collector

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -1,6 +1,6 @@
 # agent
 
-![Version: 0.70.1](https://img.shields.io/badge/Version-0.70.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.1](https://img.shields.io/badge/AppVersion-2.8.1-informational?style=flat-square)
+![Version: 0.70.2](https://img.shields.io/badge/Version-0.70.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.1](https://img.shields.io/badge/AppVersion-2.8.1-informational?style=flat-square)
 
 Chart to install K8s collection stack based on Observe Agent
 

--- a/charts/agent/templates/_cluster-metrics-config.tpl
+++ b/charts/agent/templates/_cluster-metrics-config.tpl
@@ -1,5 +1,7 @@
 {{- define "observe.deployment.clusterMetrics.config" -}}
 
+{{- $podMetrics := (and (eq .Values.application.prometheusScrape.enabled true) (eq .Values.application.prometheusScrape.independentDeployment false)) }}
+
 exporters:
 {{- include "config.exporters.debug" . | nindent 2 }}
 {{- include "config.exporters.prometheusremotewrite" . | nindent 2 }}
@@ -11,36 +13,35 @@ receivers:
     metadata_collection_interval: 5m
     auth_type: serviceAccount
     node_conditions_to_report:
-    - Ready
-    - MemoryPressure
-    - DiskPressure
+      - Ready
+      - MemoryPressure
+      - DiskPressure
     allocatable_types_to_report:
-    - cpu
-    - memory
-    - storage
-    - ephemeral-storage
+      - cpu
+      - memory
+      - storage
+      - ephemeral-storage
     # defaults and optional - https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/k8sclusterreceiver/documentation.md
     metrics:
       k8s.node.condition:
         enabled: true
 
-{{- if and (eq .Values.application.prometheusScrape.enabled true) (eq .Values.application.prometheusScrape.independentDeployment false) }}
+{{- if $podMetrics }}
 {{- include "config.receivers.prometheus.pod_metrics" . | nindent 2 }}
+{{- include "config.receivers.prometheus.cadvisor" . | nindent 2 }}
 {{- end }}
 
 processors:
 {{- include "config.processors.memory_limiter" . | nindent 2 }}
-
 {{- include "config.processors.batch" . | nindent 2 }}
-
 {{- include "config.processors.attributes.k8sattributes" (merge . (dict "target" "cluster_metrics")) | nindent 2 }}
 {{- include "config.processors.attributes.drop_container_info" . | nindent 2 }}
 {{- include "config.processors.attributes.drop_service_name" . | nindent 2 }}
-
 {{- include "config.processors.resource.observe_common" . | nindent 2 }}
 
-{{- if and (eq .Values.application.prometheusScrape.enabled true) (eq .Values.application.prometheusScrape.independentDeployment false) }}
+{{- if $podMetrics }}
 {{- include "config.processors.attributes.pod_metrics" . | nindent 2 }}
+{{- include "config.processors.attributes.cadvisor_metrics" . | nindent 2 }}
 {{- end }}
 
   # attributes to append to objects
@@ -58,16 +59,12 @@ processors:
 
 service:
   pipelines:
-      metrics:
-        receivers: [k8s_cluster]
-        processors: [memory_limiter, k8sattributes, batch, resource/observe_common, resource/drop_container_info, attributes/debug_source_cluster_metrics]
-        exporters: [{{ join ", " $metricsExporters }}]
-{{- if and (eq .Values.application.prometheusScrape.enabled true) (eq .Values.application.prometheusScrape.independentDeployment false) }}
-      metrics/pod_metrics:
-        receivers: [prometheus/pod_metrics]
-        # Drop the service.name resource attribute (which is set to the prom scrape job name) before the k8sattributes processor
-        processors: [memory_limiter, resource/drop_service_name, k8sattributes, batch, resource/observe_common, attributes/debug_source_pod_metrics]
-        exporters: [{{ join ", " $metricsExporters }}]
-{{- end }}
+    metrics:
+      receivers: [k8s_cluster]
+      processors: [memory_limiter, k8sattributes, batch, resource/observe_common, resource/drop_container_info, attributes/debug_source_cluster_metrics]
+      exporters: [{{ join ", " $metricsExporters }}]
+    {{- if $podMetrics }}
+    {{- include "config.pipelines.prometheus_scrapers" . | nindent 4 }}
+    {{- end }}
 
 {{- end }}

--- a/charts/agent/templates/_config-exporters.tpl
+++ b/charts/agent/templates/_config-exporters.tpl
@@ -93,7 +93,3 @@ debug/override:
     sampling_initial: 2
     sampling_thereafter: 1
 {{- end -}}
-
-{{- define "config.exporters.nop" -}}
-nop:
-{{- end -}}

--- a/charts/agent/templates/_config-processors.tpl
+++ b/charts/agent/templates/_config-processors.tpl
@@ -102,6 +102,16 @@ attributes/debug_source_pod_metrics:
       value: pod_metrics
 {{- end -}}
 
+{{- define "config.processors.attributes.cadvisor_metrics" -}}
+{{- if .Values.node.metrics.cadvisor.enabled }}
+attributes/debug_source_cadvisor_metrics:
+  actions:
+    - key: debug_source
+      action: insert
+      value: cadvisor_metrics
+{{- end -}}
+{{- end -}}
+
 {{- define "config.processors.attributes.drop_container_info" -}}
 resource/drop_container_info:
   attributes:

--- a/charts/agent/templates/_prometheus-scraper-config.tpl
+++ b/charts/agent/templates/_prometheus-scraper-config.tpl
@@ -1,61 +1,39 @@
 {{- define "observe.deployment.prometheusScraper.config" -}}
 
 exporters:
-{{- include "config.exporters.debug" . | nindent 2 }}
-{{- include "config.exporters.prometheusremotewrite" . | nindent 2 }}
-{{- include "config.exporters.nop" . | nindent 2 }}
+{{- if eq .Values.application.prometheusScrape.enabled true }}
+  {{- include "config.exporters.debug" . | nindent 2 }}
+  {{- include "config.exporters.prometheusremotewrite" . | nindent 2 }}
+{{- else }}
+  nop:
+{{- end }}
 
 receivers:
+{{- if eq .Values.application.prometheusScrape.enabled true }}
+  {{- include "config.receivers.prometheus.pod_metrics" . | nindent 2 }}
+  {{- include "config.receivers.prometheus.cadvisor" . | nindent 2 }}
+{{- else }}
   nop:
-{{- include "config.receivers.prometheus.pod_metrics" . | nindent 2 }}
-{{- include "config.receivers.prometheus.cadvisor" . | nindent 2 }}
+{{- end }}
 
 processors:
-{{- include "config.processors.memory_limiter" . | nindent 2 }}
-
-{{- include "config.processors.batch" . | nindent 2 }}
-
-{{- include "config.processors.attributes.k8sattributes" . | nindent 2 }}
-
-{{- include "config.processors.resource.observe_common" . | nindent 2 }}
-
-{{- include "config.processors.attributes.pod_metrics" . | nindent 2 }}
-
-{{- include "config.processors.attributes.drop_service_name" . | nindent 2 }}
-
-  attributes/debug_source_cadvisor_metrics:
-    actions:
-      - key: debug_source
-        action: insert
-        value: cadvisor_metrics
-
-# Set up receivers
-{{- $podMetricsReceivers := (list "prometheus/pod_metrics") -}}
-{{- if eq .Values.application.prometheusScrape.enabled false}}
-  {{- $podMetricsReceivers = ( list "nop" ) }}
-{{- end }}
-
-# Set up exporters
-{{- $podMetricsExporters := (list "prometheusremotewrite/observe") -}}
-{{- if eq .Values.application.prometheusScrape.enabled false}}
-  {{- $podMetricsExporters = ( list "nop" ) }}
-{{- end }}
-{{- if eq .Values.agent.config.global.debug.enabled true }}
-  {{- $podMetricsExporters = concat $podMetricsExporters ( list "debug/override" ) | uniq }}
+{{- if eq .Values.application.prometheusScrape.enabled true }}
+  {{- include "config.processors.memory_limiter" . | nindent 2 }}
+  {{- include "config.processors.batch" . | nindent 2 }}
+  {{- include "config.processors.attributes.k8sattributes" . | nindent 2 }}
+  {{- include "config.processors.resource.observe_common" . | nindent 2 }}
+  {{- include "config.processors.attributes.pod_metrics" . | nindent 2 }}
+  {{- include "config.processors.attributes.cadvisor_metrics" . | nindent 2 }}
+  {{- include "config.processors.attributes.drop_service_name" . | nindent 2 }}
 {{- end }}
 
 service:
   pipelines:
+    {{- if eq .Values.application.prometheusScrape.enabled true }}
+    {{- include "config.pipelines.prometheus_scrapers" . | nindent 4 }}
+    {{- else }}
     metrics/pod_metrics:
-      receivers: [{{ join ", " $podMetricsReceivers }}]
-      # Drop the service.name resource attribute (which is set to the prom scrape job name) before the k8sattributes processor
-      processors: [memory_limiter, resource/drop_service_name, k8sattributes, batch, resource/observe_common, attributes/debug_source_pod_metrics]
-      exporters: [{{ join ", " $podMetricsExporters }}]
-    {{- if .Values.node.metrics.cadvisor.enabled }}
-    metrics/cadvisor:
-      receivers: [prometheus/cadvisor]
-      processors: [memory_limiter, k8sattributes, batch, resource/observe_common, attributes/debug_source_cadvisor_metrics]
-      exporters: [{{ join ", " $podMetricsExporters }}]
-    {{- end -}}
-
+      receivers: [nop]
+      exporters: [nop]
+    {{- end }}
 {{- end }}


### PR DESCRIPTION
I tested the following configurations for this change and the current release:

| Setting | 1 | 2 | 3 | 4 | 5 |
| --- | --- | --- | --- | --- | --- |
| prometheus enabled | ✅ | ✅ | ✅ | ✅ | ❌ |
| independent deployment | ✅ | ✅ | ❌ | ❌ | ❌ |
| cadvisor enabled | ✅ | ❌ | ✅ | ❌ | ❌ |

There were no diffs except in case of 2, 3 (as expected):
2- the unused `attributes/debug_source_cadvisor_metrics` processor is deleted
3- the cadvisor receiver, attributes processor, and pipeline are added to the cluster-metrics deployment