### PR TITLE
feat: add configurable values for RED metric dimensions

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent
 description: Chart to install K8s collection stack based on Observe Agent
 type: application
-version: 0.70.3
+version: 0.71.0
 appVersion: "2.8.1"
 dependencies:
   - name: opentelemetry-collector

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -1,6 +1,6 @@
 # agent
 
-![Version: 0.70.3](https://img.shields.io/badge/Version-0.70.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.1](https://img.shields.io/badge/AppVersion-2.8.1-informational?style=flat-square)
+![Version: 0.71.0](https://img.shields.io/badge/Version-0.71.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.1](https://img.shields.io/badge/AppVersion-2.8.1-informational?style=flat-square)
 
 Chart to install K8s collection stack based on Observe Agent
 
@@ -76,6 +76,8 @@ This service is a *single-instance deployment*. It's critical that this service 
 | agent.selfMonitor.enabled | bool | `true` |  |
 | agent.selfMonitor.metrics.scrapeInterval | string | `"60s"` |  |
 | application.REDMetrics.enabled | bool | `false` | Whether to enable generating RED metrics from spans. See https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/spanmetricsconnector#overview |
+| application.REDMetrics.resourceDimensions | list | `["service.namespace","service.version","deployment.environment","k8s.pod.name","k8s.namespace.name"]` | List of resource attributes to include as dimensions for RED metrics. See https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/spanmetricsconnector#overview |
+| application.REDMetrics.spanDimensions | list | `["peer.db.name","peer.messaging.system","otel.status_description","observe.status_code"]` | List of span attributes to include as dimensions for RED metrics. See https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/spanmetricsconnector#overview |
 | application.prometheusScrape.enabled | bool | `false` |  |
 | application.prometheusScrape.independentDeployment | bool | `false` |  |
 | application.prometheusScrape.interval | string | `"60s"` |  |

--- a/charts/agent/templates/_config-connectors.tpl
+++ b/charts/agent/templates/_config-connectors.tpl
@@ -1,6 +1,8 @@
 {{- define "config.connectors.spanmetrics" -}}
-{{/* Note: this must be kept in sync with the same variable in config.processors.RED_metrics */}}
-{{- $spanmetricsResourceAttributes := (list "service.namespace" "service.version" "deployment.environment" "k8s.pod.name" "k8s.namespace.name") -}}
+
+{{- $fullDimensions := (concat .Values.application.REDMetrics.resourceDimensions .Values.application.REDMetrics.spanDimensions) -}}
+{{/* service.name is added automatically by the connector and errors when specified in the config */}}
+{{- $fullDimensions = (without $fullDimensions "service.name" | uniq) -}}
 
 spanmetrics:
   aggregation_temporality: AGGREGATION_TEMPORALITY_DELTA
@@ -10,11 +12,7 @@ spanmetrics:
   dimensions:
     # This connector implicitly adds: service.name, span.name, span.kind, and status.code (which we rename to otel.status_code)
     # https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/connector.go#L528-L540
-    {{- range $tag := $spanmetricsResourceAttributes }}
+    {{- range $tag := $fullDimensions }}
     - name: {{ $tag }}
     {{- end }}
-    - name: peer.db.name
-    - name: peer.messaging.system
-    - name: otel.status_description
-    - name: observe.status_code
 {{- end -}}

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -137,6 +137,19 @@ application:
   REDMetrics:
     # -- (bool) Whether to enable generating RED metrics from spans. See https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/spanmetricsconnector#overview
     enabled: false
+    # -- (list) List of resource attributes to include as dimensions for RED metrics. See https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/spanmetricsconnector#overview
+    resourceDimensions:
+      - service.namespace
+      - service.version
+      - deployment.environment
+      - k8s.pod.name
+      - k8s.namespace.name
+    # -- (list) List of span attributes to include as dimensions for RED metrics. See https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/spanmetricsconnector#overview
+    spanDimensions:
+      - peer.db.name
+      - peer.messaging.system
+      - otel.status_description
+      - observe.status_code
 
 gatewayDeployment:
   # -- (bool) Whether to enable the gateway deployment. The gateway is responsible for sampling and traces before sending them to Observe.


### PR DESCRIPTION
Example `values.yaml`:

```yaml
application:
  REDMetrics:
    enabled: true
    resourceDimensions:
      - service.namespace
      - service.version
      - deployment.environment.name # rename
      - k8s.pod.name
      - k8s.namespace.name
    spanDimensions:
      - peer.db.name
      - peer.messaging.system
      - otel.status_description
      - observe.status_code
      - customer_id # new dimension
```

`helm template` diff:

```diff
--- ./before.yaml	2025-09-30 16:39:17
+++ ./helm/export.yaml	2025-09-30 16:43:26
@@ -1181,13 +1181,14 @@
           dimensions:
           - name: service.namespace
           - name: service.version
-          - name: deployment.environment
+          - name: deployment.environment.name
           - name: k8s.pod.name
           - name: k8s.namespace.name
           - name: peer.db.name
           - name: peer.messaging.system
           - name: otel.status_description
           - name: observe.status_code
+          - name: customer_id
           histogram:
             exponential:
               max_size: 100
@@ -1374,8 +1375,8 @@
         transform/fix_red_metrics_resource_attributes:
           error_mode: ignore
           metric_statements:
-          - keep_matching_keys(resource.attributes, "^(service.name|service.namespace|service.version|deployment.environment|k8s.pod.name|k8s.namespace.name)")
-          - delete_matching_keys(datapoint.attributes, "^(service.name|service.namespace|service.version|deployment.environment|k8s.pod.name|k8s.namespace.name)")
+          - keep_matching_keys(resource.attributes, "^(service.name|service.namespace|service.version|deployment.environment.name|k8s.pod.name|k8s.namespace.name)")
+          - delete_matching_keys(datapoint.attributes, "^(service.name|service.namespace|service.version|deployment.environment.name|k8s.pod.name|k8s.namespace.name)")
           - set(datapoint.attributes["otel.status_code"], "OK") where datapoint.attributes["status.code"]
             == "STATUS_CODE_OK"
           - set(datapoint.attributes["otel.status_code"], "ERROR") where datapoint.attributes["status.code"]
```