### PR TITLE
fix: fix the examples for cluster.events.customResources value

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent
 description: Chart to install K8s collection stack based on Observe Agent
 type: application
-version: 0.86.0
+version: 0.86.1
 appVersion: "2.15.0"
 dependencies:
   - name: opentelemetry-collector

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -1,6 +1,6 @@
 # agent
 
-![Version: 0.86.0](https://img.shields.io/badge/Version-0.86.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.15.0](https://img.shields.io/badge/AppVersion-2.15.0-informational?style=flat-square)
+![Version: 0.86.1](https://img.shields.io/badge/Version-0.86.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.15.0](https://img.shields.io/badge/AppVersion-2.15.0-informational?style=flat-square)
 
 Chart to install K8s collection stack based on Observe Agent
 
@@ -241,7 +241,7 @@ This service is an *OpenTelemetryCollector*, a custom resource that is managed b
 | cluster-metrics.serviceAccount.name | string | `"observe-agent-service-account"` |  |
 | cluster-metrics.tolerations | list | `[]` |  |
 | cluster.deploymentEnvironment.name | string | `""` | deployment environment cluster runs in (e.g. testing, production, etc). populates to deployment.environment.name per https://opentelemetry.io/docs/specs/semconv/resource/deployment-environment/ |
-| cluster.events.customResources | list | `[]` | A list of custom resource definition names whose custom resources will be collected. Example: ["applications.argoproj.io", "cninodes.vpcresources.k8s.aws"] |
+| cluster.events.customResources | list | `[]` | A list of custom resource definition names whose custom resources will be collected, in plural name form. Example: ["certificates", "virtualservices", "applications", "kustomizations"] |
 | cluster.events.enabled | bool | `true` |  |
 | cluster.events.pullInterval | string | `"20m"` |  |
 | cluster.metadata.waitForInitialPoll | bool | `false` | whether to wait for the initial metadata poll to complete before processing telemetry |

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -37,8 +37,8 @@ cluster:
     # how often to pull resources from cluster
     pullInterval: 20m
     enabled: true
-    # -- A list of custom resource definition names whose custom resources will be collected.
-    # Example: ["applications.argoproj.io", "cninodes.vpcresources.k8s.aws"]
+    # -- A list of custom resource definition names whose custom resources will be collected, in plural name form.
+    # Example: ["certificates", "virtualservices", "applications", "kustomizations"]
     customResources: []
   # cluster-level metrics and entity events (as metrics) from the Kubernetes API server. It uses the K8s API to listen for updates.
   metrics:


### PR DESCRIPTION
They must be provided in plural form, not the full URI.