### PR TITLE
feat: add an option to enable pod-metrics prometheus scrape internal metrics

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent
 description: Chart to install K8s collection stack based on Observe Agent
 type: application
-version: 0.86.1
+version: 0.87.0
 appVersion: "2.15.0"
 dependencies:
   - name: opentelemetry-collector

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -1,6 +1,6 @@
 # agent
 
-![Version: 0.86.1](https://img.shields.io/badge/Version-0.86.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.15.0](https://img.shields.io/badge/AppVersion-2.15.0-informational?style=flat-square)
+![Version: 0.87.0](https://img.shields.io/badge/Version-0.87.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.15.0](https://img.shields.io/badge/AppVersion-2.15.0-informational?style=flat-square)
 
 Chart to install K8s collection stack based on Observe Agent
 
@@ -94,6 +94,7 @@ This service is an *OpenTelemetryCollector*, a custom resource that is managed b
 | application.REDMetrics.resourceDimensions | list | `["service.namespace","service.version","deployment.environment","k8s.pod.name","k8s.namespace.name"]` | List of resource attributes to include as dimensions for RED metrics. See https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/spanmetricsconnector#overview |
 | application.REDMetrics.spanDimensions | list | `["peer.db.name","peer.messaging.system","otel.status_description","observe.status_code"]` | List of span attributes to include as dimensions for RED metrics. See https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/spanmetricsconnector#overview |
 | application.prometheusScrape.enabled | bool | `false` |  |
+| application.prometheusScrape.extraScrapeMetrics | bool | `false` | Enable extra scrape metrics |
 | application.prometheusScrape.independentDeployment | bool | `false` |  |
 | application.prometheusScrape.interval | string | `"60s"` |  |
 | application.prometheusScrape.metricDropRegex | string | `""` |  |

--- a/charts/agent/templates/_config-receivers.tpl
+++ b/charts/agent/templates/_config-receivers.tpl
@@ -1,6 +1,8 @@
 {{- define "config.receivers.prometheus.pod_metrics" -}}
 prometheus/pod_metrics:
   config:
+    global:
+      extra_scrape_metrics: {{.Values.application.prometheusScrape.extraScrapeMetrics}}
     scrape_configs:
     - job_name: pod-metrics
       scrape_interval: {{.Values.application.prometheusScrape.interval}}
@@ -117,6 +119,8 @@ prometheus/pod_metrics:
 {{- if .Values.node.metrics.cadvisor.enabled }}
 prometheus/cadvisor:
   config:
+    global:
+      extra_scrape_metrics: {{.Values.application.prometheusScrape.extraScrapeMetrics}}
     scrape_configs:
       - job_name: 'kubernetes-nodes-cadvisor'
         scheme: https

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -144,6 +144,8 @@ application:
     metricDropRegex: ""
     # metrics to keep
     metricKeepRegex: (.*)
+    # -- (bool) Enable extra scrape metrics
+    extraScrapeMetrics: false
   REDMetrics:
     # -- (bool) Whether to enable generating RED metrics from spans. See https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/spanmetricsconnector#overview
     enabled: false


### PR DESCRIPTION
Adding this as an option so we can better monitor the receiver: (see https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/prometheusreceiver/README.md#monitoring-the-receiver)