### PR TITLE
fix: drop internal metric otelcol_k8s_pod_association in agent-monitor

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent
 description: Chart to install K8s collection stack based on Observe Agent
 type: application
-version: 0.86.1
+version: 0.86.2
 appVersion: "2.15.0"
 dependencies:
   - name: opentelemetry-collector

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -1,6 +1,6 @@
 # agent
 
-![Version: 0.86.1](https://img.shields.io/badge/Version-0.86.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.15.0](https://img.shields.io/badge/AppVersion-2.15.0-informational?style=flat-square)
+![Version: 0.86.2](https://img.shields.io/badge/Version-0.86.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.15.0](https://img.shields.io/badge/AppVersion-2.15.0-informational?style=flat-square)
 
 Chart to install K8s collection stack based on Observe Agent
 
@@ -88,6 +88,7 @@ This service is an *OpenTelemetryCollector*, a custom resource that is managed b
 | agent.config.nodeLogsMetrics | string | `nil` | Additional OTel collector config for node-logs-metrics daemonset |
 | agent.config.prometheusScraper | string | `nil` | Additional OTel collector config for prometheus-scraper deployment |
 | agent.selfMonitor.enabled | bool | `true` |  |
+| agent.selfMonitor.metrics.metricDropRegex | string | `"otelcol_k8s_pod_association.*"` | Regex used to drop internal prometheus metrics. |
 | agent.selfMonitor.metrics.scrapeInterval | string | `"60s"` |  |
 | application.REDMetrics.enabled | bool | `false` | Whether to enable generating RED metrics from spans. See https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/spanmetricsconnector#overview |
 | application.REDMetrics.onlyGenerateForServiceEntrypointSpans | bool | `false` | If enabled, this will skip generating RED metrics for spans that are not service entrypoint spans (which are spans with kind Server, kind Consumer, or calls to DB or messaging system clients). If this and trace sampling are both enabled, it will not be possible to deduce accurate RED metrics for span types other than service entrypoint spans. |

--- a/charts/agent/templates/_monitor-config.tpl
+++ b/charts/agent/templates/_monitor-config.tpl
@@ -10,19 +10,24 @@ exporters:
 
 receivers:
   prometheus/collector:
-        config:
-          scrape_configs:
-          - job_name: opentelemetry-collector-self
-            scrape_interval: {{ .Values.agent.selfMonitor.metrics.scrapeInterval }}
-            static_configs:
-            - targets:
-              - ${env:MY_POD_IP}:8888
-          - job_name: opentelemetry-collector-other
-            scrape_interval: {{ .Values.agent.selfMonitor.metrics.scrapeInterval }}
-            honor_labels: true
-            kubernetes_sd_configs:
+    config:
+      scrape_configs:
+        - job_name: opentelemetry-collector-self
+          scrape_interval: {{ .Values.agent.selfMonitor.metrics.scrapeInterval }}
+          static_configs:
+          - targets:
+            - ${env:MY_POD_IP}:8888
+          metric_relabel_configs:
+            - action: drop
+              regex: {{.Values.agent.selfMonitor.metrics.metricDropRegex}}
+              source_labels:
+                - __name__
+        - job_name: opentelemetry-collector-other
+          scrape_interval: {{ .Values.agent.selfMonitor.metrics.scrapeInterval }}
+          honor_labels: true
+          kubernetes_sd_configs:
             - role: pod
-            relabel_configs:
+          relabel_configs:
             # select only those pods that has "observe_monitor_purpose: observecollection" annotation
             - source_labels: [__meta_kubernetes_pod_annotation_observe_monitor_purpose]
               action: keep
@@ -50,6 +55,11 @@ receivers:
             - source_labels: [__meta_kubernetes_pod_name]
               action: replace
               target_label: kubernetes_pod_name
+          metric_relabel_configs:
+            - action: drop
+              regex: {{.Values.agent.selfMonitor.metrics.metricDropRegex}}
+              source_labels:
+                - __name__
 
 {{- if .Values.agent.config.global.fleet.enabled }}
 {{- include "config.receivers.observe.heartbeat" . | nindent 2 }}

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -327,6 +327,8 @@ agent:
     enabled: true
     metrics:
       scrapeInterval: 60s
+      # -- Regex used to drop internal prometheus metrics.
+      metricDropRegex: "otelcol_k8s_pod_association.*"
 
 
 ################################################


### PR DESCRIPTION
This metric is [known to grow in an unbounded way](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47669) and [is being disabled upstream](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/47798).