### PR TITLE
feat: allow users to specify the io stream based on the folder they w…

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent
 description: Chart to install K8s collection stack based on Observe Agent
 type: application
-version: 0.80.2
+version: 0.81.0
 appVersion: "2.12.0"
 dependencies:
   - name: opentelemetry-collector

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -1,6 +1,6 @@
 # agent
 
-![Version: 0.80.2](https://img.shields.io/badge/Version-0.80.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.12.0](https://img.shields.io/badge/AppVersion-2.12.0-informational?style=flat-square)
+![Version: 0.81.0](https://img.shields.io/badge/Version-0.81.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.12.0](https://img.shields.io/badge/AppVersion-2.12.0-informational?style=flat-square)
 
 Chart to install K8s collection stack based on Observe Agent
 

--- a/charts/agent/templates/_config-processors.tpl
+++ b/charts/agent/templates/_config-processors.tpl
@@ -130,6 +130,20 @@ transform/add_resource_container_name:
       - replace_pattern(attributes["k8s.container.name"], "^(?:.*/)?([^/]+)\\..*$", "$$1")
 {{- end -}}
 
+{{- define "config.processors.transform.extract_iostream" -}}
+transform/extract_iostream:
+  error_mode: ignore
+  log_statements:
+    - context: log
+      statements:
+      # Extract the immediate parent folder from log.file.path (resource attribute)
+      # e.g., /var/log/pods/ns_pod_uid/container/stdout/0.log -> stdout
+      - set(cache["parent_folder"], resource.attributes["log.file.path"])
+      - replace_pattern(cache["parent_folder"], "^.*/([^/]+)/[^/]+$$", "$$1")
+      # Set log.iostream as a log attribute only if the parent folder is stdout or stderr
+      - set(attributes["log.iostream"], cache["parent_folder"]) where cache["parent_folder"] == "stdout" or cache["parent_folder"] == "stderr"
+{{- end -}}
+
 
 {{- define "config.processors.resource.agent_instance" -}}
 resource/agent_instance:

--- a/charts/agent/templates/_fargate-sidecar-config.tpl
+++ b/charts/agent/templates/_fargate-sidecar-config.tpl
@@ -10,6 +10,7 @@ processors:
   {{- if .Values.nodeless.logs.containerNameFromFile }}
   - groupbyattrs/log_file
   - transform/add_resource_container_name
+  - transform/extract_iostream
   {{- end }}
   - resource/fargate_resource_attributes
   - k8sattributes
@@ -77,6 +78,7 @@ processors:
 {{- if .Values.nodeless.logs.containerNameFromFile }}
   {{- include "config.processors.groupbyattrs.log_file" . | nindent 2 }}
   {{- include "config.processors.transform.add_resource_container_name" . | nindent 2 }}
+  {{- include "config.processors.transform.extract_iostream" . | nindent 2 }}
 {{- end }}
 
 exporters:

--- a/charts/agent/templates/nodeless-otelcollector.yaml
+++ b/charts/agent/templates/nodeless-otelcollector.yaml
@@ -68,6 +68,9 @@ spec:
           echo -n "$APP_CONTAINER" > /applogs/app-container-name.txt
           {{- end }}
 
+          # Create stdout/stderr directories for log streaming
+          mkdir -p /applogs/stdout /applogs/stderr
+
           # Create logrotate config inline
           # size and rotation should keep total memory usage < 5Mi per container
           # compression helps keep the size down
@@ -77,6 +80,32 @@ spec:
           # su root root to grant logrotate permission to rotate the log file
           cat > /etc/logrotate.conf << 'EOF'
           /applogs/*.log {
+              size 1M
+              rotate 5
+              compress
+              delaycompress
+              missingok
+              notifempty
+              copytruncate
+              dateext
+              su root root
+              dateformat -%Y%m%d-%H%M%S
+          }
+
+          /applogs/stdout/*.log {
+              size 1M
+              rotate 5
+              compress
+              delaycompress
+              missingok
+              notifempty
+              copytruncate
+              dateext
+              su root root
+              dateformat -%Y%m%d-%H%M%S
+          }
+
+          /applogs/stderr/*.log {
               size 1M
               rotate 5
               compress


### PR DESCRIPTION
…rite to

Currently, users cannot provide the io stream of the logs that are getting created in a fargate cluster - all logs are redirected to a single file. I changed the code to allow users to specify which file the logs should go to - if the parent folder is stdout, the stream will be set to stdout and ditto for stderr.