### PR TITLE
fix: Treat "nil" ready replicas as 0

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent
 description: Chart to install K8s collection stack based on Observe Agent
 type: application
-version: 0.70.2
+version: 0.70.3
 appVersion: "2.8.1"
 dependencies:
   - name: opentelemetry-collector

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -1,6 +1,6 @@
 # agent
 
-![Version: 0.70.2](https://img.shields.io/badge/Version-0.70.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.1](https://img.shields.io/badge/AppVersion-2.8.1-informational?style=flat-square)
+![Version: 0.70.3](https://img.shields.io/badge/Version-0.70.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.1](https://img.shields.io/badge/AppVersion-2.8.1-informational?style=flat-square)
 
 Chart to install K8s collection stack based on Observe Agent
 

--- a/charts/agent/templates/_cluster-events-config.tpl
+++ b/charts/agent/templates/_cluster-events-config.tpl
@@ -183,7 +183,7 @@ processors:
           - set(attributes["observe_transform"]["facets"]["desiredReplicas"], body["spec"]["replicas"])
           # custom
           - set(attributes["observe_transform"]["facets"]["status"], "Healthy")
-          - set(attributes["observe_transform"]["facets"]["status"], "Unhealthy") where attributes["observe_transform"]["facets"]["readyReplicas"] != attributes["observe_transform"]["facets"]["desiredReplicas"]
+          - set(attributes["observe_transform"]["facets"]["status"], "Unhealthy") where attributes["observe_transform"]["facets"]["desiredReplicas"] != nil and attributes["observe_transform"]["facets"]["readyReplicas"] != attributes["observe_transform"]["facets"]["desiredReplicas"]
       # ReplicaSet
       - context: log
         conditions:
@@ -199,7 +199,7 @@ processors:
           - set(attributes["observe_transform"]["facets"]["readyReplicas"], body["status"]["readyReplicas"])
           - set(attributes["observe_transform"]["facets"]["readyReplicas"], 0) where attributes["observe_transform"]["facets"]["readyReplicas"] == nil
           - set(attributes["observe_transform"]["facets"]["status"], "Healthy")
-          - set(attributes["observe_transform"]["facets"]["status"], "Unhealthy") where attributes["observe_transform"]["facets"]["readyReplicas"] != attributes["observe_transform"]["facets"]["desiredReplicas"]
+          - set(attributes["observe_transform"]["facets"]["status"], "Unhealthy") where attributes["observe_transform"]["facets"]["desiredReplicas"] != nil and attributes["observe_transform"]["facets"]["readyReplicas"] != attributes["observe_transform"]["facets"]["desiredReplicas"]
       # Event
       - context: log
         conditions:
@@ -266,7 +266,7 @@ processors:
           - set(attributes["observe_transform"]["facets"]["numberUnavailable"], body["status"]["numberUnavailable"])
           - set(attributes["observe_transform"]["facets"]["numberMisscheduled"], body["status"]["numberMisscheduled"])
           - set(attributes["observe_transform"]["facets"]["status"], "Healthy")
-          - set(attributes["observe_transform"]["facets"]["status"], "Unhealthy") where attributes["observe_transform"]["facets"]["numberReady"] != attributes["observe_transform"]["facets"]["desiredNumberScheduled"]
+          - set(attributes["observe_transform"]["facets"]["status"], "Unhealthy") where attributes["observe_transform"]["facets"]["desiredNumberScheduled"] != nil and attributes["observe_transform"]["facets"]["numberReady"] != attributes["observe_transform"]["facets"]["desiredNumberScheduled"]
       # StatefulSet
       - context: log
         conditions:
@@ -284,7 +284,7 @@ processors:
           - set(attributes["observe_transform"]["facets"]["currentReplicas"], body["status"]["currentReplicas"])
           - set(attributes["observe_transform"]["facets"]["readyReplicas"], body["status"]["readyReplicas"])
           - set(attributes["observe_transform"]["facets"]["status"], "Healthy")
-          - set(attributes["observe_transform"]["facets"]["status"], "Unhealthy") where attributes["observe_transform"]["facets"]["readyReplicas"] != attributes["observe_transform"]["facets"]["desiredReplicas"]
+          - set(attributes["observe_transform"]["facets"]["status"], "Unhealthy") where attributes["observe_transform"]["facets"]["desiredReplicas"] != nil and attributes["observe_transform"]["facets"]["readyReplicas"] != attributes["observe_transform"]["facets"]["desiredReplicas"]
       - context: log
         conditions:
           - body["kind"] == "ConfigMap"


### PR DESCRIPTION
We currently set the status of various workload objects to "Unhealthy" when readyReplicas != desiredReplicas. However, sometimes readyReplicas could be omitted (instead of being set to 0) if no replicas are ready.

At the same time, in particular cases, one could set desiredReplicas to 0 (for whatever reason).

In this case, with the current logic, the object would always be considered "Unhealthy" since nil != 0.

Treat nil as 0 to consider objects defined with desiredReplicas == 0 always "Healthy".