### PR TITLE
chore: ignore examples directory in orca scan

### DIFF
--- a/.github/workflows/orca.yaml
+++ b/.github/workflows/orca.yaml
@@ -30,6 +30,7 @@ jobs:
           path:
             # scanning the entire repository
             "."
+          exclude_paths: "examples,charts/*/examples"
 
       - name: Run Orca FS Scan
         if: always()
@@ -48,3 +49,4 @@ jobs:
           path:
              # scanning the entire repository
             "."
+          exclude_paths: "examples,charts/*/examples"


### PR DESCRIPTION
This covers our top level examples dir and the upcoming chart examples (see: #462)