### PR TITLE
feat: shard prometheus-scraper via OpenTelemetry Target Allocator

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Lint charts
         run: make lint
 
+      - name: Verify agent Prometheus Target Allocator rendering
+        run: make verify-agent-prometheus-ta
+
   test-charts:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,10 @@ build-deps: add-repos
 		echo ; \
 	done
 
+.PHONY: verify-agent-prometheus-ta
+verify-agent-prometheus-ta:
+	test/verify_agent_prometheus_ta_template.sh
+
 .PHONY: test
 test: build-deps build-test-images
 	test/test.sh agent stack traces

--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent
 description: Chart to install K8s collection stack based on Observe Agent
 type: application
-version: 0.86.1
+version: 0.87.0
 appVersion: "2.15.0"
 dependencies:
   - name: opentelemetry-collector

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -1,6 +1,6 @@
 # agent
 
-![Version: 0.86.1](https://img.shields.io/badge/Version-0.86.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.15.0](https://img.shields.io/badge/AppVersion-2.15.0-informational?style=flat-square)
+![Version: 0.87.0](https://img.shields.io/badge/Version-0.87.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.15.0](https://img.shields.io/badge/AppVersion-2.15.0-informational?style=flat-square)
 
 Chart to install K8s collection stack based on Observe Agent
 
@@ -21,6 +21,8 @@ This service is a *single-instance deployment*. It's critical that this service 
 ## prometheus-scraper
 
 This service is a *single-instance deployment*. It's critical that this service is only a single instance since otherwise it would produce duplicate data. It is responsible for scraping pods for Prometheus metrics is configured and runs.
+
+When **`application.prometheusScrape.targetAllocator.enabled`** is `true` (requires **`application.prometheusScrape.independentDeployment`**), the chart also deploys an OpenTelemetry **Target Allocator** and configures the `prometheus/pod_metrics` receiver to shard targets across **`prometheus-scraper.replicaCount`** observe-agent pods. Set **`prometheus-scraper.replicaCount`** to at least `2` for meaningful sharding. The OpenTelemetry Operator is not required for this path. Pair the **`targetAllocator.image`** tag with your observe-agent / OTel collector version per OpenTelemetry release notes.
 
 ## forwarder
 
@@ -101,6 +103,13 @@ This service is an *OpenTelemetryCollector*, a custom resource that is managed b
 | application.prometheusScrape.namespaceDropRegex | string | `"(.*istio.*|.*ingress.*|kube-system)"` |  |
 | application.prometheusScrape.namespaceKeepRegex | string | `"(.*)"` |  |
 | application.prometheusScrape.portKeepRegex | string | `".*metrics"` |  |
+| application.prometheusScrape.targetAllocator.enabled | bool | `false` |  |
+| application.prometheusScrape.targetAllocator.image.repository | string | `"ghcr.io/open-telemetry/opentelemetry-operator/target-allocator"` |  |
+| application.prometheusScrape.targetAllocator.image.tag | string | `"0.150.0"` |  |
+| application.prometheusScrape.targetAllocator.interval | string | `"30s"` |  |
+| application.prometheusScrape.targetAllocator.resources.limits.memory | string | `"256Mi"` |  |
+| application.prometheusScrape.targetAllocator.resources.requests.cpu | string | `"50m"` |  |
+| application.prometheusScrape.targetAllocator.resources.requests.memory | string | `"128Mi"` |  |
 | cluster-events.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key | string | `"observeinc.com/unschedulable"` |  |
 | cluster-events.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].operator | string | `"DoesNotExist"` |  |
 | cluster-events.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[1].key | string | `"kubernetes.io/os"` |  |
@@ -703,6 +712,7 @@ This service is an *OpenTelemetryCollector*, a custom resource that is managed b
 | prometheus-scraper.resources.limits.memory | string | `"512Mi"` |  |
 | prometheus-scraper.resources.requests.cpu | string | `"250m"` |  |
 | prometheus-scraper.resources.requests.memory | string | `"512Mi"` |  |
+| prometheus-scraper.securityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
 | prometheus-scraper.serviceAccount.create | bool | `false` |  |
 | prometheus-scraper.serviceAccount.name | string | `"observe-agent-service-account"` |  |
 | prometheus-scraper.tolerations | list | `[]` |  |

--- a/charts/agent/README.md.gotmpl
+++ b/charts/agent/README.md.gotmpl
@@ -23,6 +23,8 @@ This service is a *single-instance deployment*. It's critical that this service 
 
 This service is a *single-instance deployment*. It's critical that this service is only a single instance since otherwise it would produce duplicate data. It is responsible for scraping pods for Prometheus metrics is configured and runs.
 
+When **`application.prometheusScrape.targetAllocator.enabled`** is `true` (requires **`application.prometheusScrape.independentDeployment`**), the chart also deploys an OpenTelemetry **Target Allocator** and configures the `prometheus/pod_metrics` receiver to shard targets across **`prometheus-scraper.replicaCount`** observe-agent pods. Set **`prometheus-scraper.replicaCount`** to at least `2` for meaningful sharding. The OpenTelemetry Operator is not required for this path. Pair the **`targetAllocator.image`** tag with your observe-agent / OTel collector version per OpenTelemetry release notes.
+
 ## forwarder
 
 This service is a *daemonset* which means it runs on every node in the cluster. It is responsible for receiving telemetry from the other services, specifically via an OTLP receiver and forwarding it to Observe. It can be used as the target for various instrumentation SDK's and clients as well. See [here](https://docs.observeinc.com/en/latest/content/observe-agent/ConfigureApplicationInstrumentation.html) for more details.

--- a/charts/agent/ci/prometheus-ta-values.yaml
+++ b/charts/agent/ci/prometheus-ta-values.yaml
@@ -1,0 +1,60 @@
+# Same as test-values.yaml but enables Target Allocator sharding for pod_metrics.
+# chart-testing runs `helm template` with each ci/*-values.yaml independently.
+observe:
+  collectionEndpoint:
+    value: "http://test-stack-collector.testing.svc.cluster.local:8080"
+  token:
+    create: true
+    value: "fake-ds:fake-token"
+
+application:
+  prometheusScrape:
+    enabled: true
+    independentDeployment: true
+    targetAllocator:
+      enabled: true
+  REDMetrics:
+    enabled: true
+
+node:
+  forwarder:
+    enabled: true
+    metrics:
+      outputFormat: otel
+      convertCumulativeToDelta: true
+  metrics:
+    cadvisor:
+      enabled: true
+
+gatewayDeployment:
+  enabled: true
+  traceSampling:
+    enabled: true
+
+agent:
+  config:
+    global:
+      fleet:
+        enabled: true
+        interval: 10s
+        configInterval: 10m
+
+cluster:
+  namespaceOverride:
+    value: "testing"
+
+cluster-events:
+  namespaceOverride: "testing"
+cluster-metrics:
+  namespaceOverride: "testing"
+forwarder:
+  namespaceOverride: "testing"
+monitor:
+  namespaceOverride: "testing"
+node-logs-metrics:
+  namespaceOverride: "testing"
+prometheus-scraper:
+  namespaceOverride: "testing"
+  replicaCount: 2
+gateway:
+  namespaceOverride: "testing"

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/agent-monitor-configmap.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/agent-monitor-configmap.yaml
@@ -1,0 +1,154 @@
+---
+# Source: agent/templates/agent-monitor-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: monitor
+  namespace: observe
+data:
+  relay: |
+      exporters:
+        debug/override:
+          sampling_initial: 2
+          sampling_thereafter: 1
+          verbosity: basic
+        prometheusremotewrite/observe:
+          endpoint: ${env:OBSERVE_PROMETHEUS_ENDPOINT}
+          headers:
+            authorization: ${env:OBSERVE_AUTHORIZATION_HEADER}
+            x-observe-target-package: Kubernetes Explorer
+          max_batch_request_parallelism: 5
+          remote_write_queue:
+            num_consumers: 5
+          resource_to_telemetry_conversion:
+            enabled: true
+          retry_on_failure:
+            enabled: true
+            initial_interval: 1s
+            max_elapsed_time: 5m
+            max_interval: 30s
+          send_metadata: true
+          timeout: 10s
+      processors:
+        attributes/debug_source_agent_monitor:
+          actions:
+          - action: insert
+            key: debug_source
+            value: agent_monitor
+        batch:
+          send_batch_max_size: 4096
+          send_batch_size: 4096
+          timeout: 5s
+        k8sattributes:
+          extract:
+            labels:
+            - from: pod
+              key_regex: (app\.kubernetes\.io/.+)
+              tag_name: $1
+            metadata:
+            - k8s.namespace.name
+            - k8s.deployment.name
+            - k8s.replicaset.name
+            - k8s.statefulset.name
+            - k8s.daemonset.name
+            - k8s.cronjob.name
+            - k8s.job.name
+            - k8s.node.name
+            - k8s.node.uid
+            - k8s.pod.name
+            - k8s.pod.uid
+            - k8s.cluster.uid
+            - k8s.container.name
+            - container.id
+            - service.namespace
+            - service.name
+            - service.version
+            - service.instance.id
+            otel_annotations: true
+          passthrough: false
+          pod_association:
+          - sources:
+            - from: resource_attribute
+              name: k8s.pod.ip
+          - sources:
+            - from: resource_attribute
+              name: k8s.pod.uid
+          - sources:
+            - from: connection
+          wait_for_metadata: false
+          wait_for_metadata_timeout: 10s
+        memory_limiter:
+          check_interval: 5s
+          limit_percentage: 80
+          spike_limit_percentage: 15
+        resource/drop_service_name:
+          attributes:
+          - action: delete
+            key: service.name
+        resource/observe_common:
+          attributes:
+          - action: upsert
+            key: k8s.cluster.name
+            value: ${env:OBSERVE_CLUSTER_NAME}
+          - action: upsert
+            key: k8s.cluster.uid
+            value: ${env:OBSERVE_CLUSTER_UID}
+      receivers:
+        prometheus/collector:
+          config:
+            scrape_configs:
+            - job_name: opentelemetry-collector-self
+              scrape_interval: 60s
+              static_configs:
+              - targets:
+                - ${env:MY_POD_IP}:8888
+            - honor_labels: true
+              job_name: opentelemetry-collector-other
+              kubernetes_sd_configs:
+              - role: pod
+              relabel_configs:
+              - action: keep
+                regex: observecollection
+                source_labels:
+                - __meta_kubernetes_pod_annotation_observe_monitor_purpose
+              - action: keep
+                regex: true
+                source_labels:
+                - __meta_kubernetes_pod_annotation_observe_monitor_scrape
+              - action: replace
+                regex: (.+)
+                source_labels:
+                - __meta_kubernetes_pod_annotation_observe_monitor_path
+                target_label: __metrics_path__
+              - action: replace
+                regex: ([^:]+)(?::\d+)?;(\d+)
+                replacement: $$1:$$2
+                source_labels:
+                - __address__
+                - __meta_kubernetes_pod_annotation_observe_monitor_port
+                target_label: __address__
+              - action: labelmap
+                regex: __meta_kubernetes_pod_label_(.+)
+              - action: replace
+                source_labels:
+                - __meta_kubernetes_namespace
+                target_label: kubernetes_namespace
+              - action: replace
+                source_labels:
+                - __meta_kubernetes_pod_name
+                target_label: kubernetes_pod_name
+              scrape_interval: 60s
+      service:
+        pipelines:
+          metrics:
+            exporters:
+            - prometheusremotewrite/observe
+            processors:
+            - memory_limiter
+            - resource/drop_service_name
+            - k8sattributes
+            - batch
+            - resource/observe_common
+            - attributes/debug_source_agent_monitor
+            receivers:
+            - prometheus/collector

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/cluster-events-configmap.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/cluster-events-configmap.yaml
@@ -1,0 +1,547 @@
+---
+# Source: agent/templates/cluster-events-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-events
+  namespace: observe
+data:
+  relay: |
+      exporters:
+        debug/override:
+          sampling_initial: 2
+          sampling_thereafter: 1
+          verbosity: basic
+        otlphttp/observe/entity:
+          compression: zstd
+          headers:
+            authorization: ${env:OBSERVE_AUTHORIZATION_HEADER}
+            x-observe-target-package: Kubernetes Explorer
+          logs_endpoint: ${env:OBSERVE_COLLECTOR_URL}/v1/kubernetes/v1/entity
+          retry_on_failure:
+            enabled: true
+            initial_interval: 1s
+            max_elapsed_time: 5m
+            max_interval: 30s
+          sending_queue:
+            enabled: true
+          timeout: 10s
+      processors:
+        batch:
+          send_batch_max_size: 1024
+          send_batch_size: 1024
+          timeout: 5s
+        filter/cluster:
+          error_mode: ignore
+          logs:
+            log_record:
+            - body["metadata"]["name"] != "kube-system" and body["object"]["metadata"]["name"]
+              != "kube-system"
+        memory_limiter:
+          check_interval: 5s
+          limit_percentage: 80
+          spike_limit_percentage: 15
+        observek8sattributes: null
+        resource/observe_common:
+          attributes:
+          - action: upsert
+            key: k8s.cluster.name
+            value: ${env:OBSERVE_CLUSTER_NAME}
+          - action: upsert
+            key: k8s.cluster.uid
+            value: ${env:OBSERVE_CLUSTER_UID}
+        transform/cluster:
+          error_mode: ignore
+          log_statements:
+          - context: log
+            statements:
+            - set(attributes["observe_filter"], "objects_pull_watch")
+            - set(attributes["observe_transform"]["control"]["isDelete"], true) where body["object"]
+              != nil and body["type"] == "DELETED"
+            - set(attributes["observe_transform"]["control"]["debug_source"], "watch") where
+              body["object"] != nil and body["type"] != nil
+            - set(attributes["observe_transform"]["control"]["debug_source"], "pull") where
+              body["object"] == nil or body["type"] == nil
+            - set(body, body["object"]) where body["object"] != nil and body["type"] !=
+              nil
+            - set(attributes["observe_transform"]["valid_from"], observed_time_unix_nano)
+            - set(attributes["observe_transform"]["valid_to"], Int(observed_time_unix_nano)
+              + 5400000000000)
+            - set(attributes["observe_transform"]["kind"], "Cluster")
+            - set(attributes["observe_transform"]["control"]["isDelete"], false) where attributes["observe_transform"]["control"]["isDelete"]
+              == nil
+            - set(attributes["observe_transform"]["control"]["version"], body["metadata"]["resourceVersion"])
+            - set(attributes["observe_transform"]["identifiers"]["clusterName"], resource.attributes["k8s.cluster.name"])
+            - set(attributes["observe_transform"]["identifiers"]["clusterUid"], resource.attributes["k8s.cluster.uid"])
+            - set(attributes["observe_transform"]["identifiers"]["uid"], resource.attributes["k8s.cluster.uid"])
+            - set(attributes["observe_transform"]["identifiers"]["kind"], "Cluster")
+            - set(attributes["observe_transform"]["identifiers"]["name"], resource.attributes["k8s.cluster.name"])
+            - set(attributes["observe_transform"]["facets"]["creationTimestamp"], body["metadata"]["creationTimestamp"])
+            - set(attributes["observe_transform"]["facets"]["labels"], body["metadata"]["labels"])
+            - set(attributes["observe_transform"]["facets"]["annotations"], body["metadata"]["annotations"])
+            - set(body, "")
+        transform/object:
+          error_mode: ignore
+          log_statements:
+          - context: log
+            statements:
+            - set(attributes["observe_filter"], "objects_pull_watch")
+            - set(attributes["observe_transform"]["valid_from"], observed_time_unix_nano)
+            - set(attributes["observe_transform"]["valid_to"], Int(observed_time_unix_nano)
+              + 5400000000000)
+            - set(attributes["observe_transform"]["kind"], body["kind"])
+            - set(attributes["observe_transform"]["control"]["isDelete"], false) where attributes["observe_transform"]["control"]["isDelete"]
+              == nil
+            - set(attributes["observe_transform"]["control"]["version"], body["metadata"]["resourceVersion"])
+            - set(attributes["observe_transform"]["control"]["agentVersion"], "2.15.0")
+            - set(attributes["observe_transform"]["identifiers"]["clusterName"], resource.attributes["k8s.cluster.name"])
+            - set(attributes["observe_transform"]["identifiers"]["clusterUid"], resource.attributes["k8s.cluster.uid"])
+            - set(attributes["observe_transform"]["identifiers"]["kind"], body["kind"])
+            - set(attributes["observe_transform"]["identifiers"]["name"], body["metadata"]["name"])
+            - set(attributes["observe_transform"]["identifiers"]["namespaceName"], body["metadata"]["namespace"])
+            - set(attributes["observe_transform"]["identifiers"]["uid"], body["metadata"]["uid"])
+            - set(attributes["observe_transform"]["facets"]["creationTimestamp"], body["metadata"]["creationTimestamp"])
+            - set(attributes["observe_transform"]["facets"]["deletionTimestamp"], body["metadata"]["deletionTimestamp"])
+            - set(attributes["observe_transform"]["facets"]["ownerRefKind"], body["metadata"]["ownerReferences"][0]["kind"])
+            - set(attributes["observe_transform"]["facets"]["ownerRefName"], body["metadata"]["ownerReferences"][0]["name"])
+            - set(attributes["observe_transform"]["facets"]["labels"], body["metadata"]["labels"])
+            - set(attributes["observe_transform"]["facets"]["annotations"], body["metadata"]["annotations"])
+            - set(attributes["observe_transform"]["facets"]["replicaSetName"], body["metadata"]["ownerReferences"][0]["name"])
+              where body["metadata"]["ownerReferences"][0]["kind"] == "ReplicaSet"
+            - set(attributes["observe_transform"]["facets"]["daemonSetName"], body["metadata"]["ownerReferences"][0]["name"])
+              where body["metadata"]["ownerReferences"][0]["kind"] == "DaemonSet"
+            - set(attributes["observe_transform"]["facets"]["jobName"], body["metadata"]["ownerReferences"][0]["name"])
+              where body["metadata"]["ownerReferences"][0]["kind"] == "Job"
+            - set(attributes["observe_transform"]["facets"]["cronJobName"], attributes["observe_transform"]["facets"]["jobName"])
+              where IsMatch(attributes["observe_transform"]["facets"]["jobName"], ".*-\\d{8}$")
+            - replace_pattern(attributes["observe_transform"]["facets"]["cronJobName"],
+              "-\\d{8}$$", "")
+            - set(attributes["observe_transform"]["facets"]["statefulSetName"], body["metadata"]["ownerReferences"][0]["name"])
+              where body["metadata"]["ownerReferences"][0]["kind"] == "StatefulSet"
+            - set(attributes["observe_transform"]["facets"]["deploymentName"], body["metadata"]["ownerReferences"][0]["name"])
+              where body["metadata"]["ownerReferences"][0]["kind"] == "ReplicaSet"
+            - replace_pattern(attributes["observe_transform"]["facets"]["deploymentName"],
+              "^(.*)-[0-9a-f]+$$", "$$1")
+            - set(attributes["observe_transform"]["facets"]["deploymentName"], body["metadata"]["ownerReferences"][0]["name"])
+              where body["metadata"]["ownerReferences"][0]["kind"] == "Deployment"
+          - conditions:
+            - body["kind"] == "Pod"
+            context: log
+            statements:
+            - set(attributes["observe_transform"]["identifiers"]["podName"], body["metadata"]["name"])
+            - set(attributes["observe_transform"]["identifiers"]["podUid"], body["metadata"]["uid"])
+            - set(attributes["observe_transform"]["facets"]["phase"], body["status"]["phase"])
+            - set(attributes["observe_transform"]["facets"]["podIP"], body["status"]["podIP"])
+            - set(attributes["observe_transform"]["facets"]["qosClass"], body["status"]["qosClass"])
+            - set(attributes["observe_transform"]["facets"]["startTime"], body["status"]["startTime"])
+            - set(attributes["observe_transform"]["facets"]["readinessGates"], body["object"]["spec"]["readinessGates"])
+            - set(attributes["observe_transform"]["facets"]["nodeName"], body["spec"]["nodeName"])
+          - conditions:
+            - body["kind"] == "Namespace"
+            context: log
+            statements:
+            - set(attributes["observe_transform"]["facets"]["status"], body["status"]["phase"])
+            - set(attributes["observe_transform"]["identifiers"]["namespaceName"], body["metadata"]["name"])
+            - set(attributes["observe_transform"]["identifiers"]["namespaceUid"], body["metadata"]["uid"])
+          - conditions:
+            - body["kind"] == "Node"
+            context: log
+            statements:
+            - set(attributes["observe_transform"]["identifiers"]["nodeName"], body["metadata"]["name"])
+            - set(attributes["observe_transform"]["identifiers"]["nodeUid"], body["metadata"]["uid"])
+            - set(attributes["observe_transform"]["facets"]["kernelVersion"], body["status"]["nodeInfo"]["kernelVersion"])
+            - set(attributes["observe_transform"]["facets"]["kubeProxyVersion"], body["status"]["nodeInfo"]["kubeProxyVersion"])
+            - set(attributes["observe_transform"]["facets"]["kubeletVersion"], body["status"]["nodeInfo"]["kubeletVersion"])
+            - set(attributes["observe_transform"]["facets"]["osImage"], body["status"]["nodeInfo"]["osImage"])
+            - set(attributes["observe_transform"]["facets"]["taints"], body["spec"]["taints"])
+          - conditions:
+            - body["kind"] == "Deployment"
+            context: log
+            statements:
+            - set(attributes["observe_transform"]["identifiers"]["deploymentName"], body["metadata"]["name"])
+            - set(attributes["observe_transform"]["identifiers"]["deploymentUid"], body["metadata"]["uid"])
+            - set(attributes["observe_transform"]["facets"]["updatedReplicas"], body["status"]["updatedReplicas"])
+            - set(attributes["observe_transform"]["facets"]["availableReplicas"], body["status"]["availableReplicas"])
+            - set(attributes["observe_transform"]["facets"]["readyReplicas"], body["status"]["readyReplicas"])
+            - set(attributes["observe_transform"]["facets"]["readyReplicas"], 0) where attributes["observe_transform"]["facets"]["readyReplicas"]
+              == nil
+            - set(attributes["observe_transform"]["facets"]["unavailableReplicas"], body["status"]["unavailableReplicas"])
+            - set(attributes["observe_transform"]["facets"]["selector"], body["spec"]["selector"]["matchLabels"])
+            - set(attributes["observe_transform"]["facets"]["desiredReplicas"], body["spec"]["replicas"])
+            - set(attributes["observe_transform"]["facets"]["status"], "Healthy")
+            - set(attributes["observe_transform"]["facets"]["status"], "Unhealthy") where
+              attributes["observe_transform"]["facets"]["desiredReplicas"] != nil and attributes["observe_transform"]["facets"]["readyReplicas"]
+              != attributes["observe_transform"]["facets"]["desiredReplicas"]
+          - conditions:
+            - body["kind"] == "ReplicaSet"
+            context: log
+            statements:
+            - set(attributes["observe_transform"]["identifiers"]["replicaSetName"], body["metadata"]["name"])
+            - set(attributes["observe_transform"]["identifiers"]["replicaSetUid"], body["metadata"]["uid"])
+            - set(attributes["observe_transform"]["facets"]["desiredReplicas"], body["spec"]["replicas"])
+            - set(attributes["observe_transform"]["facets"]["currentReplicas"], body["status"]["replicas"])
+            - set(attributes["observe_transform"]["facets"]["availableReplicas"], body["status"]["availableReplicas"])
+            - set(attributes["observe_transform"]["facets"]["readyReplicas"], body["status"]["readyReplicas"])
+            - set(attributes["observe_transform"]["facets"]["readyReplicas"], 0) where attributes["observe_transform"]["facets"]["readyReplicas"]
+              == nil
+            - set(attributes["observe_transform"]["facets"]["status"], "Healthy")
+            - set(attributes["observe_transform"]["facets"]["status"], "Unhealthy") where
+              attributes["observe_transform"]["facets"]["desiredReplicas"] != nil and attributes["observe_transform"]["facets"]["readyReplicas"]
+              != attributes["observe_transform"]["facets"]["desiredReplicas"]
+          - conditions:
+            - body["kind"] == "Event"
+            context: log
+            statements:
+            - set(attributes["observe_transform"]["identifiers"]["involvedObjectKind"],
+              body["involvedObject"]["kind"])
+            - set(attributes["observe_transform"]["identifiers"]["involvedObjectName"],
+              body["involvedObject"]["name"])
+            - set(attributes["observe_transform"]["identifiers"]["involvedObjectUid"], body["involvedObject"]["uid"])
+            - set(attributes["observe_transform"]["facets"]["firstTimestamp"], body["firstTimestamp"])
+            - set(attributes["observe_transform"]["facets"]["lastTimestamp"], body["lastTimestamp"])
+            - set(attributes["observe_transform"]["facets"]["message"], body["message"])
+            - set(attributes["observe_transform"]["facets"]["reason"], body["reason"])
+            - set(attributes["observe_transform"]["facets"]["count"], body["count"])
+            - set(attributes["observe_transform"]["facets"]["type"], body["type"])
+            - set(attributes["observe_transform"]["facets"]["sourceComponent"], body["source"]["component"])
+          - conditions:
+            - body["kind"] == "Job"
+            context: log
+            statements:
+            - set(attributes["observe_transform"]["identifiers"]["jobName"], body["metadata"]["name"])
+            - set(attributes["observe_transform"]["identifiers"]["jobUid"], body["metadata"]["uid"])
+            - set(attributes["observe_transform"]["facets"]["cronJobName"], body["metadata"]["ownerReferences"][0]["name"])
+              where body["metadata"]["ownerReferences"][0]["kind"] == "CronJob"
+            - set(attributes["observe_transform"]["facets"]["cronJobUid"], body["metadata"]["ownerReferences"][0]["uid"])
+              where body["metadata"]["ownerReferences"][0]["kind"] == "CronJob"
+            - set(attributes["observe_transform"]["facets"]["completions"], body["spec"]["completions"])
+            - set(attributes["observe_transform"]["facets"]["parallelism"], body["spec"]["parallelism"])
+            - set(attributes["observe_transform"]["facets"]["activeDeadlineSeconds"], body["spec"]["activeDeadlineSeconds"])
+            - set(attributes["observe_transform"]["facets"]["backoffLimit"], body["spec"]["backoffLimit"])
+            - set(attributes["observe_transform"]["facets"]["startTime"], body["status"]["startTime"])
+            - set(attributes["observe_transform"]["facets"]["activePods"], body["status"]["active"])
+            - set(attributes["observe_transform"]["facets"]["failedPods"], body["status"]["falied"])
+            - set(attributes["observe_transform"]["facets"]["succeededPods"], body["status"]["succeeded"])
+            - set(attributes["observe_transform"]["facets"]["readyPods"], body["status"]["ready"])
+          - conditions:
+            - body["kind"] == "CronJob"
+            context: log
+            statements:
+            - set(attributes["observe_transform"]["identifiers"]["cronJobName"], body["metadata"]["name"])
+            - set(attributes["observe_transform"]["identifiers"]["cronJobUid"], body["metadata"]["uid"])
+            - set(attributes["observe_transform"]["facets"]["schedule"], body["spec"]["schedule"])
+            - set(attributes["observe_transform"]["facets"]["suspend"], "Active") where
+              body["spec"]["suspend"] == false
+            - set(attributes["observe_transform"]["facets"]["suspend"], "Suspend") where
+              body["spec"]["suspend"] == true
+          - conditions:
+            - body["kind"] == "DaemonSet"
+            context: log
+            statements:
+            - set(attributes["observe_transform"]["identifiers"]["daemonSetName"], body["metadata"]["name"])
+            - set(attributes["observe_transform"]["identifiers"]["daemonSetUid"], body["metadata"]["uid"])
+            - set(attributes["observe_transform"]["facets"]["updateStrategy"], body["spec"]["updateStrategy"]["type"])
+            - set(attributes["observe_transform"]["facets"]["maxUnavailable"], body["spec"]["updateStrategy"]["rollingUpdate"]["maxUnavailable"])
+            - set(attributes["observe_transform"]["facets"]["maxSurge"], body["spec"]["updateStrategy"]["rollingUpdate"]["maxSurge"])
+            - set(attributes["observe_transform"]["facets"]["numberReady"], body["status"]["numberReady"])
+            - set(attributes["observe_transform"]["facets"]["desiredNumberScheduled"], body["status"]["desiredNumberScheduled"])
+            - set(attributes["observe_transform"]["facets"]["currentNumberScheduled"], body["status"]["currentNumberScheduled"])
+            - set(attributes["observe_transform"]["facets"]["updatedNumberScheduled"], body["status"]["updatedNumberScheduled"])
+            - set(attributes["observe_transform"]["facets"]["numberAvailable"], body["status"]["numberAvailable"])
+            - set(attributes["observe_transform"]["facets"]["numberUnavailable"], body["status"]["numberUnavailable"])
+            - set(attributes["observe_transform"]["facets"]["numberMisscheduled"], body["status"]["numberMisscheduled"])
+            - set(attributes["observe_transform"]["facets"]["status"], "Healthy")
+            - set(attributes["observe_transform"]["facets"]["status"], "Unhealthy") where
+              attributes["observe_transform"]["facets"]["desiredNumberScheduled"] != nil
+              and attributes["observe_transform"]["facets"]["numberReady"] != attributes["observe_transform"]["facets"]["desiredNumberScheduled"]
+          - conditions:
+            - body["kind"] == "StatefulSet"
+            context: log
+            statements:
+            - set(attributes["observe_transform"]["identifiers"]["statefulSetName"], body["metadata"]["name"])
+            - set(attributes["observe_transform"]["identifiers"]["statefulSetUid"], body["metadata"]["uid"])
+            - set(attributes["observe_transform"]["facets"]["serviceName"], body["spec"]["serviceName"])
+            - set(attributes["observe_transform"]["facets"]["podManagementPolicy"], body["spec"]["podManagementPolicy"])
+            - set(attributes["observe_transform"]["facets"]["desiredReplicas"], body["spec"]["replicas"])
+            - set(attributes["observe_transform"]["facets"]["updateStrategy"], body["spec"]["updateStrategy"]["type"])
+            - set(attributes["observe_transform"]["facets"]["partition"], body["spec"]["updateStrategy"]["rollingUpdate"]["partition"])
+            - set(attributes["observe_transform"]["facets"]["currentReplicas"], body["status"]["currentReplicas"])
+            - set(attributes["observe_transform"]["facets"]["readyReplicas"], body["status"]["readyReplicas"])
+            - set(attributes["observe_transform"]["facets"]["status"], "Healthy")
+            - set(attributes["observe_transform"]["facets"]["status"], "Unhealthy") where
+              attributes["observe_transform"]["facets"]["desiredReplicas"] != nil and attributes["observe_transform"]["facets"]["readyReplicas"]
+              != attributes["observe_transform"]["facets"]["desiredReplicas"]
+          - conditions:
+            - body["kind"] == "ConfigMap"
+            context: log
+            statements:
+            - set(attributes["observe_transform"]["identifiers"]["configMapName"], body["metadata"]["name"])
+            - set(attributes["observe_transform"]["identifiers"]["configMapUid"], body["metadata"]["uid"])
+            - set(attributes["observe_transform"]["facets"]["immutable"], body["immutable"])
+          - conditions:
+            - body["kind"] == "Secret"
+            context: log
+            statements:
+            - set(attributes["observe_transform"]["identifiers"]["secretName"], body["metadata"]["name"])
+            - set(attributes["observe_transform"]["identifiers"]["secretUid"], body["metadata"]["uid"])
+            - set(attributes["observe_transform"]["facets"]["immutable"], body["immutable"])
+            - set(attributes["observe_transform"]["facets"]["data"], body["data"])
+            - set(attributes["observe_transform"]["facets"]["type"], body["type"])
+          - conditions:
+            - body["kind"] == "PersistentVolume"
+            context: log
+            statements:
+            - set(attributes["observe_transform"]["identifiers"]["persistentVolumeName"],
+              body["metadata"]["name"])
+            - set(attributes["observe_transform"]["identifiers"]["persistentVolumeUid"],
+              body["metadata"]["uid"])
+            - set(attributes["observe_transform"]["facets"]["capacity"], body["spec"]["capacity"]["storage"])
+            - set(attributes["observe_transform"]["facets"]["reclaimPolicy"], body["spec"]["persistentVolumeReclaimPolicy"])
+            - set(attributes["observe_transform"]["facets"]["class"], body["spec"]["storageClassName"])
+            - set(attributes["observe_transform"]["facets"]["accessModes"], body["spec"]["accessModes"])
+            - set(attributes["observe_transform"]["facets"]["volumeMode"], body["spec"]["volumeMode"])
+            - set(attributes["observe_transform"]["facets"]["phase"], body["status"]["phase"])
+          - conditions:
+            - body["kind"] == "PersistentVolumeClaim"
+            context: log
+            statements:
+            - set(attributes["observe_transform"]["identifiers"]["persistentVolumeClaimName"],
+              body["metadata"]["name"])
+            - set(attributes["observe_transform"]["identifiers"]["persistentVolumeClaimUid"],
+              body["metadata"]["uid"])
+            - set(attributes["observe_transform"]["facets"]["capacityRequests"], body["spec"]["resources"]["requests"]["storage"])
+            - set(attributes["observe_transform"]["facets"]["capacityLimits"], body["spec"]["resources"]["limits"]["storage"])
+            - set(attributes["observe_transform"]["facets"]["class"], body["spec"]["storageClassName"])
+            - set(attributes["observe_transform"]["facets"]["volumeName"], body["spec"]["volumeName"])
+            - set(attributes["observe_transform"]["facets"]["desiredAccessModes"], body["spec"]["accessModes"])
+            - set(attributes["observe_transform"]["facets"]["volumeMode"], body["spec"]["volumeMode"])
+            - set(attributes["observe_transform"]["facets"]["capacity"], body["status"]["capacity"]["storage"])
+            - set(attributes["observe_transform"]["facets"]["phase"], body["status"]["phase"])
+            - set(attributes["observe_transform"]["facets"]["currentAccessModes"], body["spec"]["accessModes"])
+          - conditions:
+            - body["kind"] == "Service"
+            context: log
+            statements:
+            - set(attributes["observe_transform"]["identifiers"]["serviceName"], body["metadata"]["name"])
+            - set(attributes["observe_transform"]["identifiers"]["serviceUid"], body["metadata"]["uid"])
+            - set(attributes["observe_transform"]["facets"]["serviceType"], body["spec"]["type"])
+            - set(attributes["observe_transform"]["facets"]["clusterIP"], body["spec"]["clusterIP"])
+            - set(attributes["observe_transform"]["facets"]["externalIPs"], body["spec"]["externalIPs"])
+            - set(attributes["observe_transform"]["facets"]["sessionAffinity"], body["spec"]["sessionAffinity"])
+            - set(attributes["observe_transform"]["facets"]["externalName"], body["spec"]["externalName"])
+            - set(attributes["observe_transform"]["facets"]["externalTrafficPolicy"], body["spec"]["externalTrafficPolicy"])
+            - set(attributes["observe_transform"]["facets"]["ipFamilies"], "IPv4,IPv6")
+              where Len(body["spec"]["ipFamilies"]) == 2
+            - set(attributes["observe_transform"]["facets"]["ipFamilies"], body["spec"]["ipFamilies"][0])
+              where Len(body["spec"]["ipFamilies"]) == 1
+          - conditions:
+            - body["kind"] == "Ingress"
+            context: log
+            statements:
+            - set(attributes["observe_transform"]["identifiers"]["ingressName"], body["metadata"]["name"])
+            - set(attributes["observe_transform"]["identifiers"]["ingressUid"], body["metadata"]["uid"])
+            - set(attributes["observe_transform"]["facets"]["class"], body["spec"]["ingressClassName"])
+            - set(attributes["observe_transform"]["facets"]["class"], body["metadata"]["annotations"]["kubernetes.io/ingress.class"])
+              where attributes["observe_transform"]["facets"]["class"] == nil
+          - conditions:
+            - body["kind"] == "RoleBinding"
+            context: log
+            statements:
+            - set(attributes["observe_transform"]["identifiers"]["roleBindingName"], body["metadata"]["name"])
+            - set(attributes["observe_transform"]["identifiers"]["roleBindingUid"], body["metadata"]["uid"])
+            - set(attributes["observe_transform"]["facets"]["subjects"], body["subjects"])
+            - set(attributes["observe_transform"]["facets"]["role"], body["roleRef"]["name"])
+          - conditions:
+            - body["kind"] == "Role"
+            context: log
+            statements:
+            - set(attributes["observe_transform"]["identifiers"]["roleName"], body["metadata"]["name"])
+            - set(attributes["observe_transform"]["identifiers"]["roleUid"], body["metadata"]["uid"])
+            - set(attributes["observe_transform"]["facets"]["rules"], body["rules"])
+            - set(attributes["observe_transform"]["facets"]["role"], body["roleRef"]["name"])
+          - conditions:
+            - body["kind"] == "ClusterRoleBinding"
+            context: log
+            statements:
+            - set(attributes["observe_transform"]["identifiers"]["clusterRoleBindingName"],
+              body["metadata"]["name"])
+            - set(attributes["observe_transform"]["identifiers"]["clusterRoleBindingUid"],
+              body["metadata"]["uid"])
+            - set(attributes["observe_transform"]["facets"]["subjects"], body["subjects"])
+            - set(attributes["observe_transform"]["facets"]["role"], body["roleRef"]["name"])
+          - conditions:
+            - body["kind"] == "ServiceAccount"
+            context: log
+            statements:
+            - set(attributes["observe_transform"]["identifiers"]["serviceAccountName"],
+              body["metadata"]["name"])
+            - set(attributes["observe_transform"]["identifiers"]["serviceAccountUid"], body["metadata"]["uid"])
+            - set(attributes["observe_transform"]["facets"]["automountToken"], body["automountServiceAccountToken"])
+        transform/unify:
+          error_mode: ignore
+          log_statements:
+          - context: log
+            statements:
+            - set(attributes["observe_transform"]["control"]["isDelete"], true) where body["object"]
+              != nil and body["type"] == "DELETED"
+            - set(attributes["observe_transform"]["control"]["debug_source"], "watch") where
+              body["object"] != nil and body["type"] != nil
+            - set(attributes["observe_transform"]["control"]["debug_source"], "pull") where
+              body["object"] == nil or body["type"] == nil
+            - set(body, body["object"]) where body["object"] != nil and body["type"] !=
+              nil
+      receivers:
+        k8sobjects/cluster:
+          auth_type: serviceAccount
+          objects:
+          - interval: 20m
+            mode: pull
+            name: namespaces
+        k8sobjects/objects:
+          auth_type: serviceAccount
+          objects:
+          - interval: 15m
+            mode: pull
+            name: events
+          - mode: watch
+            name: events
+          - interval: 15m
+            mode: pull
+            name: pods
+          - mode: watch
+            name: pods
+          - interval: 15m
+            mode: pull
+            name: namespaces
+          - mode: watch
+            name: namespaces
+          - interval: 15m
+            mode: pull
+            name: nodes
+          - mode: watch
+            name: nodes
+          - interval: 15m
+            mode: pull
+            name: deployments
+          - mode: watch
+            name: deployments
+          - interval: 15m
+            mode: pull
+            name: replicasets
+          - mode: watch
+            name: replicasets
+          - interval: 15m
+            mode: pull
+            name: configmaps
+          - mode: watch
+            name: configmaps
+          - interval: 15m
+            mode: pull
+            name: endpoints
+          - mode: watch
+            name: endpoints
+          - interval: 15m
+            mode: pull
+            name: jobs
+          - mode: watch
+            name: jobs
+          - interval: 15m
+            mode: pull
+            name: cronjobs
+          - mode: watch
+            name: cronjobs
+          - interval: 15m
+            mode: pull
+            name: daemonsets
+          - mode: watch
+            name: daemonsets
+          - interval: 15m
+            mode: pull
+            name: statefulsets
+          - mode: watch
+            name: statefulsets
+          - interval: 15m
+            mode: pull
+            name: services
+          - mode: watch
+            name: services
+          - interval: 15m
+            mode: pull
+            name: ingresses
+          - mode: watch
+            name: ingresses
+          - interval: 15m
+            mode: pull
+            name: secrets
+          - mode: watch
+            name: secrets
+          - interval: 15m
+            mode: pull
+            name: persistentvolumeclaims
+          - mode: watch
+            name: persistentvolumeclaims
+          - interval: 15m
+            mode: pull
+            name: persistentvolumes
+          - mode: watch
+            name: persistentvolumes
+          - interval: 15m
+            mode: pull
+            name: storageclasses
+          - mode: watch
+            name: storageclasses
+          - interval: 15m
+            mode: pull
+            name: roles
+          - mode: watch
+            name: roles
+          - interval: 15m
+            mode: pull
+            name: rolebindings
+          - mode: watch
+            name: rolebindings
+          - interval: 15m
+            mode: pull
+            name: clusterroles
+          - mode: watch
+            name: clusterroles
+          - interval: 15m
+            mode: pull
+            name: clusterrolebindings
+          - mode: watch
+            name: clusterrolebindings
+          - interval: 15m
+            mode: pull
+            name: serviceaccounts
+          - mode: watch
+            name: serviceaccounts
+          - interval: 15m
+            mode: pull
+            name: customresourcedefinitions
+          - mode: watch
+            name: customresourcedefinitions
+      service:
+        pipelines:
+          logs/cluster:
+            exporters:
+            - otlphttp/observe/entity
+            processors:
+            - memory_limiter
+            - batch
+            - resource/observe_common
+            - filter/cluster
+            - transform/cluster
+            receivers:
+            - k8sobjects/cluster
+          logs/objects:
+            exporters:
+            - otlphttp/observe/entity
+            processors:
+            - memory_limiter
+            - batch
+            - resource/observe_common
+            - transform/unify
+            - observek8sattributes
+            - transform/object
+            receivers:
+            - k8sobjects/objects

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/cluster-events/deployment.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/cluster-events/deployment.yaml
@@ -1,0 +1,171 @@
+---
+# Source: agent/charts/cluster-events/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-cluster-events
+  namespace: observe
+  labels:
+    helm.sh/chart: cluster-events-0.143.0
+    app.kubernetes.io/name: cluster-events
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-collector
+    app.kubernetes.io/component: standalone-collector
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: cluster-events
+      app.kubernetes.io/instance: example
+      component: standalone-collector
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+        observe_monitor_path: /metrics
+        observe_monitor_port: "8888"
+        observe_monitor_purpose: observecollection
+        observe_monitor_scrape: "true"
+        observeinc_com_scrape: "false"
+      labels:
+        app.kubernetes.io/name: cluster-events
+        app.kubernetes.io/instance: example
+        component: standalone-collector
+
+    spec:
+
+      serviceAccountName: observe-agent-service-account
+      automountServiceAccountToken: true
+      securityContext:
+        {}
+      containers:
+        - name: cluster-events
+          command:
+            - /observe-agent
+          args:
+            - --config=/conf/relay.yaml
+            - start
+            - --observe-config=/observe-agent-conf/observe-agent.yaml
+            - --config=/conf/relay.yaml
+          securityContext:
+            {}
+          image: "observeinc/observe-agent:2.15.0"
+          imagePullPolicy: IfNotPresent
+          ports:
+
+            - name: jaeger-compact
+              containerPort: 6831
+              protocol: UDP
+            - name: jaeger-grpc
+              containerPort: 14250
+              protocol: TCP
+            - name: jaeger-thrift
+              containerPort: 14268
+              protocol: TCP
+            - name: metrics
+              containerPort: 8888
+              protocol: TCP
+            - name: otlp
+              containerPort: 4317
+              protocol: TCP
+            - name: otlp-http
+              containerPort: 4318
+              protocol: TCP
+            - name: zipkin
+              containerPort: 9411
+              protocol: TCP
+          env:
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: GOMEMLIMIT
+              value: "204MiB"
+            - name: OTEL_K8S_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+            - name: OTEL_K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OBSERVE_CLUSTER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  key: name
+                  name: cluster-name
+            - name: OBSERVE_CLUSTER_UID
+              valueFrom:
+                configMapKeyRef:
+                  key: id
+                  name: cluster-info
+            - name: TOKEN
+              valueFrom:
+                secretKeyRef:
+                  key: OBSERVE_TOKEN
+                  name: agent-credentials
+                  optional: true
+          livenessProbe:
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            httpGet:
+              path: /status
+              port: 13133
+          readinessProbe:
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            httpGet:
+              path: /status
+              port: 13133
+          resources:
+            limits:
+              memory: 256Mi
+            requests:
+              cpu: 150m
+              memory: 256Mi
+          volumeMounts:
+            - mountPath: /conf
+              name: cluster-events-configmap
+            - mountPath: /observe-agent-conf
+              name: observe-agent-deployment-config
+      initContainers:
+        - env:
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          image: observeinc/kube-cluster-info:v0.11.6
+          imagePullPolicy: Always
+          name: kube-cluster-info
+      volumes:
+        - name: cluster-events-configmap
+          configMap:
+            name: cluster-events
+            items:
+              - key: relay
+                path: relay.yaml
+        - configMap:
+            defaultMode: 420
+            items:
+            - key: relay
+              path: observe-agent.yaml
+            name: observe-agent
+          name: observe-agent-deployment-config
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: observeinc.com/unschedulable
+                operator: DoesNotExist
+              - key: kubernetes.io/os
+                operator: NotIn
+                values:
+                - windows
+      hostNetwork: false

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/cluster-events/networkpolicy.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/cluster-events/networkpolicy.yaml
@@ -1,0 +1,39 @@
+---
+# Source: agent/charts/cluster-events/templates/networkpolicy.yaml
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: example-cluster-events
+  namespace: observe
+  labels:
+    helm.sh/chart: cluster-events-0.143.0
+    app.kubernetes.io/name: cluster-events
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-collector
+    app.kubernetes.io/component: standalone-collector
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: cluster-events
+      app.kubernetes.io/instance: example
+      component: standalone-collector
+  ingress:
+    - ports:
+        - port: 6831
+          protocol: UDP
+        - port: 14250
+          protocol: TCP
+        - port: 14268
+          protocol: TCP
+        - port: 8888
+          protocol: TCP
+        - port: 4317
+          protocol: TCP
+        - port: 4318
+          protocol: TCP
+        - port: 9411
+          protocol: TCP
+  egress:
+    - {}

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/cluster-events/service.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/cluster-events/service.yaml
@@ -1,0 +1,54 @@
+---
+# Source: agent/charts/cluster-events/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-cluster-events
+  namespace: observe
+  labels:
+    helm.sh/chart: cluster-events-0.143.0
+    app.kubernetes.io/name: cluster-events
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-collector
+    app.kubernetes.io/component: standalone-collector
+    component: standalone-collector
+spec:
+  type: ClusterIP
+  ports:
+
+    - name: jaeger-compact
+      port: 6831
+      targetPort: 6831
+      protocol: UDP
+    - name: jaeger-grpc
+      port: 14250
+      targetPort: 14250
+      protocol: TCP
+    - name: jaeger-thrift
+      port: 14268
+      targetPort: 14268
+      protocol: TCP
+    - name: metrics
+      port: 8888
+      targetPort: 8888
+      protocol: TCP
+    - name: otlp
+      port: 4317
+      targetPort: 4317
+      protocol: TCP
+      appProtocol: grpc
+    - name: otlp-http
+      port: 4318
+      targetPort: 4318
+      protocol: TCP
+    - name: zipkin
+      port: 9411
+      targetPort: 9411
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: cluster-events
+    app.kubernetes.io/instance: example
+    component: standalone-collector
+  internalTrafficPolicy: Cluster

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/cluster-metrics-configmap.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/cluster-metrics-configmap.yaml
@@ -1,0 +1,129 @@
+---
+# Source: agent/templates/cluster-metrics-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-metrics
+  namespace: observe
+data:
+  relay: |
+      exporters:
+        debug/override:
+          sampling_initial: 2
+          sampling_thereafter: 1
+          verbosity: basic
+        prometheusremotewrite/observe:
+          endpoint: ${env:OBSERVE_PROMETHEUS_ENDPOINT}
+          headers:
+            authorization: ${env:OBSERVE_AUTHORIZATION_HEADER}
+            x-observe-target-package: Kubernetes Explorer
+          max_batch_request_parallelism: 5
+          remote_write_queue:
+            num_consumers: 5
+          resource_to_telemetry_conversion:
+            enabled: true
+          retry_on_failure:
+            enabled: true
+            initial_interval: 1s
+            max_elapsed_time: 5m
+            max_interval: 30s
+          send_metadata: true
+          timeout: 10s
+      processors:
+        attributes/debug_source_cluster_metrics:
+          actions:
+          - action: insert
+            key: debug_source
+            value: cluster_metrics
+        batch:
+          send_batch_max_size: 4096
+          send_batch_size: 4096
+          timeout: 5s
+        k8sattributes:
+          extract:
+            labels:
+            - from: pod
+              key_regex: (app\.kubernetes\.io/.+)
+              tag_name: $1
+            metadata:
+            - k8s.namespace.name
+            - k8s.deployment.name
+            - k8s.replicaset.name
+            - k8s.statefulset.name
+            - k8s.daemonset.name
+            - k8s.cronjob.name
+            - k8s.job.name
+            - k8s.node.name
+            - k8s.node.uid
+            - k8s.pod.name
+            - k8s.pod.uid
+            - k8s.cluster.uid
+            - k8s.container.name
+            - service.namespace
+            - service.name
+            - service.version
+            - service.instance.id
+            otel_annotations: true
+          passthrough: false
+          pod_association:
+          - sources:
+            - from: resource_attribute
+              name: k8s.pod.ip
+          - sources:
+            - from: resource_attribute
+              name: k8s.pod.uid
+          - sources:
+            - from: connection
+          wait_for_metadata: false
+          wait_for_metadata_timeout: 10s
+        memory_limiter:
+          check_interval: 5s
+          limit_percentage: 80
+          spike_limit_percentage: 15
+        resource/drop_container_info:
+          attributes:
+          - action: delete
+            key: container.id
+        resource/drop_service_name:
+          attributes:
+          - action: delete
+            key: service.name
+        resource/observe_common:
+          attributes:
+          - action: upsert
+            key: k8s.cluster.name
+            value: ${env:OBSERVE_CLUSTER_NAME}
+          - action: upsert
+            key: k8s.cluster.uid
+            value: ${env:OBSERVE_CLUSTER_UID}
+      receivers:
+        k8s_cluster:
+          allocatable_types_to_report:
+          - cpu
+          - memory
+          - storage
+          - ephemeral-storage
+          auth_type: serviceAccount
+          collection_interval: 60s
+          metadata_collection_interval: 5m
+          metrics:
+            k8s.node.condition:
+              enabled: true
+          node_conditions_to_report:
+          - Ready
+          - MemoryPressure
+          - DiskPressure
+      service:
+        pipelines:
+          metrics:
+            exporters:
+            - prometheusremotewrite/observe
+            processors:
+            - memory_limiter
+            - k8sattributes
+            - batch
+            - resource/observe_common
+            - resource/drop_container_info
+            - attributes/debug_source_cluster_metrics
+            receivers:
+            - k8s_cluster

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/cluster-metrics/deployment.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/cluster-metrics/deployment.yaml
@@ -1,0 +1,172 @@
+---
+# Source: agent/charts/cluster-metrics/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-cluster-metrics
+  namespace: observe
+  labels:
+    helm.sh/chart: cluster-metrics-0.143.0
+    app.kubernetes.io/name: cluster-metrics
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-collector
+    app.kubernetes.io/component: standalone-collector
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: cluster-metrics
+      app.kubernetes.io/instance: example
+      component: standalone-collector
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+        observe_monitor_path: /metrics
+        observe_monitor_port: "8888"
+        observe_monitor_purpose: observecollection
+        observe_monitor_scrape: "true"
+        observeinc_com_scrape: "false"
+      labels:
+        app.kubernetes.io/name: cluster-metrics
+        app.kubernetes.io/instance: example
+        component: standalone-collector
+
+    spec:
+
+      serviceAccountName: observe-agent-service-account
+      automountServiceAccountToken: true
+      securityContext:
+        {}
+      containers:
+        - name: cluster-metrics
+          command:
+            - /observe-agent
+          args:
+            - --config=/conf/relay.yaml
+            - start
+            - --observe-config=/observe-agent-conf/observe-agent.yaml
+            - --config=/conf/relay.yaml
+            - --feature-gates=+exporter.prometheusremotewritexporter.EnableMultipleWorkers
+          securityContext:
+            {}
+          image: "observeinc/observe-agent:2.15.0"
+          imagePullPolicy: IfNotPresent
+          ports:
+
+            - name: jaeger-compact
+              containerPort: 6831
+              protocol: UDP
+            - name: jaeger-grpc
+              containerPort: 14250
+              protocol: TCP
+            - name: jaeger-thrift
+              containerPort: 14268
+              protocol: TCP
+            - name: metrics
+              containerPort: 8888
+              protocol: TCP
+            - name: otlp
+              containerPort: 4317
+              protocol: TCP
+            - name: otlp-http
+              containerPort: 4318
+              protocol: TCP
+            - name: zipkin
+              containerPort: 9411
+              protocol: TCP
+          env:
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: GOMEMLIMIT
+              value: "409MiB"
+            - name: OTEL_K8S_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+            - name: OTEL_K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OBSERVE_CLUSTER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  key: name
+                  name: cluster-name
+            - name: OBSERVE_CLUSTER_UID
+              valueFrom:
+                configMapKeyRef:
+                  key: id
+                  name: cluster-info
+            - name: TOKEN
+              valueFrom:
+                secretKeyRef:
+                  key: OBSERVE_TOKEN
+                  name: agent-credentials
+                  optional: true
+          livenessProbe:
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            httpGet:
+              path: /status
+              port: 13133
+          readinessProbe:
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            httpGet:
+              path: /status
+              port: 13133
+          resources:
+            limits:
+              memory: 512Mi
+            requests:
+              cpu: 250m
+              memory: 512Mi
+          volumeMounts:
+            - mountPath: /conf
+              name: cluster-metrics-configmap
+            - mountPath: /observe-agent-conf
+              name: observe-agent-deployment-config
+      initContainers:
+        - env:
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          image: observeinc/kube-cluster-info:v0.11.6
+          imagePullPolicy: Always
+          name: kube-cluster-info
+      volumes:
+        - name: cluster-metrics-configmap
+          configMap:
+            name: cluster-metrics
+            items:
+              - key: relay
+                path: relay.yaml
+        - configMap:
+            defaultMode: 420
+            items:
+            - key: relay
+              path: observe-agent.yaml
+            name: observe-agent
+          name: observe-agent-deployment-config
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: observeinc.com/unschedulable
+                operator: DoesNotExist
+              - key: kubernetes.io/os
+                operator: NotIn
+                values:
+                - windows
+      hostNetwork: false

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/cluster-metrics/networkpolicy.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/cluster-metrics/networkpolicy.yaml
@@ -1,0 +1,39 @@
+---
+# Source: agent/charts/cluster-metrics/templates/networkpolicy.yaml
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: example-cluster-metrics
+  namespace: observe
+  labels:
+    helm.sh/chart: cluster-metrics-0.143.0
+    app.kubernetes.io/name: cluster-metrics
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-collector
+    app.kubernetes.io/component: standalone-collector
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: cluster-metrics
+      app.kubernetes.io/instance: example
+      component: standalone-collector
+  ingress:
+    - ports:
+        - port: 6831
+          protocol: UDP
+        - port: 14250
+          protocol: TCP
+        - port: 14268
+          protocol: TCP
+        - port: 8888
+          protocol: TCP
+        - port: 4317
+          protocol: TCP
+        - port: 4318
+          protocol: TCP
+        - port: 9411
+          protocol: TCP
+  egress:
+    - {}

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/cluster-metrics/service.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/cluster-metrics/service.yaml
@@ -1,0 +1,54 @@
+---
+# Source: agent/charts/cluster-metrics/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-cluster-metrics
+  namespace: observe
+  labels:
+    helm.sh/chart: cluster-metrics-0.143.0
+    app.kubernetes.io/name: cluster-metrics
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-collector
+    app.kubernetes.io/component: standalone-collector
+    component: standalone-collector
+spec:
+  type: ClusterIP
+  ports:
+
+    - name: jaeger-compact
+      port: 6831
+      targetPort: 6831
+      protocol: UDP
+    - name: jaeger-grpc
+      port: 14250
+      targetPort: 14250
+      protocol: TCP
+    - name: jaeger-thrift
+      port: 14268
+      targetPort: 14268
+      protocol: TCP
+    - name: metrics
+      port: 8888
+      targetPort: 8888
+      protocol: TCP
+    - name: otlp
+      port: 4317
+      targetPort: 4317
+      protocol: TCP
+      appProtocol: grpc
+    - name: otlp-http
+      port: 4318
+      targetPort: 4318
+      protocol: TCP
+    - name: zipkin
+      port: 9411
+      targetPort: 9411
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: cluster-metrics
+    app.kubernetes.io/instance: example
+    component: standalone-collector
+  internalTrafficPolicy: Cluster

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/cluster-name-configmap.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/cluster-name-configmap.yaml
@@ -1,0 +1,9 @@
+---
+# Source: agent/templates/cluster-name-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-name
+  namespace: observe
+data:
+  name: observe-agent-monitored-cluster

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/cluster-role.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/cluster-role.yaml
@@ -1,0 +1,53 @@
+---
+# Source: agent/templates/cluster-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: observe-agent-cluster-role-observe
+  labels:
+    app.kubernetes.io/name: observe-agent-cluster-role
+    app.kubernetes.io/instance: observe-agent
+
+rules:
+  - apiGroups:
+    - ""
+    resources:
+    - configmaps
+    verbs:
+    - create
+    - get
+  - apiGroups:
+    - ""
+    - '*'
+    - apps
+    - authorization.k8s.io
+    - autoscaling
+    - batch
+    - networking.k8s.io
+    - events.k8s.io
+    - rbac.authorization.k8s.io
+    - storage.k8s.io
+    - vpcresources.k8s.aws
+    resources:
+    - '*'
+    verbs:
+    - get
+    - list
+    - watch
+---
+# Source: agent/templates/cluster-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: observe-agent-cluster-role-binding
+  labels:
+    app.kubernetes.io/name: observe-agent-cluster-role-binding-observe
+    app.kubernetes.io/instance: observe-agent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: observe-agent-cluster-role-observe
+subjects:
+- kind: ServiceAccount
+  name: observe-agent-service-account
+  namespace: observe

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/forwarder-configmap.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/forwarder-configmap.yaml
@@ -1,0 +1,237 @@
+---
+# Source: agent/templates/forwarder-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: forwarder
+  namespace: observe
+data:
+  relay: |
+      exporters:
+        debug/override:
+          sampling_initial: 2
+          sampling_thereafter: 1
+          verbosity: basic
+        otlphttp/observe/base:
+          compression: zstd
+          endpoint: ${env:OBSERVE_OTEL_ENDPOINT}
+          headers:
+            authorization: ${env:OBSERVE_AUTHORIZATION_HEADER}
+            x-observe-target-package: Kubernetes Explorer
+          retry_on_failure:
+            enabled: true
+            initial_interval: 1s
+            max_elapsed_time: 5m
+            max_interval: 30s
+          sending_queue:
+            enabled: true
+          timeout: 10s
+        otlphttp/observe/forward/trace:
+          compression: zstd
+          endpoint: ${env:OBSERVE_OTEL_ENDPOINT}
+          headers:
+            authorization: Bearer ${env:TRACE_TOKEN}
+            x-observe-target-package: Tracing
+          retry_on_failure:
+            enabled: true
+            initial_interval: 1s
+            max_elapsed_time: 5m
+            max_interval: 30s
+          sending_queue:
+            enabled: true
+          timeout: 10s
+        otlphttp/observe/otel_metrics:
+          compression: zstd
+          endpoint: ${env:OBSERVE_OTEL_ENDPOINT}
+          headers:
+            authorization: ${env:OBSERVE_AUTHORIZATION_HEADER}
+            x-observe-target-package: Metrics
+          retry_on_failure:
+            enabled: true
+            initial_interval: 1s
+            max_elapsed_time: 5m
+            max_interval: 30s
+          sending_queue:
+            enabled: true
+          timeout: 10s
+        prometheusremotewrite/observe:
+          endpoint: ${env:OBSERVE_PROMETHEUS_ENDPOINT}
+          headers:
+            authorization: ${env:OBSERVE_AUTHORIZATION_HEADER}
+            x-observe-target-package: Kubernetes Explorer
+          max_batch_request_parallelism: 5
+          remote_write_queue:
+            num_consumers: 5
+          resource_to_telemetry_conversion:
+            enabled: true
+          retry_on_failure:
+            enabled: true
+            initial_interval: 1s
+            max_elapsed_time: 5m
+            max_interval: 30s
+          send_metadata: true
+          timeout: 10s
+      processors:
+        attributes/debug_source_app_logs:
+          actions:
+          - action: insert
+            key: debug_source
+            value: app_logs
+        attributes/debug_source_app_metrics:
+          actions:
+          - action: insert
+            key: debug_source
+            value: app_metrics
+        attributes/debug_source_app_traces:
+          actions:
+          - action: insert
+            key: debug_source
+            value: app_traces
+        batch:
+          send_batch_max_size: 4096
+          send_batch_size: 4096
+          timeout: 5s
+        deltatocumulative/observe:
+          max_stale: 5m
+        filter/drop_long_spans:
+          error_mode: ignore
+          traces:
+            span:
+            - (span.end_time - span.start_time) > Duration("1h")
+        k8sattributes:
+          extract:
+            labels:
+            - from: pod
+              key_regex: (app\.kubernetes\.io/.+)
+              tag_name: $1
+            metadata:
+            - k8s.namespace.name
+            - k8s.deployment.name
+            - k8s.replicaset.name
+            - k8s.statefulset.name
+            - k8s.daemonset.name
+            - k8s.cronjob.name
+            - k8s.job.name
+            - k8s.node.name
+            - k8s.node.uid
+            - k8s.pod.name
+            - k8s.pod.uid
+            - k8s.cluster.uid
+            - k8s.container.name
+            - container.id
+            - service.namespace
+            - service.name
+            - service.version
+            - service.instance.id
+            otel_annotations: true
+          passthrough: false
+          pod_association:
+          - sources:
+            - from: resource_attribute
+              name: k8s.pod.ip
+          - sources:
+            - from: resource_attribute
+              name: k8s.pod.uid
+          - sources:
+            - from: connection
+          wait_for_metadata: false
+          wait_for_metadata_timeout: 10s
+        memory_limiter:
+          check_interval: 5s
+          limit_percentage: 80
+          spike_limit_percentage: 15
+        resource/add_empty_service_attributes:
+          attributes:
+          - action: insert
+            key: service.name
+            value: ""
+          - action: insert
+            key: service.namespace
+            value: ""
+          - action: insert
+            key: deployment.environment
+            value: ""
+        resource/observe_common:
+          attributes:
+          - action: upsert
+            key: k8s.cluster.name
+            value: ${env:OBSERVE_CLUSTER_NAME}
+          - action: upsert
+            key: k8s.cluster.uid
+            value: ${env:OBSERVE_CLUSTER_UID}
+        resourcedetection/cloud:
+          detectors:
+          - eks
+          - gcp
+          - ecs
+          - ec2
+          - azure
+          override: false
+          timeout: 2s
+        transform/add_span_status_code:
+          error_mode: ignore
+          trace_statements:
+          - set(span.attributes["observe.status_code"], Int(span.attributes["rpc.grpc.status_code"]))
+            where span.attributes["observe.status_code"] == nil and span.attributes["rpc.grpc.status_code"]
+            != nil
+          - set(span.attributes["observe.status_code"], Int(span.attributes["grpc.status_code"]))
+            where span.attributes["observe.status_code"] == nil and span.attributes["grpc.status_code"]
+            != nil
+          - set(span.attributes["observe.status_code"], Int(span.attributes["rpc.status_code"]))
+            where span.attributes["observe.status_code"] == nil and span.attributes["rpc.status_code"]
+            != nil
+          - set(span.attributes["observe.status_code"], Int(span.attributes["http.status_code"]))
+            where span.attributes["observe.status_code"] == nil and span.attributes["http.status_code"]
+            != nil
+          - set(span.attributes["observe.status_code"], Int(span.attributes["http.response.status_code"]))
+            where span.attributes["observe.status_code"] == nil and span.attributes["http.response.status_code"]
+            != nil
+      receivers:
+        otlp/app-telemetry:
+          protocols:
+            grpc:
+              endpoint: ${env:MY_POD_IP}:4317
+            http:
+              endpoint: ${env:MY_POD_IP}:4318
+      service:
+        pipelines:
+          logs/observe-forward:
+            exporters:
+            - otlphttp/observe/base
+            processors:
+            - memory_limiter
+            - k8sattributes
+            - batch
+            - resourcedetection/cloud
+            - resource/observe_common
+            - attributes/debug_source_app_logs
+            receivers:
+            - otlp/app-telemetry
+          metrics/observe-forward:
+            exporters:
+            - prometheusremotewrite/observe
+            processors:
+            - memory_limiter
+            - k8sattributes
+            - deltatocumulative/observe
+            - batch
+            - resourcedetection/cloud
+            - resource/observe_common
+            - attributes/debug_source_app_metrics
+            receivers:
+            - otlp/app-telemetry
+          traces/observe-forward:
+            exporters:
+            - otlphttp/observe/forward/trace
+            processors:
+            - filter/drop_long_spans
+            - memory_limiter
+            - transform/add_span_status_code
+            - resource/add_empty_service_attributes
+            - k8sattributes
+            - batch
+            - resourcedetection/cloud
+            - resource/observe_common
+            - attributes/debug_source_app_traces
+            receivers:
+            - otlp/app-telemetry

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/forwarder/daemonset.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/forwarder/daemonset.yaml
@@ -1,0 +1,186 @@
+---
+# Source: agent/charts/forwarder/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: example-forwarder-agent
+  namespace: observe
+  labels:
+    helm.sh/chart: forwarder-0.143.0
+    app.kubernetes.io/name: forwarder
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-collector
+    app.kubernetes.io/component: agent-collector
+spec:
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: forwarder
+      app.kubernetes.io/instance: example
+      component: agent-collector
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+        observe_monitor_path: /metrics
+        observe_monitor_port: "8888"
+        observe_monitor_purpose: observecollection
+        observe_monitor_scrape: "true"
+        observeinc_com_scrape: "false"
+      labels:
+        app.kubernetes.io/name: forwarder
+        app.kubernetes.io/instance: example
+        component: agent-collector
+
+    spec:
+
+      serviceAccountName: observe-agent-service-account
+      automountServiceAccountToken: true
+      securityContext:
+        {}
+      containers:
+        - name: forwarder
+          command:
+            - /observe-agent
+          args:
+            - --config=/conf/relay.yaml
+            - start
+            - --observe-config=/observe-agent-conf/observe-agent.yaml
+            - --config=/conf/relay.yaml
+          securityContext:
+            {}
+          image: "observeinc/observe-agent:2.15.0"
+          imagePullPolicy: IfNotPresent
+          ports:
+
+            - name: jaeger-compact
+              containerPort: 6831
+              protocol: UDP
+              hostPort: 6831
+            - name: jaeger-grpc
+              containerPort: 14250
+              protocol: TCP
+              hostPort: 14250
+            - name: jaeger-thrift
+              containerPort: 14268
+              protocol: TCP
+              hostPort: 14268
+            - name: metrics
+              containerPort: 8888
+              protocol: TCP
+            - name: otlp
+              containerPort: 4317
+              protocol: TCP
+              hostPort: 4317
+            - name: otlp-http
+              containerPort: 4318
+              protocol: TCP
+              hostPort: 4318
+            - name: zipkin
+              containerPort: 9411
+              protocol: TCP
+              hostPort: 9411
+          env:
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: GOMEMLIMIT
+              value: "409MiB"
+            - name: OTEL_K8S_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+            - name: OTEL_K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OBSERVE_CLUSTER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  key: name
+                  name: cluster-name
+            - name: OBSERVE_CLUSTER_UID
+              valueFrom:
+                configMapKeyRef:
+                  key: id
+                  name: cluster-info
+            - name: K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: TOKEN
+              valueFrom:
+                secretKeyRef:
+                  key: OBSERVE_TOKEN
+                  name: agent-credentials
+                  optional: true
+            - name: TRACE_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  key: TRACE_TOKEN
+                  name: agent-credentials
+                  optional: true
+          livenessProbe:
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            httpGet:
+              path: /status
+              port: 13133
+          readinessProbe:
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            httpGet:
+              path: /status
+              port: 13133
+          resources:
+            limits:
+              memory: 512Mi
+            requests:
+              cpu: 300m
+              memory: 512Mi
+          volumeMounts:
+            - mountPath: /conf
+              name: forwarder-configmap
+            - mountPath: /observe-agent-conf
+              name: observe-agent-deployment-config
+      initContainers:
+        - env:
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          image: observeinc/kube-cluster-info:v0.11.6
+          imagePullPolicy: Always
+          name: kube-cluster-info
+      volumes:
+        - name: forwarder-configmap
+          configMap:
+            name: forwarder
+            items:
+              - key: relay
+                path: relay.yaml
+        - configMap:
+            defaultMode: 420
+            items:
+            - key: relay
+              path: observe-agent.yaml
+            name: observe-agent
+          name: observe-agent-deployment-config
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: observeinc.com/unschedulable
+                operator: DoesNotExist
+              - key: kubernetes.io/os
+                operator: NotIn
+                values:
+                - windows
+      hostNetwork: false

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/forwarder/networkpolicy.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/forwarder/networkpolicy.yaml
@@ -1,0 +1,39 @@
+---
+# Source: agent/charts/forwarder/templates/networkpolicy.yaml
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: example-forwarder
+  namespace: observe
+  labels:
+    helm.sh/chart: forwarder-0.143.0
+    app.kubernetes.io/name: forwarder
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-collector
+    app.kubernetes.io/component: agent-collector
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: forwarder
+      app.kubernetes.io/instance: example
+      component: agent-collector
+  ingress:
+    - ports:
+        - port: 6831
+          protocol: UDP
+        - port: 14250
+          protocol: TCP
+        - port: 14268
+          protocol: TCP
+        - port: 8888
+          protocol: TCP
+        - port: 4317
+          protocol: TCP
+        - port: 4318
+          protocol: TCP
+        - port: 9411
+          protocol: TCP
+  egress:
+    - {}

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/forwarder/service.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/forwarder/service.yaml
@@ -1,0 +1,54 @@
+---
+# Source: agent/charts/forwarder/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-forwarder
+  namespace: observe
+  labels:
+    helm.sh/chart: forwarder-0.143.0
+    app.kubernetes.io/name: forwarder
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-collector
+    app.kubernetes.io/component: agent-collector
+    component: agent-collector
+spec:
+  type: ClusterIP
+  ports:
+
+    - name: jaeger-compact
+      port: 6831
+      targetPort: 6831
+      protocol: UDP
+    - name: jaeger-grpc
+      port: 14250
+      targetPort: 14250
+      protocol: TCP
+    - name: jaeger-thrift
+      port: 14268
+      targetPort: 14268
+      protocol: TCP
+    - name: metrics
+      port: 8888
+      targetPort: 8888
+      protocol: TCP
+    - name: otlp
+      port: 4317
+      targetPort: 4317
+      protocol: TCP
+      appProtocol: grpc
+    - name: otlp-http
+      port: 4318
+      targetPort: 4318
+      protocol: TCP
+    - name: zipkin
+      port: 9411
+      targetPort: 9411
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: forwarder
+    app.kubernetes.io/instance: example
+    component: agent-collector
+  internalTrafficPolicy: Local

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/monitor/deployment.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/monitor/deployment.yaml
@@ -1,0 +1,172 @@
+---
+# Source: agent/charts/monitor/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-monitor
+  namespace: observe
+  labels:
+    helm.sh/chart: monitor-0.143.0
+    app.kubernetes.io/name: monitor
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-collector
+    app.kubernetes.io/component: standalone-collector
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: monitor
+      app.kubernetes.io/instance: example
+      component: standalone-collector
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+        observe_monitor_path: /metrics
+        observe_monitor_port: "8888"
+        observe_monitor_purpose: observecollection
+        observe_monitor_scrape: "false"
+        observeinc_com_scrape: "false"
+      labels:
+        app.kubernetes.io/name: monitor
+        app.kubernetes.io/instance: example
+        component: standalone-collector
+
+    spec:
+
+      serviceAccountName: observe-agent-service-account
+      automountServiceAccountToken: true
+      securityContext:
+        {}
+      containers:
+        - name: monitor
+          command:
+            - /observe-agent
+          args:
+            - --config=/conf/relay.yaml
+            - start
+            - --observe-config=/observe-agent-conf/observe-agent.yaml
+            - --config=/conf/relay.yaml
+            - --feature-gates=+exporter.prometheusremotewritexporter.EnableMultipleWorkers
+          securityContext:
+            {}
+          image: "observeinc/observe-agent:2.15.0"
+          imagePullPolicy: IfNotPresent
+          ports:
+
+            - name: jaeger-compact
+              containerPort: 6831
+              protocol: UDP
+            - name: jaeger-grpc
+              containerPort: 14250
+              protocol: TCP
+            - name: jaeger-thrift
+              containerPort: 14268
+              protocol: TCP
+            - name: metrics
+              containerPort: 8888
+              protocol: TCP
+            - name: otlp
+              containerPort: 4317
+              protocol: TCP
+            - name: otlp-http
+              containerPort: 4318
+              protocol: TCP
+            - name: zipkin
+              containerPort: 9411
+              protocol: TCP
+          env:
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: GOMEMLIMIT
+              value: "204MiB"
+            - name: OTEL_K8S_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+            - name: OTEL_K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OBSERVE_CLUSTER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  key: name
+                  name: cluster-name
+            - name: OBSERVE_CLUSTER_UID
+              valueFrom:
+                configMapKeyRef:
+                  key: id
+                  name: cluster-info
+            - name: TOKEN
+              valueFrom:
+                secretKeyRef:
+                  key: OBSERVE_TOKEN
+                  name: agent-credentials
+                  optional: true
+          livenessProbe:
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            httpGet:
+              path: /status
+              port: 13133
+          readinessProbe:
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            httpGet:
+              path: /status
+              port: 13133
+          resources:
+            limits:
+              memory: 256Mi
+            requests:
+              cpu: 150m
+              memory: 256Mi
+          volumeMounts:
+            - mountPath: /conf
+              name: monitor-configmap
+            - mountPath: /observe-agent-conf
+              name: observe-agent-deployment-config
+      initContainers:
+        - env:
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          image: observeinc/kube-cluster-info:v0.11.6
+          imagePullPolicy: Always
+          name: kube-cluster-info
+      volumes:
+        - name: monitor-configmap
+          configMap:
+            name: monitor
+            items:
+              - key: relay
+                path: relay.yaml
+        - configMap:
+            defaultMode: 420
+            items:
+            - key: relay
+              path: observe-agent.yaml
+            name: observe-agent
+          name: observe-agent-deployment-config
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: observeinc.com/unschedulable
+                operator: DoesNotExist
+              - key: kubernetes.io/os
+                operator: NotIn
+                values:
+                - windows
+      hostNetwork: false

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/monitor/networkpolicy.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/monitor/networkpolicy.yaml
@@ -1,0 +1,39 @@
+---
+# Source: agent/charts/monitor/templates/networkpolicy.yaml
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: example-monitor
+  namespace: observe
+  labels:
+    helm.sh/chart: monitor-0.143.0
+    app.kubernetes.io/name: monitor
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-collector
+    app.kubernetes.io/component: standalone-collector
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: monitor
+      app.kubernetes.io/instance: example
+      component: standalone-collector
+  ingress:
+    - ports:
+        - port: 6831
+          protocol: UDP
+        - port: 14250
+          protocol: TCP
+        - port: 14268
+          protocol: TCP
+        - port: 8888
+          protocol: TCP
+        - port: 4317
+          protocol: TCP
+        - port: 4318
+          protocol: TCP
+        - port: 9411
+          protocol: TCP
+  egress:
+    - {}

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/monitor/service.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/monitor/service.yaml
@@ -1,0 +1,54 @@
+---
+# Source: agent/charts/monitor/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-monitor
+  namespace: observe
+  labels:
+    helm.sh/chart: monitor-0.143.0
+    app.kubernetes.io/name: monitor
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-collector
+    app.kubernetes.io/component: standalone-collector
+    component: standalone-collector
+spec:
+  type: ClusterIP
+  ports:
+
+    - name: jaeger-compact
+      port: 6831
+      targetPort: 6831
+      protocol: UDP
+    - name: jaeger-grpc
+      port: 14250
+      targetPort: 14250
+      protocol: TCP
+    - name: jaeger-thrift
+      port: 14268
+      targetPort: 14268
+      protocol: TCP
+    - name: metrics
+      port: 8888
+      targetPort: 8888
+      protocol: TCP
+    - name: otlp
+      port: 4317
+      targetPort: 4317
+      protocol: TCP
+      appProtocol: grpc
+    - name: otlp-http
+      port: 4318
+      targetPort: 4318
+      protocol: TCP
+    - name: zipkin
+      port: 9411
+      targetPort: 9411
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: monitor
+    app.kubernetes.io/instance: example
+    component: standalone-collector
+  internalTrafficPolicy: Cluster

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/node-logs-metrics-configmap.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/node-logs-metrics-configmap.yaml
@@ -1,0 +1,298 @@
+---
+# Source: agent/templates/node-logs-metrics-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: node-logs-metrics
+  namespace: observe
+data:
+  relay: |
+      exporters:
+        debug/override:
+          sampling_initial: 2
+          sampling_thereafter: 1
+          verbosity: basic
+        otlphttp/observe/base:
+          compression: zstd
+          endpoint: ${env:OBSERVE_OTEL_ENDPOINT}
+          headers:
+            authorization: ${env:OBSERVE_AUTHORIZATION_HEADER}
+            x-observe-target-package: Kubernetes Explorer
+          retry_on_failure:
+            enabled: true
+            initial_interval: 1s
+            max_elapsed_time: 5m
+            max_interval: 30s
+          sending_queue:
+            enabled: true
+          timeout: 10s
+        prometheusremotewrite/observe:
+          endpoint: ${env:OBSERVE_PROMETHEUS_ENDPOINT}
+          headers:
+            authorization: ${env:OBSERVE_AUTHORIZATION_HEADER}
+            x-observe-target-package: Kubernetes Explorer
+          max_batch_request_parallelism: 5
+          remote_write_queue:
+            num_consumers: 5
+          resource_to_telemetry_conversion:
+            enabled: true
+          retry_on_failure:
+            enabled: true
+            initial_interval: 1s
+            max_elapsed_time: 5m
+            max_interval: 30s
+          send_metadata: true
+          timeout: 10s
+      extensions:
+        file_storage:
+          create_directory: true
+      processors:
+        attributes/debug_source_hostmetrics:
+          actions:
+          - action: insert
+            key: debug_source
+            value: hostmetrics
+        attributes/debug_source_kubeletstats_metrics:
+          actions:
+          - action: insert
+            key: debug_source
+            value: kubeletstats_metrics
+        attributes/debug_source_pod_logs:
+          actions:
+          - action: insert
+            key: debug_source
+            value: pod_logs
+        batch:
+          send_batch_max_size: 4096
+          send_batch_size: 4096
+          timeout: 5s
+        k8sattributes:
+          extract:
+            labels:
+            - from: pod
+              key_regex: (app\.kubernetes\.io/.+)
+              tag_name: $1
+            metadata:
+            - k8s.namespace.name
+            - k8s.deployment.name
+            - k8s.replicaset.name
+            - k8s.statefulset.name
+            - k8s.daemonset.name
+            - k8s.cronjob.name
+            - k8s.job.name
+            - k8s.node.name
+            - k8s.node.uid
+            - k8s.pod.name
+            - k8s.pod.uid
+            - k8s.cluster.uid
+            - k8s.container.name
+            - container.id
+            - service.namespace
+            - service.name
+            - service.version
+            - service.instance.id
+            otel_annotations: true
+          passthrough: false
+          pod_association:
+          - sources:
+            - from: resource_attribute
+              name: k8s.pod.ip
+          - sources:
+            - from: resource_attribute
+              name: k8s.pod.uid
+          - sources:
+            - from: connection
+          wait_for_metadata: false
+          wait_for_metadata_timeout: 10s
+        memory_limiter:
+          check_interval: 5s
+          limit_percentage: 80
+          spike_limit_percentage: 15
+        metricstransform/duplicate_k8s_cpu_metrics:
+          transforms:
+          - action: insert
+            include: container.cpu.usage
+            new_name: container.cpu.utilization
+          - action: insert
+            include: k8s.pod.cpu.usage
+            new_name: k8s.pod.cpu.utilization
+          - action: insert
+            include: k8s.node.cpu.usage
+            new_name: k8s.node.cpu.utilization
+        resource/observe_common:
+          attributes:
+          - action: upsert
+            key: k8s.cluster.name
+            value: ${env:OBSERVE_CLUSTER_NAME}
+          - action: upsert
+            key: k8s.cluster.uid
+            value: ${env:OBSERVE_CLUSTER_UID}
+        resourcedetection/cloud:
+          detectors:
+          - eks
+          - gcp
+          - ecs
+          - ec2
+          - azure
+          override: false
+          timeout: 2s
+      receivers:
+        filelog:
+          exclude:
+          - '**/*.gz'
+          - '**/*.tmp'
+          exclude_older_than: 24h
+          include:
+          - /var/log/pods/*/*/*.log
+          - /var/log/pods/*/*/*.log.*
+          include_file_name: false
+          include_file_path: true
+          max_log_size: 1024kb
+          operators:
+          - id: container-parser
+            max_log_size: 102400
+            type: container
+          poll_interval: 20ms
+          retry_on_failure:
+            enabled: true
+            initial_interval: 1s
+            max_elapsed_time: 5m
+            max_interval: 30s
+          start_at: end
+          storage: file_storage
+        hostmetrics:
+          collection_interval: 60s
+          root_path: /hostfs
+          scrapers:
+            cpu: null
+            disk: null
+            filesystem:
+              exclude_fs_types:
+                fs_types:
+                - autofs
+                - binfmt_misc
+                - bpf
+                - cgroup2
+                - configfs
+                - debugfs
+                - devpts
+                - devtmpfs
+                - fusectl
+                - hugetlbfs
+                - iso9660
+                - mqueue
+                - nsfs
+                - overlay
+                - proc
+                - procfs
+                - pstore
+                - rpc_pipefs
+                - securityfs
+                - selinuxfs
+                - squashfs
+                - sysfs
+                - tracefs
+                match_type: strict
+              exclude_mount_points:
+                match_type: regexp
+                mount_points:
+                - /dev/*
+                - /proc/*
+                - /sys/*
+                - /run/k3s/containerd/*
+                - /var/lib/docker/*
+                - /var/lib/kubelet/*
+                - /snap/*
+            load: null
+            memory: null
+            network: null
+        kubeletstats:
+          auth_type: serviceAccount
+          collection_interval: 60s
+          endpoint: ${env:K8S_NODE_NAME}:10250
+          extra_metadata_labels:
+          - container.id
+          insecure_skip_verify: true
+          k8s_api_config:
+            auth_type: serviceAccount
+          metric_groups:
+          - node
+          - pod
+          - container
+          metrics:
+            container.cpu.usage:
+              enabled: true
+            container.uptime:
+              enabled: true
+            k8s.container.cpu.node.utilization:
+              enabled: true
+            k8s.container.cpu_limit_utilization:
+              enabled: true
+            k8s.container.cpu_request_utilization:
+              enabled: true
+            k8s.container.memory.node.utilization:
+              enabled: true
+            k8s.container.memory_limit_utilization:
+              enabled: true
+            k8s.container.memory_request_utilization:
+              enabled: true
+            k8s.node.cpu.usage:
+              enabled: true
+            k8s.node.uptime:
+              enabled: true
+            k8s.pod.cpu.node.utilization:
+              enabled: true
+            k8s.pod.cpu.usage:
+              enabled: true
+            k8s.pod.cpu_limit_utilization:
+              enabled: true
+            k8s.pod.cpu_request_utilization:
+              enabled: true
+            k8s.pod.memory.node.utilization:
+              enabled: true
+            k8s.pod.memory_limit_utilization:
+              enabled: true
+            k8s.pod.memory_request_utilization:
+              enabled: true
+            k8s.pod.uptime:
+              enabled: true
+          node: ${env:K8S_NODE_NAME}
+      service:
+        pipelines:
+          logs:
+            exporters:
+            - otlphttp/observe/base
+            processors:
+            - memory_limiter
+            - k8sattributes
+            - batch
+            - resourcedetection/cloud
+            - resource/observe_common
+            - attributes/debug_source_pod_logs
+            receivers:
+            - filelog
+          metrics/hostmetrics:
+            exporters:
+            - prometheusremotewrite/observe
+            processors:
+            - memory_limiter
+            - k8sattributes
+            - batch
+            - resourcedetection/cloud
+            - resource/observe_common
+            - attributes/debug_source_hostmetrics
+            receivers:
+            - hostmetrics
+          metrics/kubeletstats:
+            exporters:
+            - prometheusremotewrite/observe
+            processors:
+            - memory_limiter
+            - metricstransform/duplicate_k8s_cpu_metrics
+            - k8sattributes
+            - batch
+            - resourcedetection/cloud
+            - resource/observe_common
+            - attributes/debug_source_kubeletstats_metrics
+            receivers:
+            - kubeletstats

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/node-logs-metrics/daemonset.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/node-logs-metrics/daemonset.yaml
@@ -1,0 +1,193 @@
+---
+# Source: agent/charts/node-logs-metrics/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: example-node-logs-metrics-agent
+  namespace: observe
+  labels:
+    helm.sh/chart: node-logs-metrics-0.143.0
+    app.kubernetes.io/name: node-logs-metrics
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-collector
+    app.kubernetes.io/component: agent-collector
+spec:
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: node-logs-metrics
+      app.kubernetes.io/instance: example
+      component: agent-collector
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+        observe_monitor_path: /metrics
+        observe_monitor_port: "8888"
+        observe_monitor_purpose: observecollection
+        observe_monitor_scrape: "true"
+        observeinc_com_scrape: "false"
+      labels:
+        app.kubernetes.io/name: node-logs-metrics
+        app.kubernetes.io/instance: example
+        component: agent-collector
+
+    spec:
+
+      serviceAccountName: observe-agent-service-account
+      automountServiceAccountToken: true
+      securityContext:
+        {}
+      containers:
+        - name: node-logs-metrics
+          command:
+            - /observe-agent
+          args:
+            - --config=/conf/relay.yaml
+            - start
+            - --observe-config=/observe-agent-conf/observe-agent.yaml
+            - --config=/conf/relay.yaml
+            - --feature-gates=+exporter.prometheusremotewritexporter.EnableMultipleWorkers
+          securityContext:
+            runAsGroup: 0
+            runAsUser: 0
+          image: "observeinc/observe-agent:2.15.0"
+          imagePullPolicy: IfNotPresent
+          ports:
+
+            - name: metrics
+              containerPort: 8888
+              protocol: TCP
+          env:
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: GOMEMLIMIT
+              value: "409MiB"
+            - name: OTEL_K8S_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+            - name: OTEL_K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OBSERVE_CLUSTER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  key: name
+                  name: cluster-name
+            - name: OBSERVE_CLUSTER_UID
+              valueFrom:
+                configMapKeyRef:
+                  key: id
+                  name: cluster-info
+            - name: K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: K8S_NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: TOKEN
+              valueFrom:
+                secretKeyRef:
+                  key: OBSERVE_TOKEN
+                  name: agent-credentials
+                  optional: true
+            - name: TRACES_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  key: TRACES_TOKEN
+                  name: agent-credentials
+                  optional: true
+          livenessProbe:
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            httpGet:
+              path: /status
+              port: 13133
+          readinessProbe:
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            httpGet:
+              path: /status
+              port: 13133
+          resources:
+            limits:
+              memory: 512Mi
+            requests:
+              cpu: 250m
+              memory: 512Mi
+          volumeMounts:
+            - mountPath: /conf
+              name: node-logs-metrics-configmap
+            - mountPath: /observe-agent-conf
+              name: observe-agent-deployment-config
+            - mountPath: /var/log/pods
+              name: varlogpods
+              readOnly: true
+            - mountPath: /var/lib/docker/containers
+              name: varlibdockercontainers
+              readOnly: true
+            - mountPath: /var/lib/otelcol
+              name: varlibotelcol
+            - mountPath: /hostfs
+              mountPropagation: HostToContainer
+              name: hostfs
+              readOnly: true
+      initContainers:
+        - env:
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          image: observeinc/kube-cluster-info:v0.11.6
+          imagePullPolicy: Always
+          name: kube-cluster-info
+      volumes:
+        - name: node-logs-metrics-configmap
+          configMap:
+            name: node-logs-metrics
+            items:
+              - key: relay
+                path: relay.yaml
+        - configMap:
+            defaultMode: 420
+            items:
+            - key: relay
+              path: observe-agent.yaml
+            name: observe-agent
+          name: observe-agent-deployment-config
+        - hostPath:
+            path: /var/log/pods
+          name: varlogpods
+        - hostPath:
+            path: /var/lib/docker/containers
+          name: varlibdockercontainers
+        - hostPath:
+            path: /var/lib/otelcol
+            type: DirectoryOrCreate
+          name: varlibotelcol
+        - hostPath:
+            path: /
+          name: hostfs
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: observeinc.com/unschedulable
+                operator: DoesNotExist
+              - key: kubernetes.io/os
+                operator: NotIn
+                values:
+                - windows
+      hostNetwork: false

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/observe-agent-configmap.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/observe-agent-configmap.yaml
@@ -1,0 +1,42 @@
+---
+# Source: agent/templates/observe-agent-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: observe-agent
+  namespace: observe
+data:
+  relay: |
+    observe_url:
+    token:
+
+    debug: false
+
+    health_check:
+      enabled: true
+      endpoint: "${env:MY_POD_IP}:13133"
+      path: "/status"
+
+    internal_telemetry:
+      enabled: true
+      metrics:
+        enabled: true
+        host: "${env:MY_POD_IP}"
+        port: 8888
+        level: normal
+      logs:
+        enabled: true
+        level: WARN
+        encoding: console
+
+
+    forwarding:
+      enabled: false
+
+    self_monitoring:
+      enabled: false
+      fleet:
+        enabled: false
+
+    host_monitoring:
+      enabled: false

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/prometheus-scraper-configmap.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/prometheus-scraper-configmap.yaml
@@ -1,0 +1,136 @@
+---
+# Source: agent/templates/prometheus-scraper-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-scraper
+  namespace: observe
+data:
+  relay: |
+      exporters:
+        debug/override:
+          sampling_initial: 2
+          sampling_thereafter: 1
+          verbosity: basic
+        prometheusremotewrite/observe:
+          endpoint: ${env:OBSERVE_PROMETHEUS_ENDPOINT}
+          headers:
+            authorization: ${env:OBSERVE_AUTHORIZATION_HEADER}
+            x-observe-target-package: Kubernetes Explorer
+          max_batch_request_parallelism: 5
+          remote_write_queue:
+            num_consumers: 5
+          resource_to_telemetry_conversion:
+            enabled: true
+          retry_on_failure:
+            enabled: true
+            initial_interval: 1s
+            max_elapsed_time: 5m
+            max_interval: 30s
+          send_metadata: true
+          timeout: 10s
+      processors:
+        attributes/debug_source_cadvisor_metrics:
+          actions:
+          - action: insert
+            key: debug_source
+            value: cadvisor_metrics
+        attributes/debug_source_pod_metrics:
+          actions:
+          - action: insert
+            key: debug_source
+            value: pod_metrics
+        batch:
+          send_batch_max_size: 4096
+          send_batch_size: 4096
+          timeout: 5s
+        k8sattributes:
+          extract:
+            labels:
+            - from: pod
+              key_regex: (app\.kubernetes\.io/.+)
+              tag_name: $1
+            metadata:
+            - k8s.namespace.name
+            - k8s.deployment.name
+            - k8s.replicaset.name
+            - k8s.statefulset.name
+            - k8s.daemonset.name
+            - k8s.cronjob.name
+            - k8s.job.name
+            - k8s.node.name
+            - k8s.node.uid
+            - k8s.pod.name
+            - k8s.pod.uid
+            - k8s.cluster.uid
+            - k8s.container.name
+            - container.id
+            - service.namespace
+            - service.name
+            - service.version
+            - service.instance.id
+            otel_annotations: true
+          passthrough: false
+          pod_association:
+          - sources:
+            - from: resource_attribute
+              name: k8s.pod.ip
+          - sources:
+            - from: resource_attribute
+              name: k8s.pod.uid
+          - sources:
+            - from: connection
+          wait_for_metadata: false
+          wait_for_metadata_timeout: 10s
+        memory_limiter:
+          check_interval: 5s
+          limit_percentage: 80
+          spike_limit_percentage: 15
+        resource/drop_service_name:
+          attributes:
+          - action: delete
+            key: service.name
+        resource/observe_common:
+          attributes:
+          - action: upsert
+            key: k8s.cluster.name
+            value: ${env:OBSERVE_CLUSTER_NAME}
+          - action: upsert
+            key: k8s.cluster.uid
+            value: ${env:OBSERVE_CLUSTER_UID}
+      receivers:
+        prometheus/cadvisor:
+          target_allocator:
+            collector_id: ${env:OTEL_K8S_POD_NAME}
+            endpoint: http://example-prometheus-ta-cadvisor.observe.svc.cluster.local:8080
+            interval: 30s
+        prometheus/pod_metrics:
+          target_allocator:
+            collector_id: ${env:OTEL_K8S_POD_NAME}
+            endpoint: http://example-prometheus-ta-pod-metrics.observe.svc.cluster.local:8080
+            interval: 30s
+      service:
+        pipelines:
+          metrics/cadvisor:
+            exporters:
+            - prometheusremotewrite/observe
+            processors:
+            - memory_limiter
+            - k8sattributes
+            - batch
+            - resource/observe_common
+            - attributes/debug_source_cadvisor_metrics
+            receivers:
+            - prometheus/cadvisor
+          metrics/pod_metrics:
+            exporters:
+            - prometheusremotewrite/observe
+            processors:
+            - memory_limiter
+            - resource/drop_service_name
+            - k8sattributes
+            - batch
+            - resource/observe_common
+            - attributes/debug_source_pod_metrics
+            receivers:
+            - prometheus/pod_metrics

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/prometheus-scraper/deployment.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/prometheus-scraper/deployment.yaml
@@ -1,0 +1,157 @@
+---
+# Source: agent/charts/prometheus-scraper/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-prometheus-scraper
+  namespace: observe
+  labels:
+    helm.sh/chart: prometheus-scraper-0.143.0
+    app.kubernetes.io/name: prometheus-scraper
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-collector
+    app.kubernetes.io/component: standalone-collector
+spec:
+  replicas: 2
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus-scraper
+      app.kubernetes.io/instance: example
+      component: standalone-collector
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+        observe_monitor_path: /metrics
+        observe_monitor_port: "8888"
+        observe_monitor_purpose: observecollection
+        observe_monitor_scrape: "true"
+        observeinc_com_scrape: "false"
+      labels:
+        app.kubernetes.io/name: prometheus-scraper
+        app.kubernetes.io/instance: example
+        component: standalone-collector
+
+    spec:
+
+      serviceAccountName: observe-agent-service-account
+      automountServiceAccountToken: true
+      securityContext:
+        {}
+      containers:
+        - name: prometheus-scraper
+          command:
+            - /observe-agent
+          args:
+            - --config=/conf/relay.yaml
+            - start
+            - --observe-config=/observe-agent-conf/observe-agent.yaml
+            - --config=/conf/relay.yaml
+            - --feature-gates=+exporter.prometheusremotewritexporter.EnableMultipleWorkers
+          securityContext:
+            seccompProfile:
+              type: RuntimeDefault
+          image: "observeinc/observe-agent:2.15.0"
+          imagePullPolicy: IfNotPresent
+          ports:
+
+            - name: jaeger-compact
+              containerPort: 6831
+              protocol: UDP
+            - name: jaeger-grpc
+              containerPort: 14250
+              protocol: TCP
+            - name: jaeger-thrift
+              containerPort: 14268
+              protocol: TCP
+            - name: metrics
+              containerPort: 8888
+              protocol: TCP
+            - name: otlp
+              containerPort: 4317
+              protocol: TCP
+            - name: otlp-http
+              containerPort: 4318
+              protocol: TCP
+            - name: zipkin
+              containerPort: 9411
+              protocol: TCP
+          env:
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: GOMEMLIMIT
+              value: "409MiB"
+            - name: OTEL_K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OTEL_K8S_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+          livenessProbe:
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            httpGet:
+              path: /status
+              port: 13133
+          readinessProbe:
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            httpGet:
+              path: /status
+              port: 13133
+          resources:
+            limits:
+              memory: 512Mi
+            requests:
+              cpu: 250m
+              memory: 512Mi
+          volumeMounts:
+            - mountPath: /conf
+              name: prometheus-scraper-configmap
+            - mountPath: /observe-agent-conf
+              name: observe-agent-deployment-config
+      initContainers:
+        - env:
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          image: observeinc/kube-cluster-info:v0.11.6
+          imagePullPolicy: Always
+          name: kube-cluster-info
+      volumes:
+        - name: prometheus-scraper-configmap
+          configMap:
+            name: prometheus-scraper
+            items:
+              - key: relay
+                path: relay.yaml
+        - configMap:
+            defaultMode: 420
+            items:
+            - key: relay
+              path: observe-agent.yaml
+            name: observe-agent
+          name: observe-agent-deployment-config
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: observeinc.com/unschedulable
+                operator: DoesNotExist
+              - key: kubernetes.io/os
+                operator: NotIn
+                values:
+                - windows
+      hostNetwork: false

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/prometheus-scraper/networkpolicy.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/prometheus-scraper/networkpolicy.yaml
@@ -1,0 +1,39 @@
+---
+# Source: agent/charts/prometheus-scraper/templates/networkpolicy.yaml
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: example-prometheus-scraper
+  namespace: observe
+  labels:
+    helm.sh/chart: prometheus-scraper-0.143.0
+    app.kubernetes.io/name: prometheus-scraper
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-collector
+    app.kubernetes.io/component: standalone-collector
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus-scraper
+      app.kubernetes.io/instance: example
+      component: standalone-collector
+  ingress:
+    - ports:
+        - port: 6831
+          protocol: UDP
+        - port: 14250
+          protocol: TCP
+        - port: 14268
+          protocol: TCP
+        - port: 8888
+          protocol: TCP
+        - port: 4317
+          protocol: TCP
+        - port: 4318
+          protocol: TCP
+        - port: 9411
+          protocol: TCP
+  egress:
+    - {}

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/prometheus-scraper/service.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/prometheus-scraper/service.yaml
@@ -1,0 +1,54 @@
+---
+# Source: agent/charts/prometheus-scraper/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-prometheus-scraper
+  namespace: observe
+  labels:
+    helm.sh/chart: prometheus-scraper-0.143.0
+    app.kubernetes.io/name: prometheus-scraper
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-collector
+    app.kubernetes.io/component: standalone-collector
+    component: standalone-collector
+spec:
+  type: ClusterIP
+  ports:
+
+    - name: jaeger-compact
+      port: 6831
+      targetPort: 6831
+      protocol: UDP
+    - name: jaeger-grpc
+      port: 14250
+      targetPort: 14250
+      protocol: TCP
+    - name: jaeger-thrift
+      port: 14268
+      targetPort: 14268
+      protocol: TCP
+    - name: metrics
+      port: 8888
+      targetPort: 8888
+      protocol: TCP
+    - name: otlp
+      port: 4317
+      targetPort: 4317
+      protocol: TCP
+      appProtocol: grpc
+    - name: otlp-http
+      port: 4318
+      targetPort: 4318
+      protocol: TCP
+    - name: zipkin
+      port: 9411
+      targetPort: 9411
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: prometheus-scraper
+    app.kubernetes.io/instance: example
+    component: standalone-collector
+  internalTrafficPolicy: Cluster

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/prometheus-target-allocator.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/prometheus-target-allocator.yaml
@@ -1,0 +1,492 @@
+---
+# Source: agent/templates/prometheus-target-allocator.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: example-prometheus-ta-pod-metrics
+  namespace: observe
+  labels:
+    app.kubernetes.io/name: prometheus-target-allocator
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: pod-metrics
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: agent/templates/prometheus-target-allocator.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: example-prometheus-ta-cadvisor
+  namespace: observe
+  labels:
+    app.kubernetes.io/name: prometheus-target-allocator
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: cadvisor
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: agent/templates/prometheus-target-allocator.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: example-prometheus-ta-pod-metrics
+  namespace: observe
+  labels:
+    app.kubernetes.io/name: prometheus-target-allocator
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: pod-metrics
+data:
+  targetallocator.yaml: |
+    collector_namespace: "observe"
+    collector_selector:
+      matchLabels:
+        app.kubernetes.io/name: prometheus-scraper
+        app.kubernetes.io/instance: "example"
+        component: standalone-collector
+    listen_addr: ":8080"
+    allocation_strategy: consistent-hashing
+    filter_strategy: relabel-config
+    prometheus_cr:
+      enabled: false
+    config:
+      global:
+        scrape_interval: "60s"
+      scrape_configs:
+
+        - job_name: pod-metrics
+          scrape_interval: 60s
+          honor_labels: true
+          kubernetes_sd_configs:
+          - role: pod
+          relabel_configs:
+          # this is defaulted to keep so we start with everything
+          - action: keep
+
+          # Drop anything matching the configured namespace.
+          - action: 'drop'
+            source_labels: ['__meta_kubernetes_namespace']
+            regex: (.*istio.*|.*ingress.*|kube-system)
+
+          # Drop anything not matching the configured namespace.
+          - action: 'keep'
+            source_labels: ['__meta_kubernetes_namespace']
+            regex: (.*)
+
+          # Drop endpoints without one of: a port name suffixed with the configured regex, or an explicit prometheus port annotation.
+          - action: 'keep'
+            source_labels: ['__meta_kubernetes_pod_container_port_name', '__meta_kubernetes_pod_annotation_prometheus_io_port']
+            regex: '(.*metrics;|.*;\d+)'
+
+          # Drop pods with phase Succeeded or Failed.
+          - action: 'drop'
+            regex: 'Succeeded|Failed'
+            source_labels: ['__meta_kubernetes_pod_phase']
+
+          ################################################################
+          # Drop anything annotated with 'observeinc.com.scrape=false' or 'observeinc_com_scrape=false' .
+          - action: 'drop'
+            regex: 'false'
+            source_labels: ['__meta_kubernetes_pod_annotation_observeinc_com_scrape']
+
+          ################################################################
+          # Prometheus Configs
+          # Drop anything annotated with 'prometheus.io.scrape=false'.
+          - action: 'drop'
+            regex: 'false'
+            source_labels: ['__meta_kubernetes_pod_annotation_prometheus_io_scrape']
+
+          # Allow pods to override the scrape scheme with 'prometheus.io.scheme=https'.
+          - action: 'replace'
+            regex: '(https?)'
+            replacement: '$1'
+            source_labels: ['__meta_kubernetes_pod_annotation_prometheus_io_scheme']
+            target_label: '__scheme__'
+
+          # Allow service to override the scrape path with 'prometheus.io.path=/other_metrics_path'.
+          - action: 'replace'
+            regex: '(.+)'
+            replacement: '$1'
+            source_labels: ['__meta_kubernetes_pod_annotation_prometheus_io_path']
+            target_label: '__metrics_path__'
+
+          # Allow services to override the scrape port with 'prometheus.io.port=1234'.
+          - action: 'replace'
+            regex: '(.+?)(\:\d+)?;(\d+)'
+            replacement: '$1:$3'
+            source_labels: ['__address__', '__meta_kubernetes_pod_annotation_prometheus_io_port']
+            target_label: '__address__'
+
+
+          ################################################################
+
+          #podAnnotations: {
+          #  observeinc_com_scrape: 'true',
+          #  observeinc_com_path: '/metrics',
+          #  observeinc_com_port: '8080',
+          #}
+
+          # set metrics_path (default is /metrics) to the metrics path specified in "observeinc_com_path: <metric path>" annotation.
+          - source_labels: [__meta_kubernetes_pod_annotation_observeinc_com_path]
+            action: replace
+            target_label: __metrics_path__
+            regex: (.+)
+
+          # set the scrapping port to the port specified in "observeinc_com_port: <port>" annotation and set address accordingly.
+          - source_labels: [__address__, __meta_kubernetes_pod_annotation_observeinc_com_port]
+            action: replace
+            regex: ([^:]+)(?::\d+)?;(\d+)
+            replacement: '$1:$2'
+            target_label: __address__
+          ################################################################
+
+          # Maps all Kubernetes pod labels to Prometheus labels with the prefix removed (e.g., __meta_kubernetes_pod_label_app becomes app).
+          - action: labelmap
+            regex: __meta_kubernetes_pod_label_(.+)
+
+          # adds new label
+          - source_labels: [__meta_kubernetes_namespace]
+            action: replace
+            target_label: kubernetes_namespace
+
+          # adds new label
+          - source_labels: [__meta_kubernetes_pod_name]
+            action: replace
+            target_label: kubernetes_pod_name
+
+          metric_relabel_configs:
+            - action: keep
+              regex: (.*)
+              source_labels:
+                - __name__
+---
+# Source: agent/templates/prometheus-target-allocator.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: example-prometheus-ta-cadvisor
+  namespace: observe
+  labels:
+    app.kubernetes.io/name: prometheus-target-allocator
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: cadvisor
+data:
+  targetallocator.yaml: |
+    collector_namespace: "observe"
+    collector_selector:
+      matchLabels:
+        app.kubernetes.io/name: prometheus-scraper
+        app.kubernetes.io/instance: "example"
+        component: standalone-collector
+    listen_addr: ":8080"
+    allocation_strategy: consistent-hashing
+    filter_strategy: relabel-config
+    prometheus_cr:
+      enabled: false
+    config:
+      global:
+        scrape_interval: "60s"
+      scrape_configs:
+
+        - job_name: 'kubernetes-nodes-cadvisor'
+          scheme: https
+          tls_config:
+            ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+            insecure_skip_verify: true
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          kubernetes_sd_configs:
+            - role: node
+          relabel_configs:
+            - target_label: __address__
+              replacement: kubernetes.default.svc:443
+            - source_labels: [__meta_kubernetes_node_name]
+              regex: (.+)
+              target_label: __metrics_path__
+              replacement: /api/v1/nodes/$1/proxy/metrics/cadvisor
+---
+# Source: agent/templates/prometheus-target-allocator.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: example-prometheus-ta-pod-metrics
+  labels:
+    app.kubernetes.io/name: prometheus-target-allocator
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: pod-metrics
+rules:
+  - apiGroups: [""]
+    resources:
+      - nodes
+      - nodes/metrics
+      - services
+      - endpoints
+      - pods
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources:
+      - configmaps
+    verbs: ["get"]
+  - apiGroups: ["discovery.k8s.io"]
+    resources:
+      - endpointslices
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources:
+      - ingresses
+    verbs: ["get", "list", "watch"]
+  - nonResourceURLs: ["/metrics"]
+    verbs: ["get"]
+  - apiGroups: ["apps"]
+    resources:
+      - deployments
+      - replicasets
+      - statefulsets
+    verbs: ["get", "list", "watch"]
+---
+# Source: agent/templates/prometheus-target-allocator.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: example-prometheus-ta-cadvisor
+  labels:
+    app.kubernetes.io/name: prometheus-target-allocator
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: cadvisor
+rules:
+  - apiGroups: [""]
+    resources:
+      - nodes
+      - nodes/metrics
+      - services
+      - endpoints
+      - pods
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources:
+      - configmaps
+    verbs: ["get"]
+  - apiGroups: ["discovery.k8s.io"]
+    resources:
+      - endpointslices
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources:
+      - ingresses
+    verbs: ["get", "list", "watch"]
+  - nonResourceURLs: ["/metrics"]
+    verbs: ["get"]
+  - apiGroups: ["apps"]
+    resources:
+      - deployments
+      - replicasets
+      - statefulsets
+    verbs: ["get", "list", "watch"]
+---
+# Source: agent/templates/prometheus-target-allocator.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: example-prometheus-ta-pod-metrics
+  labels:
+    app.kubernetes.io/name: prometheus-target-allocator
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: pod-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: example-prometheus-ta-pod-metrics
+subjects:
+  - kind: ServiceAccount
+    name: example-prometheus-ta-pod-metrics
+    namespace: observe
+---
+# Source: agent/templates/prometheus-target-allocator.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: example-prometheus-ta-cadvisor
+  labels:
+    app.kubernetes.io/name: prometheus-target-allocator
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: cadvisor
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: example-prometheus-ta-cadvisor
+subjects:
+  - kind: ServiceAccount
+    name: example-prometheus-ta-cadvisor
+    namespace: observe
+---
+# Source: agent/templates/prometheus-target-allocator.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-prometheus-ta-pod-metrics
+  namespace: observe
+  labels:
+    app.kubernetes.io/name: prometheus-target-allocator
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: pod-metrics
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: prometheus-target-allocator
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: pod-metrics
+---
+# Source: agent/templates/prometheus-target-allocator.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-prometheus-ta-cadvisor
+  namespace: observe
+  labels:
+    app.kubernetes.io/name: prometheus-target-allocator
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: cadvisor
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: prometheus-target-allocator
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: cadvisor
+---
+# Source: agent/templates/prometheus-target-allocator.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-prometheus-ta-pod-metrics
+  namespace: observe
+  labels:
+    app.kubernetes.io/name: prometheus-target-allocator
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: pod-metrics
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus-target-allocator
+      app.kubernetes.io/instance: example
+      app.kubernetes.io/component: pod-metrics
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: prometheus-target-allocator
+        app.kubernetes.io/instance: example
+        app.kubernetes.io/component: pod-metrics
+    spec:
+      serviceAccountName: example-prometheus-ta-pod-metrics
+      containers:
+        - name: target-allocator
+          image: "ghcr.io/open-telemetry/opentelemetry-operator/target-allocator:0.150.0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - --config-file=/conf/targetallocator.yaml
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          env:
+            - name: OTELCOL_NAMESPACE
+              value: "observe"
+          volumeMounts:
+            - name: config
+              mountPath: /conf
+              readOnly: true
+          resources:
+            limits:
+              memory: 256Mi
+            requests:
+              cpu: 50m
+              memory: 128Mi
+          livenessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+      volumes:
+        - name: config
+          configMap:
+            name: example-prometheus-ta-pod-metrics
+            items:
+              - key: targetallocator.yaml
+                path: targetallocator.yaml
+---
+# Source: agent/templates/prometheus-target-allocator.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-prometheus-ta-cadvisor
+  namespace: observe
+  labels:
+    app.kubernetes.io/name: prometheus-target-allocator
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: cadvisor
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus-target-allocator
+      app.kubernetes.io/instance: example
+      app.kubernetes.io/component: cadvisor
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: prometheus-target-allocator
+        app.kubernetes.io/instance: example
+        app.kubernetes.io/component: cadvisor
+    spec:
+      serviceAccountName: example-prometheus-ta-cadvisor
+      containers:
+        - name: target-allocator
+          image: "ghcr.io/open-telemetry/opentelemetry-operator/target-allocator:0.150.0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - --config-file=/conf/targetallocator.yaml
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          env:
+            - name: OTELCOL_NAMESPACE
+              value: "observe"
+          volumeMounts:
+            - name: config
+              mountPath: /conf
+              readOnly: true
+          resources:
+            limits:
+              memory: 256Mi
+            requests:
+              cpu: 50m
+              memory: 128Mi
+          livenessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+      volumes:
+        - name: config
+          configMap:
+            name: example-prometheus-ta-cadvisor
+            items:
+              - key: targetallocator.yaml
+                path: targetallocator.yaml

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/secret.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/secret.yaml
@@ -1,0 +1,9 @@
+---
+# Source: agent/templates/secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: agent-credentials
+type: Opaque
+data:
+  OBSERVE_TOKEN: ""

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/serviceaccount.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/serviceaccount.yaml
@@ -1,0 +1,7 @@
+---
+# Source: agent/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: observe-agent-service-account
+  namespace: observe

--- a/charts/agent/examples/prometheus-ta-enabled/values.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/values.yaml
@@ -1,0 +1,30 @@
+# Example: Prometheus Target Allocator sharding enabled for pod-metrics and cadvisor.
+# Requires application.prometheusScrape.independentDeployment=true.
+# Set prometheus-scraper.replicaCount >= 2 for meaningful sharding.
+observe:
+  token:
+    create: true
+
+application:
+  prometheusScrape:
+    enabled: true
+    independentDeployment: true
+    targetAllocator:
+      enabled: true
+
+node:
+  metrics:
+    cadvisor:
+      enabled: true
+
+prometheus-scraper:
+  replicaCount: 2
+  extraEnvs:
+    - name: OTEL_K8S_POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name
+    - name: OTEL_K8S_POD_UID
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.uid

--- a/charts/agent/templates/_config-receivers.tpl
+++ b/charts/agent/templates/_config-receivers.tpl
@@ -1,140 +1,174 @@
+{{/*
+  Prometheus scrape_configs entry for pod-metrics (Kubernetes pod SD + relabel).
+  Used by the collector when TA is off, and by the Target Allocator when TA-only sharding is enabled.
+*/}}
+{{- define "observe.prometheus.pod_metrics.scrape_job" -}}
+- job_name: pod-metrics
+  scrape_interval: {{.Values.application.prometheusScrape.interval}}
+  honor_labels: true
+  kubernetes_sd_configs:
+  - role: pod
+  relabel_configs:
+  # this is defaulted to keep so we start with everything
+  - action: keep
+
+  # Drop anything matching the configured namespace.
+  - action: 'drop'
+    source_labels: ['__meta_kubernetes_namespace']
+    regex: {{.Values.application.prometheusScrape.namespaceDropRegex}}
+
+  # Drop anything not matching the configured namespace.
+  - action: 'keep'
+    source_labels: ['__meta_kubernetes_namespace']
+    regex: {{.Values.application.prometheusScrape.namespaceKeepRegex}}
+
+  # Drop endpoints without one of: a port name suffixed with the configured regex, or an explicit prometheus port annotation.
+  - action: 'keep'
+    source_labels: ['__meta_kubernetes_pod_container_port_name', '__meta_kubernetes_pod_annotation_prometheus_io_port']
+    regex: '({{.Values.application.prometheusScrape.portKeepRegex}};|.*;\d+)'
+
+  # Drop pods with phase Succeeded or Failed.
+  - action: 'drop'
+    regex: 'Succeeded|Failed'
+    source_labels: ['__meta_kubernetes_pod_phase']
+
+  ################################################################
+  # Drop anything annotated with 'observeinc.com.scrape=false' or 'observeinc_com_scrape=false' .
+  - action: 'drop'
+    regex: 'false'
+    source_labels: ['__meta_kubernetes_pod_annotation_observeinc_com_scrape']
+
+  ################################################################
+  # Prometheus Configs
+  # Drop anything annotated with 'prometheus.io.scrape=false'.
+  - action: 'drop'
+    regex: 'false'
+    source_labels: ['__meta_kubernetes_pod_annotation_prometheus_io_scrape']
+
+  # Allow pods to override the scrape scheme with 'prometheus.io.scheme=https'.
+  - action: 'replace'
+    regex: '(https?)'
+    replacement: '$1'
+    source_labels: ['__meta_kubernetes_pod_annotation_prometheus_io_scheme']
+    target_label: '__scheme__'
+
+  # Allow service to override the scrape path with 'prometheus.io.path=/other_metrics_path'.
+  - action: 'replace'
+    regex: '(.+)'
+    replacement: '$1'
+    source_labels: ['__meta_kubernetes_pod_annotation_prometheus_io_path']
+    target_label: '__metrics_path__'
+
+  # Allow services to override the scrape port with 'prometheus.io.port=1234'.
+  - action: 'replace'
+    regex: '(.+?)(\:\d+)?;(\d+)'
+    replacement: '$1:$3'
+    source_labels: ['__address__', '__meta_kubernetes_pod_annotation_prometheus_io_port']
+    target_label: '__address__'
+
+
+  ################################################################
+
+  #podAnnotations: {
+  #  observeinc_com_scrape: 'true',
+  #  observeinc_com_path: '/metrics',
+  #  observeinc_com_port: '8080',
+  #}
+
+  # set metrics_path (default is /metrics) to the metrics path specified in "observeinc_com_path: <metric path>" annotation.
+  - source_labels: [__meta_kubernetes_pod_annotation_observeinc_com_path]
+    action: replace
+    target_label: __metrics_path__
+    regex: (.+)
+
+  # set the scrapping port to the port specified in "observeinc_com_port: <port>" annotation and set address accordingly.
+  - source_labels: [__address__, __meta_kubernetes_pod_annotation_observeinc_com_port]
+    action: replace
+    regex: ([^:]+)(?::\d+)?;(\d+)
+    replacement: '$1:$2'
+    target_label: __address__
+  ################################################################
+
+  # Maps all Kubernetes pod labels to Prometheus labels with the prefix removed (e.g., __meta_kubernetes_pod_label_app becomes app).
+  - action: labelmap
+    regex: __meta_kubernetes_pod_label_(.+)
+
+  # adds new label
+  - source_labels: [__meta_kubernetes_namespace]
+    action: replace
+    target_label: kubernetes_namespace
+
+  # adds new label
+  - source_labels: [__meta_kubernetes_pod_name]
+    action: replace
+    target_label: kubernetes_pod_name
+
+  metric_relabel_configs:
+    {{- if .Values.application.prometheusScrape.metricDropRegex }}
+    - action: drop
+      regex: {{ .Values.application.prometheusScrape.metricDropRegex }}
+      source_labels:
+        - __name__
+    {{- end }}
+    - action: keep
+      regex: {{ .Values.application.prometheusScrape.metricKeepRegex }}
+      source_labels:
+        - __name__
+{{- end -}}
+
+{{/*
+  Prometheus scrape_configs entry for cadvisor (Kubernetes node SD via the API server proxy).
+  Used by the collector when TA is off, and by the cadvisor Target Allocator when TA-only sharding is enabled.
+*/}}
+{{- define "observe.prometheus.cadvisor.scrape_job" -}}
+- job_name: 'kubernetes-nodes-cadvisor'
+  scheme: https
+  tls_config:
+    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    insecure_skip_verify: true
+  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+  kubernetes_sd_configs:
+    - role: node
+  relabel_configs:
+    - target_label: __address__
+      replacement: kubernetes.default.svc:443
+    - source_labels: [__meta_kubernetes_node_name]
+      regex: (.+)
+      target_label: __metrics_path__
+      replacement: /api/v1/nodes/$1/proxy/metrics/cadvisor
+{{- end -}}
+
 {{- define "config.receivers.prometheus.pod_metrics" -}}
+{{- $ta := and .Values.application.prometheusScrape.independentDeployment .Values.application.prometheusScrape.targetAllocator.enabled }}
+{{- if $ta }}
+prometheus/pod_metrics:
+  target_allocator:
+    endpoint: http://{{ include "observe-agent.prometheusTargetAllocator.serviceName" (dict "root" . "suffix" "pod-metrics") }}.{{ include "observe-agent.k8sNamespace" . }}.svc.cluster.local:8080
+    interval: {{ .Values.application.prometheusScrape.targetAllocator.interval }}
+    collector_id: {{ print "${env:OTEL_K8S_POD_NAME}" }}
+{{- else }}
 prometheus/pod_metrics:
   config:
     scrape_configs:
-    - job_name: pod-metrics
-      scrape_interval: {{.Values.application.prometheusScrape.interval}}
-      honor_labels: true
-      kubernetes_sd_configs:
-      - role: pod
-      relabel_configs:
-      # this is defaulted to keep so we start with everything
-      - action: keep
-
-      # Drop anything matching the configured namespace.
-      - action: 'drop'
-        source_labels: ['__meta_kubernetes_namespace']
-        regex: {{.Values.application.prometheusScrape.namespaceDropRegex}}
-
-      # Drop anything not matching the configured namespace.
-      - action: 'keep'
-        source_labels: ['__meta_kubernetes_namespace']
-        regex: {{.Values.application.prometheusScrape.namespaceKeepRegex}}
-
-      # Drop endpoints without one of: a port name suffixed with the configured regex, or an explicit prometheus port annotation.
-      - action: 'keep'
-        source_labels: ['__meta_kubernetes_pod_container_port_name', '__meta_kubernetes_pod_annotation_prometheus_io_port']
-        regex: '({{.Values.application.prometheusScrape.portKeepRegex}};|.*;\d+)'
-
-      # Drop pods with phase Succeeded or Failed.
-      - action: 'drop'
-        regex: 'Succeeded|Failed'
-        source_labels: ['__meta_kubernetes_pod_phase']
-
-      ################################################################
-      # Drop anything annotated with 'observeinc.com.scrape=false' or 'observeinc_com_scrape=false' .
-      - action: 'drop'
-        regex: 'false'
-        source_labels: ['__meta_kubernetes_pod_annotation_observeinc_com_scrape']
-
-      ################################################################
-      # Prometheus Configs
-      # Drop anything annotated with 'prometheus.io.scrape=false'.
-      - action: 'drop'
-        regex: 'false'
-        source_labels: ['__meta_kubernetes_pod_annotation_prometheus_io_scrape']
-
-      # Allow pods to override the scrape scheme with 'prometheus.io.scheme=https'.
-      - action: 'replace'
-        regex: '(https?)'
-        replacement: '$1'
-        source_labels: ['__meta_kubernetes_pod_annotation_prometheus_io_scheme']
-        target_label: '__scheme__'
-
-      # Allow service to override the scrape path with 'prometheus.io.path=/other_metrics_path'.
-      - action: 'replace'
-        regex: '(.+)'
-        replacement: '$1'
-        source_labels: ['__meta_kubernetes_pod_annotation_prometheus_io_path']
-        target_label: '__metrics_path__'
-
-      # Allow services to override the scrape port with 'prometheus.io.port=1234'.
-      - action: 'replace'
-        regex: '(.+?)(\:\d+)?;(\d+)'
-        replacement: '$1:$3'
-        source_labels: ['__address__', '__meta_kubernetes_pod_annotation_prometheus_io_port']
-        target_label: '__address__'
-
-
-      ################################################################
-
-      #podAnnotations: {
-      #  observeinc_com_scrape: 'true',
-      #  observeinc_com_path: '/metrics',
-      #  observeinc_com_port: '8080',
-      #}
-
-      # set metrics_path (default is /metrics) to the metrics path specified in "observeinc_com_path: <metric path>" annotation.
-      - source_labels: [__meta_kubernetes_pod_annotation_observeinc_com_path]
-        action: replace
-        target_label: __metrics_path__
-        regex: (.+)
-
-      # set the scrapping port to the port specified in "observeinc_com_port: <port>" annotation and set address accordingly.
-      - source_labels: [__address__, __meta_kubernetes_pod_annotation_observeinc_com_port]
-        action: replace
-        regex: ([^:]+)(?::\d+)?;(\d+)
-        replacement: '$1:$2'
-        target_label: __address__
-      ################################################################
-
-      # Maps all Kubernetes pod labels to Prometheus labels with the prefix removed (e.g., __meta_kubernetes_pod_label_app becomes app).
-      - action: labelmap
-        regex: __meta_kubernetes_pod_label_(.+)
-
-      # adds new label
-      - source_labels: [__meta_kubernetes_namespace]
-        action: replace
-        target_label: kubernetes_namespace
-
-      # adds new label
-      - source_labels: [__meta_kubernetes_pod_name]
-        action: replace
-        target_label: kubernetes_pod_name
-
-      metric_relabel_configs:
-        - action: drop
-          regex: {{.Values.application.prometheusScrape.metricDropRegex}}
-          source_labels:
-            - __name__
-        - action: keep
-          regex: {{.Values.application.prometheusScrape.metricKeepRegex}}
-          source_labels:
-            - __name__
+{{ include "observe.prometheus.pod_metrics.scrape_job" . | nindent 4 }}
+{{- end }}
 {{- end -}}
 
 {{- define "config.receivers.prometheus.cadvisor" -}}
 {{- if .Values.node.metrics.cadvisor.enabled }}
+{{- $ta := and .Values.application.prometheusScrape.independentDeployment .Values.application.prometheusScrape.targetAllocator.enabled }}
+{{- if $ta }}
+prometheus/cadvisor:
+  target_allocator:
+    endpoint: http://{{ include "observe-agent.prometheusTargetAllocator.serviceName" (dict "root" . "suffix" "cadvisor") }}.{{ include "observe-agent.k8sNamespace" . }}.svc.cluster.local:8080
+    interval: {{ .Values.application.prometheusScrape.targetAllocator.interval }}
+    collector_id: {{ print "${env:OTEL_K8S_POD_NAME}" }}
+{{- else }}
 prometheus/cadvisor:
   config:
     scrape_configs:
-      - job_name: 'kubernetes-nodes-cadvisor'
-        scheme: https
-        tls_config:
-          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-          insecure_skip_verify: true
-        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-
-        kubernetes_sd_configs:
-          - role: node
-
-        relabel_configs:
-          - target_label: __address__
-            replacement: kubernetes.default.svc:443
-          - source_labels: [__meta_kubernetes_node_name]
-            regex: (.+)
-            target_label: __metrics_path__
-            replacement: /api/v1/nodes/$$1/proxy/metrics/cadvisor
+{{ include "observe.prometheus.cadvisor.scrape_job" . | nindent 4 }}
+{{- end }}
 {{ end }}
 {{ end }}
 

--- a/charts/agent/templates/_helpers.tpl
+++ b/charts/agent/templates/_helpers.tpl
@@ -5,6 +5,21 @@
     "observe"
   {{- end -}}
 {{- end -}}
+
+{{/* Kubernetes namespace string without extra quoting (for DNS names, env values, etc.). */}}
+{{- define "observe-agent.k8sNamespace" -}}
+{{- if .Values.cluster.namespaceOverride.value -}}
+{{- .Values.cluster.namespaceOverride.value -}}
+{{- else -}}
+observe
+{{- end -}}
+{{- end -}}
+
+{{/* DNS-safe service name for a standalone Target Allocator (TA-only sharding).
+     Usage: include "observe-agent.prometheusTargetAllocator.serviceName" (dict "root" . "suffix" "pod-metrics") */}}
+{{- define "observe-agent.prometheusTargetAllocator.serviceName" -}}
+{{- printf "%s-prometheus-ta-%s" .root.Release.Name .suffix | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- define "config.local_host" -}}
 ${env:MY_POD_IP}
 {{- end -}}

--- a/charts/agent/templates/prometheus-scraper-configmap.yaml
+++ b/charts/agent/templates/prometheus-scraper-configmap.yaml
@@ -1,3 +1,6 @@
+{{- if and .Values.application.prometheusScrape.targetAllocator.enabled (not .Values.application.prometheusScrape.independentDeployment) }}
+{{- fail "application.prometheusScrape.targetAllocator.enabled requires application.prometheusScrape.independentDeployment=true" }}
+{{- end }}
 {{ if .Values.application.prometheusScrape.independentDeployment }}
 {{- include "observe-agent.validateOtelPodUid" (dict "componentName" "prometheus-scraper" "extraEnvs" (index .Values "prometheus-scraper" "extraEnvs") "fleetEnabled" .Values.agent.config.global.fleet.enabled) -}}
 apiVersion: v1

--- a/charts/agent/templates/prometheus-target-allocator.yaml
+++ b/charts/agent/templates/prometheus-target-allocator.yaml
@@ -1,0 +1,187 @@
+{{- if and .Values.application.prometheusScrape.enabled .Values.application.prometheusScrape.independentDeployment .Values.application.prometheusScrape.targetAllocator.enabled }}
+{{- $ns := include "observe-agent.k8sNamespace" . }}
+{{- $root := . }}
+{{- $variants := list (dict "suffix" "pod-metrics" "scrapeJobPartial" "observe.prometheus.pod_metrics.scrape_job") }}
+{{- if .Values.node.metrics.cadvisor.enabled }}
+{{- $variants = append $variants (dict "suffix" "cadvisor" "scrapeJobPartial" "observe.prometheus.cadvisor.scrape_job") }}
+{{- end }}
+{{- range $variant := $variants }}
+{{- $taName := include "observe-agent.prometheusTargetAllocator.serviceName" (dict "root" $root "suffix" $variant.suffix) }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $taName }}
+  namespace: {{ $ns }}
+  labels:
+    app.kubernetes.io/name: prometheus-target-allocator
+    app.kubernetes.io/instance: {{ $root.Release.Name }}
+    app.kubernetes.io/component: {{ $variant.suffix }}
+    app.kubernetes.io/managed-by: {{ $root.Release.Service }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ $taName }}
+  labels:
+    app.kubernetes.io/name: prometheus-target-allocator
+    app.kubernetes.io/instance: {{ $root.Release.Name }}
+    app.kubernetes.io/component: {{ $variant.suffix }}
+rules:
+  - apiGroups: [""]
+    resources:
+      - nodes
+      - nodes/metrics
+      - services
+      - endpoints
+      - pods
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources:
+      - configmaps
+    verbs: ["get"]
+  - apiGroups: ["discovery.k8s.io"]
+    resources:
+      - endpointslices
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources:
+      - ingresses
+    verbs: ["get", "list", "watch"]
+  - nonResourceURLs: ["/metrics"]
+    verbs: ["get"]
+  - apiGroups: ["apps"]
+    resources:
+      - deployments
+      - replicasets
+      - statefulsets
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ $taName }}
+  labels:
+    app.kubernetes.io/name: prometheus-target-allocator
+    app.kubernetes.io/instance: {{ $root.Release.Name }}
+    app.kubernetes.io/component: {{ $variant.suffix }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ $taName }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ $taName }}
+    namespace: {{ $ns }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $taName }}
+  namespace: {{ $ns }}
+  labels:
+    app.kubernetes.io/name: prometheus-target-allocator
+    app.kubernetes.io/instance: {{ $root.Release.Name }}
+    app.kubernetes.io/component: {{ $variant.suffix }}
+data:
+  targetallocator.yaml: |
+    collector_namespace: {{ $ns | quote }}
+    collector_selector:
+      matchLabels:
+        app.kubernetes.io/name: prometheus-scraper
+        app.kubernetes.io/instance: {{ $root.Release.Name | quote }}
+        component: standalone-collector
+    listen_addr: ":8080"
+    allocation_strategy: consistent-hashing
+    filter_strategy: relabel-config
+    prometheus_cr:
+      enabled: false
+    config:
+      global:
+        scrape_interval: {{ $root.Values.application.prometheusScrape.interval | quote }}
+      scrape_configs:
+{{ include $variant.scrapeJobPartial $root | nindent 8 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $taName }}
+  namespace: {{ $ns }}
+  labels:
+    app.kubernetes.io/name: prometheus-target-allocator
+    app.kubernetes.io/instance: {{ $root.Release.Name }}
+    app.kubernetes.io/component: {{ $variant.suffix }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: prometheus-target-allocator
+    app.kubernetes.io/instance: {{ $root.Release.Name }}
+    app.kubernetes.io/component: {{ $variant.suffix }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $taName }}
+  namespace: {{ $ns }}
+  labels:
+    app.kubernetes.io/name: prometheus-target-allocator
+    app.kubernetes.io/instance: {{ $root.Release.Name }}
+    app.kubernetes.io/component: {{ $variant.suffix }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus-target-allocator
+      app.kubernetes.io/instance: {{ $root.Release.Name }}
+      app.kubernetes.io/component: {{ $variant.suffix }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: prometheus-target-allocator
+        app.kubernetes.io/instance: {{ $root.Release.Name }}
+        app.kubernetes.io/component: {{ $variant.suffix }}
+    spec:
+      serviceAccountName: {{ $taName }}
+      containers:
+        - name: target-allocator
+          image: "{{ $root.Values.application.prometheusScrape.targetAllocator.image.repository }}:{{ $root.Values.application.prometheusScrape.targetAllocator.image.tag }}"
+          imagePullPolicy: IfNotPresent
+          args:
+            - --config-file=/conf/targetallocator.yaml
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          env:
+            - name: OTELCOL_NAMESPACE
+              value: {{ $ns | quote }}
+          volumeMounts:
+            - name: config
+              mountPath: /conf
+              readOnly: true
+          resources:
+            {{- toYaml $root.Values.application.prometheusScrape.targetAllocator.resources | nindent 12 }}
+          livenessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+      volumes:
+        - name: config
+          configMap:
+            name: {{ $taName }}
+            items:
+              - key: targetallocator.yaml
+                path: targetallocator.yaml
+{{- end }}
+{{- end }}

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -144,6 +144,22 @@ application:
     metricDropRegex: ""
     # metrics to keep
     metricKeepRegex: (.*)
+    # Target Allocator (TA-only) shards pod_metrics across multiple prometheus-scraper replicas.
+    # Requires application.prometheusScrape.independentDeployment=true. OpenTelemetry Operator is not required.
+    # Set prometheus-scraper.replicaCount >= 2 for meaningful sharding.
+    targetAllocator:
+      enabled: false
+      # How often each collector syncs scrape jobs from the Target Allocator (Prometheus receiver target_allocator.interval).
+      interval: 30s
+      image:
+        repository: ghcr.io/open-telemetry/opentelemetry-operator/target-allocator
+        tag: "0.150.0"
+      resources:
+        requests:
+          cpu: 50m
+          memory: 128Mi
+        limits:
+          memory: 256Mi
   REDMetrics:
     # -- (bool) Whether to enable generating RED metrics from spans. See https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/spanmetricsconnector#overview
     enabled: false
@@ -628,6 +644,10 @@ prometheus-scraper:
       memory: 512Mi
     limits:
       memory: 512Mi
+
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault
   # ----------------------------------------- #
 
   # ----------------------------------------- #

--- a/test/verify_agent_prometheus_ta_template.sh
+++ b/test/verify_agent_prometheus_ta_template.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Verifies rendered agent chart when Target Allocator is enabled (ci/prometheus-ta-values.yaml).
+# Usage: from repo root: ./test/verify_agent_prometheus_ta_template.sh
+set -euo pipefail
+
+repo="$(git rev-parse --show-toplevel)"
+chart="$repo/charts/agent"
+values="$chart/ci/prometheus-ta-values.yaml"
+
+if [[ ! -f "$values" ]]; then
+  echo "missing $values" >&2
+  exit 1
+fi
+
+helm dependency build "$chart" >/dev/null
+
+out="$(helm template verify-ta "$chart" --namespace testing -f "$values")"
+
+# Both Target Allocator Deployments should render (one per scrape job).
+for ta in verify-ta-prometheus-ta-pod-metrics verify-ta-prometheus-ta-cadvisor; do
+  grep -q "name: $ta$" <<<"$out" || {
+    echo "expected TA resource named $ta" >&2
+    exit 1
+  }
+done
+
+# target-allocator container must exist (same image in both Deployments).
+grep -q 'name: target-allocator' <<<"$out" || {
+  echo "expected target-allocator container" >&2
+  exit 1
+}
+
+# FQDN must not contain quoted namespace, e.g. ."testing".
+if grep -E '\."testing"\.svc\.cluster\.local' <<<"$out"; then
+  echo "FAIL: namespace in URL appears quoted (bad DNS)" >&2
+  exit 1
+fi
+
+# Each receiver must point at its own TA — no cross-wiring.
+grep -qE 'endpoint: http://verify-ta-prometheus-ta-pod-metrics\.testing\.svc\.cluster\.local:8080' <<<"$out" || {
+  echo "expected prometheus/pod_metrics endpoint -> pod-metrics TA" >&2
+  exit 1
+}
+grep -qE 'endpoint: http://verify-ta-prometheus-ta-cadvisor\.testing\.svc\.cluster\.local:8080' <<<"$out" || {
+  echo "expected prometheus/cadvisor endpoint -> cadvisor TA" >&2
+  exit 1
+}
+
+# Each TA ConfigMap should carry exactly its own scrape job — isolation is what prevents
+# the two-receiver duplication problem, so verify cross-contamination does not happen.
+# Split the render on YAML-document boundaries ("---\n") and pick the ConfigMap whose name matches.
+extract_cm() {
+  awk -v name="$1" '
+    BEGIN { RS = "---\n" }
+    /kind: ConfigMap/ && $0 ~ ("  name: " name "\n") { print; exit }
+  ' <<<"$out"
+}
+pod_ta_cm="$(extract_cm verify-ta-prometheus-ta-pod-metrics)"
+cad_ta_cm="$(extract_cm verify-ta-prometheus-ta-cadvisor)"
+
+grep -q 'job_name: pod-metrics' <<<"$pod_ta_cm" || {
+  echo "pod-metrics TA ConfigMap is missing job_name: pod-metrics" >&2
+  exit 1
+}
+if grep -q 'kubernetes-nodes-cadvisor' <<<"$pod_ta_cm"; then
+  echo "pod-metrics TA ConfigMap leaked cadvisor job" >&2
+  exit 1
+fi
+grep -q 'kubernetes-nodes-cadvisor' <<<"$cad_ta_cm" || {
+  echo "cadvisor TA ConfigMap is missing kubernetes-nodes-cadvisor job" >&2
+  exit 1
+}
+if grep -q 'job_name: pod-metrics' <<<"$cad_ta_cm"; then
+  echo "cadvisor TA ConfigMap leaked pod-metrics job" >&2
+  exit 1
+fi
+
+# Sharding strategy is set on both.
+ta_count="$(grep -c 'allocation_strategy: consistent-hashing' <<<"$out" || true)"
+if [[ "$ta_count" -lt 2 ]]; then
+  echo "expected consistent-hashing on both TAs, found $ta_count" >&2
+  exit 1
+fi
+
+# Invalid combo must fail at template time (prometheus-scraper-configmap.yaml).
+bad_out="$(helm template bad-ta "$chart" --namespace testing \
+  -f "$chart/ci/test-values.yaml" \
+  --set application.prometheusScrape.independentDeployment=false \
+  --set application.prometheusScrape.targetAllocator.enabled=true 2>&1)" || true
+if ! grep -q 'targetAllocator.enabled requires application.prometheusScrape.independentDeployment=true' <<<"$bad_out"; then
+  echo "expected helm template to fail when TA is enabled without independentDeployment" >&2
+  echo "$bad_out" >&2
+  exit 1
+fi
+
+# Non-TA render must still work (regression guard — no TA resources, inline scrape_configs kept).
+plain_out="$(helm template plain "$chart" --namespace testing -f "$chart/ci/test-values.yaml")"
+if grep -q 'prometheus-ta' <<<"$plain_out"; then
+  echo "non-TA render should not include TA resources" >&2
+  exit 1
+fi
+grep -q 'job_name: pod-metrics' <<<"$plain_out" || {
+  echo "non-TA render is missing inline pod-metrics scrape_configs" >&2
+  exit 1
+}
+
+echo "verify_agent_prometheus_ta_template.sh: OK"


### PR DESCRIPTION
## Summary

Adds an opt-in Prometheus Target Allocator (TA) sharding path for the `prometheus-scraper` Deployment. Once enabled, a standalone TA discovers targets and distributes them across scraper replicas via consistent-hashing, so the Deployment can scale horizontally without duplicating metrics.

Opt in with:

```yaml
application:
  prometheusScrape:
    independentDeployment: true
    targetAllocator:
      enabled: true
prometheus-scraper:
  replicaCount: 2   # or more
```

## Topology: before (no Target Allocator)

With a single replica, both receivers watch the K8s API directly and scrape all matching targets independently:

```
                    ┌── Kubernetes API ──────┐
                    │   pods, nodes, ...     │
                    └─────┬──────────┬───────┘
                        watch       watch
                           │           │
                           ▼           ▼
    ┌──────────────────────────────────────────────────┐
    │      prometheus-scraper   (replicaCount = 1)     │
    │                                                  │
    │  prometheus/pod_metrics                          │
    │    inline scrape_configs ──────▶ scrapes ALL pods│
    │                                                  │
    │  prometheus/cadvisor                             │
    │    inline scrape_configs ──────▶ scrapes ALL nodes│
    └──────────────────────────┬───────────────────────┘
                               ▼
                        Observe (PRW exporter)
```

Scaling `replicaCount` to N causes every replica to independently scrape all targets — N× duplication:

```
                    ┌── Kubernetes API ──────┐
                    │   pods, nodes, ...     │
                    └──┬───────┬───────┬─────┘
                     watch   watch   watch
                       │       │       │
            ┌──────────┘       │       └──────────┐
            ▼                  ▼                  ▼
    ┌──────────────┐   ┌──────────────┐   ┌──────────────┐
    │  replica 1   │   │  replica 2   │   │  replica N   │
    │  pod_metrics │   │  pod_metrics │   │  pod_metrics │
    │  cadvisor    │   │  cadvisor    │   │  cadvisor    │
    └──────┬───────┘   └──────┬───────┘   └──────┬───────┘
           │    scrapes ALL   │    scrapes ALL    │
           └──────────────────┴──────────┬────────┘
                                         ▼
                                  Observe (PRW exporter)
                                  receives N× every metric  ← problem
```

## Topology: after (with Target Allocator)

```
                    ┌── Kubernetes API ──────┐
                    │   pods, nodes, ...     │
                    └─────┬──────────┬───────┘
                       watch       watch
                          │           │
              ┌───────────┘           └───────────┐
              ▼                                   ▼
    ┌─────────────────────┐             ┌─────────────────────┐
    │ TA (pod-metrics)    │             │ TA (cadvisor)       │
    │ owns: pod-metrics   │             │ owns: kubernetes-   │
    │ allocation:         │             │   nodes-cadvisor    │
    │  consistent-hashing │             │ allocation:         │
    │                     │             │  consistent-hashing │
    └──────────┬──────────┘             └──────────┬──────────┘
               │                                   │
               │    GET /jobs/.../targets?collector_id=<pod-name>
               ▼                                   ▼
    ┌────────────────────────────────────────────────────────┐
    │        prometheus-scraper   (replicaCount = N)         │
    │                                                        │
    │  ┌─ replica 1 ──────────┐    ┌─ replica 2 ──────────┐  │
    │  │ prom/pod_metrics ───▶ TA-pod-metrics             │  │
    │  │ prom/cadvisor    ───▶ TA-cadvisor                │  │
    │  └──────────────────────┘    └──────────────────────┘  │
    │        scrapes its              scrapes its            │
    │        assigned share           assigned share         │
    └────────────────────┬───────────────────────────────────┘
                         ▼
                  Observe (PRW exporter)
```

## Why one TA per job

The OTel prometheus receiver with `target_allocator` has no per-receiver job filter — each receiver instance polls `/scrape_configs`, reads **every** job the TA returns, and scrapes all of them. The chart has two prometheus receivers (`prometheus/pod_metrics` and `prometheus/cadvisor`) because their pipelines differ in processor chain (the pod-metrics pipeline drops `service.name`; each tags metrics with its own source attribute). A single shared TA would make each receiver scrape both jobs:

```
  ┌─ one shared TA ───────────┐
  │ jobs: pod-metrics         │   /scrape_configs returns BOTH jobs
  │       cadvisor            │ ────────────────────────────────────┐
  └───────────────────────────┘                                     │
                                                                    ▼
                          ┌─────────────────────────────────────────────────┐
                          │ scraper pod                                     │
                          │   receiver pod_metrics  scrapes pod + cadvisor  │ ← 2×
                          │   receiver cadvisor     scrapes pod + cadvisor  │ ← 2×
                          └─────────────────────────────────────────────────┘
```

Every metric flows through both pipelines → 2× duplication per pod, before replica-level sharding even applies.

Isolating each job to its own TA keeps the `/scrape_configs` response to exactly one job per receiver, which is all the receiver sees, which is all it scrapes.

## What's in this PR

- `charts/agent/templates/prometheus-target-allocator.yaml` — ranges over a list of per-job TA variants (`pod-metrics` always; `cadvisor` when `node.metrics.cadvisor.enabled`), emitting a full TA stack per variant (ServiceAccount, ClusterRole, ClusterRoleBinding, ConfigMap, Service, Deployment).
- `charts/agent/templates/_config-receivers.tpl` — both `pod_metrics` and `cadvisor` receivers now branch on TA: TA mode emits a `target_allocator` block pointing at the matching TA Service; non-TA mode keeps the existing inline `scrape_configs` path.
- `charts/agent/templates/_helpers.tpl` — TA service-name helper now takes a `suffix` so each variant gets a unique DNS name.
- `charts/agent/templates/prometheus-scraper-configmap.yaml` — fails at `helm template` time if `targetAllocator.enabled` is set without `independentDeployment`.
- `charts/agent/values.yaml` — new `application.prometheusScrape.targetAllocator` block (`enabled`, `interval`, `image`, `resources`).
- `charts/agent/ci/prometheus-ta-values.yaml`, `test/verify_agent_prometheus_ta_template.sh`, `Makefile`, `.github/workflows/test.yml` — render-time checks that both TAs deploy, each TA's ConfigMap contains only its own scrape job, each receiver points at its own TA, and the non-TA path still renders cleanly.
- `charts/agent/README.md` — docs for the new flag.

## Status

**Draft / WIP** while we decide between shipping this as-is vs. a single-receiver refactor (see Alternatives). Works end-to-end locally.

## Test plan

- [x] `helm lint` clean on both the new TA CI values and the existing defaults
- [x] `helm template` verify script passes (both TAs rendered, correct endpoint wiring, no cross-contamination in TA ConfigMaps, non-TA path unchanged)
- [x] Local minikube install end-to-end with the real TA image + cadvisor sharding + probe pods (results below)
- [ ] Multi-node real-cluster soak: cadvisor target distribution across >1 node, scraper churn behavior over a few hours
- [ ] Decide design direction (see Alternatives)

## Local smoke test (minikube)

Sensitive identifiers redacted.

<details>
<summary>Setup commands</summary>

```sh
# Stop any host-level observe-agent
sudo systemctl stop observe-agent

# Fresh minikube
minikube start --driver=docker --cpus=4 --memory=6g

# Namespace + credentials
kubectl create namespace observe
kubectl -n observe create secret generic agent-credentials \
  --from-literal=OBSERVE_TOKEN='<REDACTED>'
kubectl annotate secret agent-credentials -n observe \
  meta.helm.sh/release-name=observe-agent \
  meta.helm.sh/release-namespace=observe
kubectl label secret agent-credentials -n observe \
  app.kubernetes.io/managed-by=Helm

# Install from local chart with TA + cadvisor + 2 scraper replicas
helm install observe-agent ./charts/agent -n observe \
  --set observe.collectionEndpoint.value="https://<customer-id>.collect.observe-eng.com/" \
  --set cluster.name="observe-agent-monitored-cluster" \
  --set node.containers.logs.enabled=true \
  --set node.forwarder.enabled=true \
  --set node.forwarder.metrics.outputFormat=otel \
  --set application.REDMetrics.enabled=true \
  --set agent.config.global.fleet.enabled=true \
  --set application.prometheusScrape.enabled=true \
  --set application.prometheusScrape.independentDeployment=true \
  --set application.prometheusScrape.targetAllocator.enabled=true \
  --set node.metrics.cadvisor.enabled=true \
  --set prometheus-scraper.replicaCount=2
```

</details>

### All pods Ready

```
NAME                                                      READY   STATUS
observe-agent-cluster-events-<hash>                       1/1     Running
observe-agent-cluster-metrics-<hash>                      1/1     Running
observe-agent-forwarder-agent-<hash>                      1/1     Running
observe-agent-monitor-<hash>                              1/1     Running
observe-agent-node-logs-metrics-agent-<hash>              1/1     Running
observe-agent-prometheus-scraper-<hash>-<a>               1/1     Running   # replica 1
observe-agent-prometheus-scraper-<hash>-<b>               1/1     Running   # replica 2
observe-agent-prometheus-ta-cadvisor-<hash>               1/1     Running
observe-agent-prometheus-ta-pod-metrics-<hash>            1/1     Running
```

### 1. Per-TA job isolation

```sh
kubectl -n observe port-forward svc/observe-agent-prometheus-ta-pod-metrics 18080:8080 &
kubectl -n observe port-forward svc/observe-agent-prometheus-ta-cadvisor   18081:8080 &
curl -s http://localhost:18080/scrape_configs | jq 'keys'
curl -s http://localhost:18081/scrape_configs | jq 'keys'
```

Result:

```
pod-metrics TA  /scrape_configs  →  ["pod-metrics"]
cadvisor TA     /scrape_configs  →  ["kubernetes-nodes-cadvisor"]
```

No cross-contamination — if either TA advertised both jobs, each receiver would scrape both.

### 2. Cadvisor sharding (1 node, 2 scrapers)

```sh
for id in $(kubectl get pods -n observe -l app.kubernetes.io/name=prometheus-scraper \
              -o jsonpath='{.items[*].metadata.name}'); do
  echo "$id:"
  curl -s "http://localhost:18081/jobs/kubernetes-nodes-cadvisor/targets?collector_id=$id" \
    | jq '.[].targets'
done
```

Result:

```
scraper-<a>  →  [["192.168.49.2:10250"]]
scraper-<b>  →  []
```

The single node is owned by exactly one scraper — the other gets an empty list. Cadvisor is scraped exactly once regardless of `replicaCount`.

### 3. Pod-metrics sharding with synthetic targets

Deploy 8 probe pods (each has a container port named `metrics` so the default `portKeepRegex: .*metrics` keeps them):

```yaml
apiVersion: apps/v1
kind: Deployment
metadata: { name: probe-targets, namespace: probe }
spec:
  replicas: 8
  selector: { matchLabels: { app: probe-target } }
  template:
    metadata: { labels: { app: probe-target } }
    spec:
      containers:
        - name: probe
          image: registry.k8s.io/pause:3.9
          ports: [{ name: metrics, containerPort: 8080 }]
```

Query the pod-metrics TA:

| Step | Scrapers | Probes | Allocation | Notes |
|---|---|---|---|---|
| Initial | 2 | 8 | 4 / 4 | Perfectly even split |
| Scale scrapers to 3 | 3 | 8 | 4 / 4 / **0** | New replica sits idle |
| Scale probes to 12 | 3 | 12 | 6 / 5 / 1 | New replica picks up its share on next allocation |

Raw target count from the TA was 77 (every pod in the cluster) → `targets_remaining` was 8, then 12 after relabel filtering. The chart's rules correctly drop `kube-system` + the observe-agent's own pods (they opt out via `observeinc_com_scrape: false`).

### 4. End-to-end data flow — scrapers actually emit their assigned targets

The verify script proves that manifests render correctly; this test proves that the wired-up system *actually scrapes* and emits metrics from the assigned targets.

**Setup — install with the debug exporter wired into every pipeline:**

```sh
helm install observe-agent ./charts/agent -n observe \
  ...                                                       # (same as earlier, plus:)
  --set application.prometheusScrape.targetAllocator.enabled=true \
  --set node.metrics.cadvisor.enabled=true \
  --set prometheus-scraper.replicaCount=2 \
  --set agent.config.global.debug.enabled=true \
  --set agent.config.global.debug.verbosity=detailed \
  --set agent.config.global.service.telemetry.loggingLevel=INFO
```

**Probe targets — 8 pods serving real `/metrics`:**

```sh
kubectl apply -f - <<'YAML'
apiVersion: v1
kind: Namespace
metadata: { name: probe }
---
apiVersion: apps/v1
kind: Deployment
metadata: { name: probe-targets, namespace: probe }
spec:
  replicas: 8
  selector: { matchLabels: { app: probe-target } }
  template:
    metadata: { labels: { app: probe-target } }
    spec:
      containers:
        - name: app
          image: quay.io/brancz/prometheus-example-app:v0.5.0
          ports: [{ name: metrics, containerPort: 8080 }]
YAML
```

**Port-forward both TAs for inspection:**

```sh
kubectl -n observe port-forward svc/observe-agent-prometheus-ta-pod-metrics 18080:8080 &
kubectl -n observe port-forward svc/observe-agent-prometheus-ta-cadvisor   18081:8080 &
```

#### Pod-metrics

**Command — TA allocator gauges:**

```sh
curl -s http://localhost:18080/metrics | grep '^opentelemetry_allocator_'
```

**Result:**

```
opentelemetry_allocator_collectors_discovered 2
opentelemetry_allocator_collectors_allocatable{strategy="consistent-hashing"} 2
opentelemetry_allocator_targets{job_name="pod-metrics"} 69
opentelemetry_allocator_targets_remaining 8
opentelemetry_allocator_targets_unassigned 0
opentelemetry_allocator_targets_per_collector{collector_name="...hbnj4",strategy="consistent-hashing"} 6
opentelemetry_allocator_targets_per_collector{collector_name="...v5grp",strategy="consistent-hashing"} 2
```

69 raw targets from K8s SD → 8 kept after relabel filtering → split 6/2 between the two scrapers. Imbalance is expected for small target counts with consistent-hashing; evens out as target count grows.

**Command — which probe pods each scraper actually emitted metrics for (last 70s window, one scrape cycle after allocation settled):**

```sh
for p in $(kubectl -n observe get pods -l app.kubernetes.io/name=prometheus-scraper \
             -o jsonpath='{.items[*].metadata.name}'); do
  echo "--- $p ---"
  kubectl -n observe logs "$p" --since=70s \
    | grep -oE 'service\.instance\.id: Str\(10\.244\.[0-9]+\.[0-9]+:8080\)' \
    | sort -u
done
```

**Result:**

```
--- scraper hbnj4 ---
service.instance.id: Str(10.244.0.12:8080)
service.instance.id: Str(10.244.0.13:8080)
service.instance.id: Str(10.244.0.14:8080)
service.instance.id: Str(10.244.0.15:8080)
service.instance.id: Str(10.244.0.18:8080)
service.instance.id: Str(10.244.0.19:8080)

--- scraper v5grp ---
service.instance.id: Str(10.244.0.16:8080)
service.instance.id: Str(10.244.0.17:8080)
```

**Command — overlap + union:**

```sh
A=$(kubectl -n observe logs scraper-hbnj4 --since=70s | grep -oE '10\.244\.[0-9]+\.[0-9]+:8080' | sort -u)
B=$(kubectl -n observe logs scraper-v5grp --since=70s | grep -oE '10\.244\.[0-9]+\.[0-9]+:8080' | sort -u)
comm -12 <(echo "$A") <(echo "$B")             # overlap
{ echo "$A"; echo "$B"; } | sort -u | wc -l    # union
```

**Result:**

```
overlap: (empty — no probe pod appears in both scrapers' emissions)
union:   8                  (every probe target is scraped exactly once)
```

The OTel prometheus receiver stamps `service.instance.id` as a resource attribute on every emitted metric, set to the `<ip>:<port>` that was actually scraped. So zero overlap between the two scrapers' `service.instance.id` sets proves the deduplication guarantee the whole feature is designed for: **every probe pod's `/metrics` endpoint was hit by exactly one scraper in this scrape cycle — no pod was scraped twice, and no pod was missed.**

**Command — which metric names each scraper actually emitted for the probe pods:**

```sh
for p in $(kubectl -n observe get pods -l app.kubernetes.io/name=prometheus-scraper \
             -o jsonpath='{.items[*].metadata.name}'); do
  echo "--- $p ---"
  kubectl -n observe logs "$p" --since=70s \
    | awk '/service\.name: Str\(probe-targets\)/{p=1} /^2026/{p=0} p && /^ *-> Name:/' \
    | sort -u
done
```

**Result:**

```
--- scraper hbnj4 ---
     -> Name: scrape_duration_seconds          # Prometheus meta
     -> Name: scrape_samples_post_metric_relabeling
     -> Name: scrape_samples_scraped
     -> Name: scrape_series_added
     -> Name: up
     -> Name: version                          # the probe app's own metric

--- scraper v5grp ---
     -> Name: scrape_duration_seconds
     -> Name: scrape_samples_post_metric_relabeling
     -> Name: scrape_samples_scraped
     -> Name: scrape_series_added
     -> Name: up
     -> Name: version                          # the probe app's own metric
```

`prometheus-example-app` exposes a single data metric (`version{version="v0.5.0"} 1`); it arrives in the scraper's debug exporter output with `debug_source: Str(pod_metrics)` alongside Prometheus' scrape meta-metrics. Both scrapers emit it for their own assigned subset of probe pods.

#### Cadvisor

**Caveat:** minikube is a single-node cluster, so cadvisor service discovery finds exactly **1 target**. With 1 target and 2 scrapers, consistent-hashing deterministically assigns the target to one scraper; the other correctly gets an empty list. This is the degenerate sharding case (targets < collectors), not a full sharding proof for cadvisor — a multi-node cluster would show the same split-across-scrapers behavior demonstrated above for pod-metrics. The multi-node soak is in the Test plan as a follow-up.

**Command — TA allocator gauges:**

```sh
curl -s http://localhost:18081/metrics | grep '^opentelemetry_allocator_'
```

**Result:**

```
opentelemetry_allocator_targets{job_name="kubernetes-nodes-cadvisor"} 1
opentelemetry_allocator_targets_per_collector{collector_name="...hbnj4"} 1
opentelemetry_allocator_targets_per_collector{collector_name="...v5grp"} 0
```

**Command — count cadvisor metric emissions per scraper:**

```sh
for p in $(kubectl -n observe get pods -l app.kubernetes.io/name=prometheus-scraper \
             -o jsonpath='{.items[*].metadata.name}'); do
  n=$(kubectl -n observe logs "$p" --since=3m | grep -c 'container_cpu_usage_seconds_total')
  echo "$p: container_cpu_usage_seconds_total hits = $n"
done
```

**Result:**

```
scraper hbnj4: container_cpu_usage_seconds_total hits = 3   # owns the cadvisor target
scraper v5grp: container_cpu_usage_seconds_total hits = 0   # empty target list
```

Only the scraper owning the cadvisor target produces cadvisor metrics; the other produces none. The full cadvisor metric family (`container_blkio_*`, `container_cpu_*`, `container_fs_*`, `container_memory_*`, `container_network_*`, etc.) flows through the `metrics/cadvisor` pipeline as expected.

#### Summary

Across both receivers, every target is scraped exactly once; every metric hits the pipeline exactly once per scrape cycle. No duplication across scraper replicas.

### Steady-state logs

```sh
kubectl -n observe logs <scraper-pod> --since=30s | grep -iE 'error|warn'
```

No errors in steady state. Initial startup shows a few `Failed to retrieve job list: connection refused` — the scraper pod polls the TA before the TA pod is Ready. The receiver's TA manager retries on its interval and recovers; noted as a caveat below.

## Known caveats

1. **Startup race.** Scraper polls TA before TA is Ready → a few seconds of `connection refused` at boot. Self-corrects. Follow-up: initContainer that waits for the TA Service's endpoints to have a Ready pod.
2. **New scraper replicas don't receive targets until the target set changes.** Upstream TA's consistent-hashing allocator only re-runs allocation on target-change events, not collector-change events. In production this self-corrects within seconds (pods churn naturally); in a quiet test setup you have to perturb the target set to trigger reallocation. This is upstream behavior, not a chart bug — but worth documenting.
3. **TA image is distroless** — no `wget`, `curl`, or shell for in-container debugging. Use `kubectl port-forward` + host tooling.
4. **No `checksum/config` on the TA Deployment pod template.** Editing a TA ConfigMap won't trigger a rollout. Follow-up.

## Alternatives considered

**Single TA, two receivers.** The naive approach. Rejected — see "Why one TA per job" above.

**Single receiver + routing/filter processors.** Collapse the two prometheus receivers into one `prometheus/k8s_metrics`, split the resulting stream into two pipelines via `filter` processors keyed on `service.name` (which the prometheus receiver sets to the scrape job name). Matches the upstream "one receiver per collector" pattern and is where the OTel ecosystem is trending. Not in this PR because it's a larger refactor (receivers, pipelines, processors all change) and relies on an implicit contract between the prometheus receiver's label mapping and the filter rule — worth doing, but as a separate change where routing correctness can be tested in isolation.