### PR TITLE
feat: add HPA support for prometheus-scraper

### DIFF
--- a/charts/agent/Chart.lock
+++ b/charts/agent/Chart.lock
@@ -8,6 +8,9 @@ dependencies:
 - name: opentelemetry-collector
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
   version: 0.143.0
+- name: opentelemetry-target-allocator
+  repository: https://open-telemetry.github.io/opentelemetry-helm-charts
+  version: 0.127.2
 - name: opentelemetry-collector
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
   version: 0.143.0
@@ -20,5 +23,5 @@ dependencies:
 - name: opentelemetry-collector
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
   version: 0.143.0
-digest: sha256:52184a96f6b61deb5d64a72df555e6b2b6a0cfab82cd0f2aff09074e4ef4c418
-generated: "2026-01-20T16:33:43.393951-05:00"
+digest: sha256:4c9c0692c53055a5e879df474b3958f92ccea860a4f5214c21b1b17dc1b82492
+generated: "2026-05-05T18:09:11.69163921Z"

--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent
 description: Chart to install K8s collection stack based on Observe Agent
 type: application
-version: 0.86.1
+version: 0.87.0
 appVersion: "2.15.0"
 dependencies:
   - name: opentelemetry-collector

--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -20,6 +20,11 @@ dependencies:
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
     alias: prometheus-scraper
     condition: application.prometheusScrape.independentDeployment
+  - name: opentelemetry-target-allocator
+    version: 0.127.2
+    repository: https://open-telemetry.github.io/opentelemetry-helm-charts
+    alias: prometheus-ta
+    condition: application.prometheusScrape.targetAllocator.enabled
   - name: opentelemetry-collector
     version: 0.143.0
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -51,6 +51,7 @@ This service is an *OpenTelemetryCollector*, a custom resource that is managed b
 | https://open-telemetry.github.io/opentelemetry-helm-charts | monitor(opentelemetry-collector) | 0.143.0 |
 | https://open-telemetry.github.io/opentelemetry-helm-charts | forwarder(opentelemetry-collector) | 0.143.0 |
 | https://open-telemetry.github.io/opentelemetry-helm-charts | gateway(opentelemetry-collector) | 0.143.0 |
+| https://open-telemetry.github.io/opentelemetry-helm-charts | prometheus-ta(opentelemetry-target-allocator) | 0.127.2 |
 
 ## Values
 
@@ -707,3 +708,10 @@ This service is an *OpenTelemetryCollector*, a custom resource that is managed b
 | prometheus-scraper.serviceAccount.create | bool | `false` |  |
 | prometheus-scraper.serviceAccount.name | string | `"observe-agent-service-account"` |  |
 | prometheus-scraper.tolerations | list | `[]` |  |
+| prometheus-ta.configMap.create | bool | `false` |  |
+| prometheus-ta.configMap.existingName | string | `"prometheus-ta"` |  |
+| prometheus-ta.replicaCount | int | `1` |  |
+| prometheus-ta.targetAllocator.image.tag | string | `"0.150.0"` |  |
+| prometheus-ta.targetAllocator.resources.limits.memory | string | `"256Mi"` |  |
+| prometheus-ta.targetAllocator.resources.requests.cpu | string | `"50m"` |  |
+| prometheus-ta.targetAllocator.resources.requests.memory | string | `"128Mi"` |  |

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -643,6 +643,10 @@ This service is an *OpenTelemetryCollector*, a custom resource that is managed b
 | prometheus-scraper.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[1].key | string | `"kubernetes.io/os"` |  |
 | prometheus-scraper.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[1].operator | string | `"NotIn"` |  |
 | prometheus-scraper.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[1].values[0] | string | `"windows"` |  |
+| prometheus-scraper.autoscaling.enabled | bool | `false` |  |
+| prometheus-scraper.autoscaling.maxReplicas | int | `10` |  |
+| prometheus-scraper.autoscaling.minReplicas | int | `2` |  |
+| prometheus-scraper.autoscaling.targetCPUUtilizationPercentage | int | `70` |  |
 | prometheus-scraper.clusterRole.create | bool | `false` |  |
 | prometheus-scraper.clusterRole.name | string | `"observe-agent-cluster-role"` |  |
 | prometheus-scraper.command.extraArgs[0] | string | `"start"` |  |

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -1,6 +1,6 @@
 # agent
 
-![Version: 0.86.1](https://img.shields.io/badge/Version-0.86.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.15.0](https://img.shields.io/badge/AppVersion-2.15.0-informational?style=flat-square)
+![Version: 0.87.0](https://img.shields.io/badge/Version-0.87.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.15.0](https://img.shields.io/badge/AppVersion-2.15.0-informational?style=flat-square)
 
 Chart to install K8s collection stack based on Observe Agent
 
@@ -101,6 +101,7 @@ This service is an *OpenTelemetryCollector*, a custom resource that is managed b
 | application.prometheusScrape.namespaceDropRegex | string | `"(.*istio.*|.*ingress.*|kube-system)"` |  |
 | application.prometheusScrape.namespaceKeepRegex | string | `"(.*)"` |  |
 | application.prometheusScrape.portKeepRegex | string | `".*metrics"` |  |
+| application.prometheusScrape.targetAllocator.enabled | bool | `false` |  |
 | cluster-events.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key | string | `"observeinc.com/unschedulable"` |  |
 | cluster-events.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].operator | string | `"DoesNotExist"` |  |
 | cluster-events.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[1].key | string | `"kubernetes.io/os"` |  |

--- a/charts/agent/ci/prometheus-ta-values.yaml
+++ b/charts/agent/ci/prometheus-ta-values.yaml
@@ -1,0 +1,31 @@
+observe:
+  collectionEndpoint:
+    value: "http://test-stack-collector.testing.svc.cluster.local:8080"
+  token:
+    create: true
+    value: "fake-ds:fake-token"
+
+application:
+  prometheusScrape:
+    enabled: true
+    independentDeployment: true
+    targetAllocator:
+      enabled: true
+
+node:
+  metrics:
+    cadvisor:
+      enabled: true
+
+cluster:
+  namespaceOverride:
+    value: "testing"
+
+cluster-events:
+  namespaceOverride: "testing"
+cluster-metrics:
+  namespaceOverride: "testing"
+node-logs-metrics:
+  namespaceOverride: "testing"
+prometheus-scraper:
+  namespaceOverride: "testing"

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/agent-monitor-configmap.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/agent-monitor-configmap.yaml
@@ -1,0 +1,154 @@
+---
+# Source: agent/templates/agent-monitor-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: monitor
+  namespace: observe
+data:
+  relay: |
+      exporters:
+        debug/override:
+          sampling_initial: 2
+          sampling_thereafter: 1
+          verbosity: basic
+        prometheusremotewrite/observe:
+          endpoint: ${env:OBSERVE_PROMETHEUS_ENDPOINT}
+          headers:
+            authorization: ${env:OBSERVE_AUTHORIZATION_HEADER}
+            x-observe-target-package: Kubernetes Explorer
+          max_batch_request_parallelism: 5
+          remote_write_queue:
+            num_consumers: 5
+          resource_to_telemetry_conversion:
+            enabled: true
+          retry_on_failure:
+            enabled: true
+            initial_interval: 1s
+            max_elapsed_time: 5m
+            max_interval: 30s
+          send_metadata: true
+          timeout: 10s
+      processors:
+        attributes/debug_source_agent_monitor:
+          actions:
+          - action: insert
+            key: debug_source
+            value: agent_monitor
+        batch:
+          send_batch_max_size: 4096
+          send_batch_size: 4096
+          timeout: 5s
+        k8sattributes:
+          extract:
+            labels:
+            - from: pod
+              key_regex: (app\.kubernetes\.io/.+)
+              tag_name: $1
+            metadata:
+            - k8s.namespace.name
+            - k8s.deployment.name
+            - k8s.replicaset.name
+            - k8s.statefulset.name
+            - k8s.daemonset.name
+            - k8s.cronjob.name
+            - k8s.job.name
+            - k8s.node.name
+            - k8s.node.uid
+            - k8s.pod.name
+            - k8s.pod.uid
+            - k8s.cluster.uid
+            - k8s.container.name
+            - container.id
+            - service.namespace
+            - service.name
+            - service.version
+            - service.instance.id
+            otel_annotations: true
+          passthrough: false
+          pod_association:
+          - sources:
+            - from: resource_attribute
+              name: k8s.pod.ip
+          - sources:
+            - from: resource_attribute
+              name: k8s.pod.uid
+          - sources:
+            - from: connection
+          wait_for_metadata: false
+          wait_for_metadata_timeout: 10s
+        memory_limiter:
+          check_interval: 5s
+          limit_percentage: 80
+          spike_limit_percentage: 15
+        resource/drop_service_name:
+          attributes:
+          - action: delete
+            key: service.name
+        resource/observe_common:
+          attributes:
+          - action: upsert
+            key: k8s.cluster.name
+            value: ${env:OBSERVE_CLUSTER_NAME}
+          - action: upsert
+            key: k8s.cluster.uid
+            value: ${env:OBSERVE_CLUSTER_UID}
+      receivers:
+        prometheus/collector:
+          config:
+            scrape_configs:
+            - job_name: opentelemetry-collector-self
+              scrape_interval: 60s
+              static_configs:
+              - targets:
+                - ${env:MY_POD_IP}:8888
+            - honor_labels: true
+              job_name: opentelemetry-collector-other
+              kubernetes_sd_configs:
+              - role: pod
+              relabel_configs:
+              - action: keep
+                regex: observecollection
+                source_labels:
+                - __meta_kubernetes_pod_annotation_observe_monitor_purpose
+              - action: keep
+                regex: true
+                source_labels:
+                - __meta_kubernetes_pod_annotation_observe_monitor_scrape
+              - action: replace
+                regex: (.+)
+                source_labels:
+                - __meta_kubernetes_pod_annotation_observe_monitor_path
+                target_label: __metrics_path__
+              - action: replace
+                regex: ([^:]+)(?::\d+)?;(\d+)
+                replacement: $$1:$$2
+                source_labels:
+                - __address__
+                - __meta_kubernetes_pod_annotation_observe_monitor_port
+                target_label: __address__
+              - action: labelmap
+                regex: __meta_kubernetes_pod_label_(.+)
+              - action: replace
+                source_labels:
+                - __meta_kubernetes_namespace
+                target_label: kubernetes_namespace
+              - action: replace
+                source_labels:
+                - __meta_kubernetes_pod_name
+                target_label: kubernetes_pod_name
+              scrape_interval: 60s
+      service:
+        pipelines:
+          metrics:
+            exporters:
+            - prometheusremotewrite/observe
+            processors:
+            - memory_limiter
+            - resource/drop_service_name
+            - k8sattributes
+            - batch
+            - resource/observe_common
+            - attributes/debug_source_agent_monitor
+            receivers:
+            - prometheus/collector

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/cluster-events-configmap.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/cluster-events-configmap.yaml
@@ -1,0 +1,547 @@
+---
+# Source: agent/templates/cluster-events-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-events
+  namespace: observe
+data:
+  relay: |
+      exporters:
+        debug/override:
+          sampling_initial: 2
+          sampling_thereafter: 1
+          verbosity: basic
+        otlphttp/observe/entity:
+          compression: zstd
+          headers:
+            authorization: ${env:OBSERVE_AUTHORIZATION_HEADER}
+            x-observe-target-package: Kubernetes Explorer
+          logs_endpoint: ${env:OBSERVE_COLLECTOR_URL}/v1/kubernetes/v1/entity
+          retry_on_failure:
+            enabled: true
+            initial_interval: 1s
+            max_elapsed_time: 5m
+            max_interval: 30s
+          sending_queue:
+            enabled: true
+          timeout: 10s
+      processors:
+        batch:
+          send_batch_max_size: 1024
+          send_batch_size: 1024
+          timeout: 5s
+        filter/cluster:
+          error_mode: ignore
+          logs:
+            log_record:
+            - body["metadata"]["name"] != "kube-system" and body["object"]["metadata"]["name"]
+              != "kube-system"
+        memory_limiter:
+          check_interval: 5s
+          limit_percentage: 80
+          spike_limit_percentage: 15
+        observek8sattributes: null
+        resource/observe_common:
+          attributes:
+          - action: upsert
+            key: k8s.cluster.name
+            value: ${env:OBSERVE_CLUSTER_NAME}
+          - action: upsert
+            key: k8s.cluster.uid
+            value: ${env:OBSERVE_CLUSTER_UID}
+        transform/cluster:
+          error_mode: ignore
+          log_statements:
+          - context: log
+            statements:
+            - set(attributes["observe_filter"], "objects_pull_watch")
+            - set(attributes["observe_transform"]["control"]["isDelete"], true) where body["object"]
+              != nil and body["type"] == "DELETED"
+            - set(attributes["observe_transform"]["control"]["debug_source"], "watch") where
+              body["object"] != nil and body["type"] != nil
+            - set(attributes["observe_transform"]["control"]["debug_source"], "pull") where
+              body["object"] == nil or body["type"] == nil
+            - set(body, body["object"]) where body["object"] != nil and body["type"] !=
+              nil
+            - set(attributes["observe_transform"]["valid_from"], observed_time_unix_nano)
+            - set(attributes["observe_transform"]["valid_to"], Int(observed_time_unix_nano)
+              + 5400000000000)
+            - set(attributes["observe_transform"]["kind"], "Cluster")
+            - set(attributes["observe_transform"]["control"]["isDelete"], false) where attributes["observe_transform"]["control"]["isDelete"]
+              == nil
+            - set(attributes["observe_transform"]["control"]["version"], body["metadata"]["resourceVersion"])
+            - set(attributes["observe_transform"]["identifiers"]["clusterName"], resource.attributes["k8s.cluster.name"])
+            - set(attributes["observe_transform"]["identifiers"]["clusterUid"], resource.attributes["k8s.cluster.uid"])
+            - set(attributes["observe_transform"]["identifiers"]["uid"], resource.attributes["k8s.cluster.uid"])
+            - set(attributes["observe_transform"]["identifiers"]["kind"], "Cluster")
+            - set(attributes["observe_transform"]["identifiers"]["name"], resource.attributes["k8s.cluster.name"])
+            - set(attributes["observe_transform"]["facets"]["creationTimestamp"], body["metadata"]["creationTimestamp"])
+            - set(attributes["observe_transform"]["facets"]["labels"], body["metadata"]["labels"])
+            - set(attributes["observe_transform"]["facets"]["annotations"], body["metadata"]["annotations"])
+            - set(body, "")
+        transform/object:
+          error_mode: ignore
+          log_statements:
+          - context: log
+            statements:
+            - set(attributes["observe_filter"], "objects_pull_watch")
+            - set(attributes["observe_transform"]["valid_from"], observed_time_unix_nano)
+            - set(attributes["observe_transform"]["valid_to"], Int(observed_time_unix_nano)
+              + 5400000000000)
+            - set(attributes["observe_transform"]["kind"], body["kind"])
+            - set(attributes["observe_transform"]["control"]["isDelete"], false) where attributes["observe_transform"]["control"]["isDelete"]
+              == nil
+            - set(attributes["observe_transform"]["control"]["version"], body["metadata"]["resourceVersion"])
+            - set(attributes["observe_transform"]["control"]["agentVersion"], "2.15.0")
+            - set(attributes["observe_transform"]["identifiers"]["clusterName"], resource.attributes["k8s.cluster.name"])
+            - set(attributes["observe_transform"]["identifiers"]["clusterUid"], resource.attributes["k8s.cluster.uid"])
+            - set(attributes["observe_transform"]["identifiers"]["kind"], body["kind"])
+            - set(attributes["observe_transform"]["identifiers"]["name"], body["metadata"]["name"])
+            - set(attributes["observe_transform"]["identifiers"]["namespaceName"], body["metadata"]["namespace"])
+            - set(attributes["observe_transform"]["identifiers"]["uid"], body["metadata"]["uid"])
+            - set(attributes["observe_transform"]["facets"]["creationTimestamp"], body["metadata"]["creationTimestamp"])
+            - set(attributes["observe_transform"]["facets"]["deletionTimestamp"], body["metadata"]["deletionTimestamp"])
+            - set(attributes["observe_transform"]["facets"]["ownerRefKind"], body["metadata"]["ownerReferences"][0]["kind"])
+            - set(attributes["observe_transform"]["facets"]["ownerRefName"], body["metadata"]["ownerReferences"][0]["name"])
+            - set(attributes["observe_transform"]["facets"]["labels"], body["metadata"]["labels"])
+            - set(attributes["observe_transform"]["facets"]["annotations"], body["metadata"]["annotations"])
+            - set(attributes["observe_transform"]["facets"]["replicaSetName"], body["metadata"]["ownerReferences"][0]["name"])
+              where body["metadata"]["ownerReferences"][0]["kind"] == "ReplicaSet"
+            - set(attributes["observe_transform"]["facets"]["daemonSetName"], body["metadata"]["ownerReferences"][0]["name"])
+              where body["metadata"]["ownerReferences"][0]["kind"] == "DaemonSet"
+            - set(attributes["observe_transform"]["facets"]["jobName"], body["metadata"]["ownerReferences"][0]["name"])
+              where body["metadata"]["ownerReferences"][0]["kind"] == "Job"
+            - set(attributes["observe_transform"]["facets"]["cronJobName"], attributes["observe_transform"]["facets"]["jobName"])
+              where IsMatch(attributes["observe_transform"]["facets"]["jobName"], ".*-\\d{8}$")
+            - replace_pattern(attributes["observe_transform"]["facets"]["cronJobName"],
+              "-\\d{8}$$", "")
+            - set(attributes["observe_transform"]["facets"]["statefulSetName"], body["metadata"]["ownerReferences"][0]["name"])
+              where body["metadata"]["ownerReferences"][0]["kind"] == "StatefulSet"
+            - set(attributes["observe_transform"]["facets"]["deploymentName"], body["metadata"]["ownerReferences"][0]["name"])
+              where body["metadata"]["ownerReferences"][0]["kind"] == "ReplicaSet"
+            - replace_pattern(attributes["observe_transform"]["facets"]["deploymentName"],
+              "^(.*)-[0-9a-f]+$$", "$$1")
+            - set(attributes["observe_transform"]["facets"]["deploymentName"], body["metadata"]["ownerReferences"][0]["name"])
+              where body["metadata"]["ownerReferences"][0]["kind"] == "Deployment"
+          - conditions:
+            - body["kind"] == "Pod"
+            context: log
+            statements:
+            - set(attributes["observe_transform"]["identifiers"]["podName"], body["metadata"]["name"])
+            - set(attributes["observe_transform"]["identifiers"]["podUid"], body["metadata"]["uid"])
+            - set(attributes["observe_transform"]["facets"]["phase"], body["status"]["phase"])
+            - set(attributes["observe_transform"]["facets"]["podIP"], body["status"]["podIP"])
+            - set(attributes["observe_transform"]["facets"]["qosClass"], body["status"]["qosClass"])
+            - set(attributes["observe_transform"]["facets"]["startTime"], body["status"]["startTime"])
+            - set(attributes["observe_transform"]["facets"]["readinessGates"], body["object"]["spec"]["readinessGates"])
+            - set(attributes["observe_transform"]["facets"]["nodeName"], body["spec"]["nodeName"])
+          - conditions:
+            - body["kind"] == "Namespace"
+            context: log
+            statements:
+            - set(attributes["observe_transform"]["facets"]["status"], body["status"]["phase"])
+            - set(attributes["observe_transform"]["identifiers"]["namespaceName"], body["metadata"]["name"])
+            - set(attributes["observe_transform"]["identifiers"]["namespaceUid"], body["metadata"]["uid"])
+          - conditions:
+            - body["kind"] == "Node"
+            context: log
+            statements:
+            - set(attributes["observe_transform"]["identifiers"]["nodeName"], body["metadata"]["name"])
+            - set(attributes["observe_transform"]["identifiers"]["nodeUid"], body["metadata"]["uid"])
+            - set(attributes["observe_transform"]["facets"]["kernelVersion"], body["status"]["nodeInfo"]["kernelVersion"])
+            - set(attributes["observe_transform"]["facets"]["kubeProxyVersion"], body["status"]["nodeInfo"]["kubeProxyVersion"])
+            - set(attributes["observe_transform"]["facets"]["kubeletVersion"], body["status"]["nodeInfo"]["kubeletVersion"])
+            - set(attributes["observe_transform"]["facets"]["osImage"], body["status"]["nodeInfo"]["osImage"])
+            - set(attributes["observe_transform"]["facets"]["taints"], body["spec"]["taints"])
+          - conditions:
+            - body["kind"] == "Deployment"
+            context: log
+            statements:
+            - set(attributes["observe_transform"]["identifiers"]["deploymentName"], body["metadata"]["name"])
+            - set(attributes["observe_transform"]["identifiers"]["deploymentUid"], body["metadata"]["uid"])
+            - set(attributes["observe_transform"]["facets"]["updatedReplicas"], body["status"]["updatedReplicas"])
+            - set(attributes["observe_transform"]["facets"]["availableReplicas"], body["status"]["availableReplicas"])
+            - set(attributes["observe_transform"]["facets"]["readyReplicas"], body["status"]["readyReplicas"])
+            - set(attributes["observe_transform"]["facets"]["readyReplicas"], 0) where attributes["observe_transform"]["facets"]["readyReplicas"]
+              == nil
+            - set(attributes["observe_transform"]["facets"]["unavailableReplicas"], body["status"]["unavailableReplicas"])
+            - set(attributes["observe_transform"]["facets"]["selector"], body["spec"]["selector"]["matchLabels"])
+            - set(attributes["observe_transform"]["facets"]["desiredReplicas"], body["spec"]["replicas"])
+            - set(attributes["observe_transform"]["facets"]["status"], "Healthy")
+            - set(attributes["observe_transform"]["facets"]["status"], "Unhealthy") where
+              attributes["observe_transform"]["facets"]["desiredReplicas"] != nil and attributes["observe_transform"]["facets"]["readyReplicas"]
+              != attributes["observe_transform"]["facets"]["desiredReplicas"]
+          - conditions:
+            - body["kind"] == "ReplicaSet"
+            context: log
+            statements:
+            - set(attributes["observe_transform"]["identifiers"]["replicaSetName"], body["metadata"]["name"])
+            - set(attributes["observe_transform"]["identifiers"]["replicaSetUid"], body["metadata"]["uid"])
+            - set(attributes["observe_transform"]["facets"]["desiredReplicas"], body["spec"]["replicas"])
+            - set(attributes["observe_transform"]["facets"]["currentReplicas"], body["status"]["replicas"])
+            - set(attributes["observe_transform"]["facets"]["availableReplicas"], body["status"]["availableReplicas"])
+            - set(attributes["observe_transform"]["facets"]["readyReplicas"], body["status"]["readyReplicas"])
+            - set(attributes["observe_transform"]["facets"]["readyReplicas"], 0) where attributes["observe_transform"]["facets"]["readyReplicas"]
+              == nil
+            - set(attributes["observe_transform"]["facets"]["status"], "Healthy")
+            - set(attributes["observe_transform"]["facets"]["status"], "Unhealthy") where
+              attributes["observe_transform"]["facets"]["desiredReplicas"] != nil and attributes["observe_transform"]["facets"]["readyReplicas"]
+              != attributes["observe_transform"]["facets"]["desiredReplicas"]
+          - conditions:
+            - body["kind"] == "Event"
+            context: log
+            statements:
+            - set(attributes["observe_transform"]["identifiers"]["involvedObjectKind"],
+              body["involvedObject"]["kind"])
+            - set(attributes["observe_transform"]["identifiers"]["involvedObjectName"],
+              body["involvedObject"]["name"])
+            - set(attributes["observe_transform"]["identifiers"]["involvedObjectUid"], body["involvedObject"]["uid"])
+            - set(attributes["observe_transform"]["facets"]["firstTimestamp"], body["firstTimestamp"])
+            - set(attributes["observe_transform"]["facets"]["lastTimestamp"], body["lastTimestamp"])
+            - set(attributes["observe_transform"]["facets"]["message"], body["message"])
+            - set(attributes["observe_transform"]["facets"]["reason"], body["reason"])
+            - set(attributes["observe_transform"]["facets"]["count"], body["count"])
+            - set(attributes["observe_transform"]["facets"]["type"], body["type"])
+            - set(attributes["observe_transform"]["facets"]["sourceComponent"], body["source"]["component"])
+          - conditions:
+            - body["kind"] == "Job"
+            context: log
+            statements:
+            - set(attributes["observe_transform"]["identifiers"]["jobName"], body["metadata"]["name"])
+            - set(attributes["observe_transform"]["identifiers"]["jobUid"], body["metadata"]["uid"])
+            - set(attributes["observe_transform"]["facets"]["cronJobName"], body["metadata"]["ownerReferences"][0]["name"])
+              where body["metadata"]["ownerReferences"][0]["kind"] == "CronJob"
+            - set(attributes["observe_transform"]["facets"]["cronJobUid"], body["metadata"]["ownerReferences"][0]["uid"])
+              where body["metadata"]["ownerReferences"][0]["kind"] == "CronJob"
+            - set(attributes["observe_transform"]["facets"]["completions"], body["spec"]["completions"])
+            - set(attributes["observe_transform"]["facets"]["parallelism"], body["spec"]["parallelism"])
+            - set(attributes["observe_transform"]["facets"]["activeDeadlineSeconds"], body["spec"]["activeDeadlineSeconds"])
+            - set(attributes["observe_transform"]["facets"]["backoffLimit"], body["spec"]["backoffLimit"])
+            - set(attributes["observe_transform"]["facets"]["startTime"], body["status"]["startTime"])
+            - set(attributes["observe_transform"]["facets"]["activePods"], body["status"]["active"])
+            - set(attributes["observe_transform"]["facets"]["failedPods"], body["status"]["falied"])
+            - set(attributes["observe_transform"]["facets"]["succeededPods"], body["status"]["succeeded"])
+            - set(attributes["observe_transform"]["facets"]["readyPods"], body["status"]["ready"])
+          - conditions:
+            - body["kind"] == "CronJob"
+            context: log
+            statements:
+            - set(attributes["observe_transform"]["identifiers"]["cronJobName"], body["metadata"]["name"])
+            - set(attributes["observe_transform"]["identifiers"]["cronJobUid"], body["metadata"]["uid"])
+            - set(attributes["observe_transform"]["facets"]["schedule"], body["spec"]["schedule"])
+            - set(attributes["observe_transform"]["facets"]["suspend"], "Active") where
+              body["spec"]["suspend"] == false
+            - set(attributes["observe_transform"]["facets"]["suspend"], "Suspend") where
+              body["spec"]["suspend"] == true
+          - conditions:
+            - body["kind"] == "DaemonSet"
+            context: log
+            statements:
+            - set(attributes["observe_transform"]["identifiers"]["daemonSetName"], body["metadata"]["name"])
+            - set(attributes["observe_transform"]["identifiers"]["daemonSetUid"], body["metadata"]["uid"])
+            - set(attributes["observe_transform"]["facets"]["updateStrategy"], body["spec"]["updateStrategy"]["type"])
+            - set(attributes["observe_transform"]["facets"]["maxUnavailable"], body["spec"]["updateStrategy"]["rollingUpdate"]["maxUnavailable"])
+            - set(attributes["observe_transform"]["facets"]["maxSurge"], body["spec"]["updateStrategy"]["rollingUpdate"]["maxSurge"])
+            - set(attributes["observe_transform"]["facets"]["numberReady"], body["status"]["numberReady"])
+            - set(attributes["observe_transform"]["facets"]["desiredNumberScheduled"], body["status"]["desiredNumberScheduled"])
+            - set(attributes["observe_transform"]["facets"]["currentNumberScheduled"], body["status"]["currentNumberScheduled"])
+            - set(attributes["observe_transform"]["facets"]["updatedNumberScheduled"], body["status"]["updatedNumberScheduled"])
+            - set(attributes["observe_transform"]["facets"]["numberAvailable"], body["status"]["numberAvailable"])
+            - set(attributes["observe_transform"]["facets"]["numberUnavailable"], body["status"]["numberUnavailable"])
+            - set(attributes["observe_transform"]["facets"]["numberMisscheduled"], body["status"]["numberMisscheduled"])
+            - set(attributes["observe_transform"]["facets"]["status"], "Healthy")
+            - set(attributes["observe_transform"]["facets"]["status"], "Unhealthy") where
+              attributes["observe_transform"]["facets"]["desiredNumberScheduled"] != nil
+              and attributes["observe_transform"]["facets"]["numberReady"] != attributes["observe_transform"]["facets"]["desiredNumberScheduled"]
+          - conditions:
+            - body["kind"] == "StatefulSet"
+            context: log
+            statements:
+            - set(attributes["observe_transform"]["identifiers"]["statefulSetName"], body["metadata"]["name"])
+            - set(attributes["observe_transform"]["identifiers"]["statefulSetUid"], body["metadata"]["uid"])
+            - set(attributes["observe_transform"]["facets"]["serviceName"], body["spec"]["serviceName"])
+            - set(attributes["observe_transform"]["facets"]["podManagementPolicy"], body["spec"]["podManagementPolicy"])
+            - set(attributes["observe_transform"]["facets"]["desiredReplicas"], body["spec"]["replicas"])
+            - set(attributes["observe_transform"]["facets"]["updateStrategy"], body["spec"]["updateStrategy"]["type"])
+            - set(attributes["observe_transform"]["facets"]["partition"], body["spec"]["updateStrategy"]["rollingUpdate"]["partition"])
+            - set(attributes["observe_transform"]["facets"]["currentReplicas"], body["status"]["currentReplicas"])
+            - set(attributes["observe_transform"]["facets"]["readyReplicas"], body["status"]["readyReplicas"])
+            - set(attributes["observe_transform"]["facets"]["status"], "Healthy")
+            - set(attributes["observe_transform"]["facets"]["status"], "Unhealthy") where
+              attributes["observe_transform"]["facets"]["desiredReplicas"] != nil and attributes["observe_transform"]["facets"]["readyReplicas"]
+              != attributes["observe_transform"]["facets"]["desiredReplicas"]
+          - conditions:
+            - body["kind"] == "ConfigMap"
+            context: log
+            statements:
+            - set(attributes["observe_transform"]["identifiers"]["configMapName"], body["metadata"]["name"])
+            - set(attributes["observe_transform"]["identifiers"]["configMapUid"], body["metadata"]["uid"])
+            - set(attributes["observe_transform"]["facets"]["immutable"], body["immutable"])
+          - conditions:
+            - body["kind"] == "Secret"
+            context: log
+            statements:
+            - set(attributes["observe_transform"]["identifiers"]["secretName"], body["metadata"]["name"])
+            - set(attributes["observe_transform"]["identifiers"]["secretUid"], body["metadata"]["uid"])
+            - set(attributes["observe_transform"]["facets"]["immutable"], body["immutable"])
+            - set(attributes["observe_transform"]["facets"]["data"], body["data"])
+            - set(attributes["observe_transform"]["facets"]["type"], body["type"])
+          - conditions:
+            - body["kind"] == "PersistentVolume"
+            context: log
+            statements:
+            - set(attributes["observe_transform"]["identifiers"]["persistentVolumeName"],
+              body["metadata"]["name"])
+            - set(attributes["observe_transform"]["identifiers"]["persistentVolumeUid"],
+              body["metadata"]["uid"])
+            - set(attributes["observe_transform"]["facets"]["capacity"], body["spec"]["capacity"]["storage"])
+            - set(attributes["observe_transform"]["facets"]["reclaimPolicy"], body["spec"]["persistentVolumeReclaimPolicy"])
+            - set(attributes["observe_transform"]["facets"]["class"], body["spec"]["storageClassName"])
+            - set(attributes["observe_transform"]["facets"]["accessModes"], body["spec"]["accessModes"])
+            - set(attributes["observe_transform"]["facets"]["volumeMode"], body["spec"]["volumeMode"])
+            - set(attributes["observe_transform"]["facets"]["phase"], body["status"]["phase"])
+          - conditions:
+            - body["kind"] == "PersistentVolumeClaim"
+            context: log
+            statements:
+            - set(attributes["observe_transform"]["identifiers"]["persistentVolumeClaimName"],
+              body["metadata"]["name"])
+            - set(attributes["observe_transform"]["identifiers"]["persistentVolumeClaimUid"],
+              body["metadata"]["uid"])
+            - set(attributes["observe_transform"]["facets"]["capacityRequests"], body["spec"]["resources"]["requests"]["storage"])
+            - set(attributes["observe_transform"]["facets"]["capacityLimits"], body["spec"]["resources"]["limits"]["storage"])
+            - set(attributes["observe_transform"]["facets"]["class"], body["spec"]["storageClassName"])
+            - set(attributes["observe_transform"]["facets"]["volumeName"], body["spec"]["volumeName"])
+            - set(attributes["observe_transform"]["facets"]["desiredAccessModes"], body["spec"]["accessModes"])
+            - set(attributes["observe_transform"]["facets"]["volumeMode"], body["spec"]["volumeMode"])
+            - set(attributes["observe_transform"]["facets"]["capacity"], body["status"]["capacity"]["storage"])
+            - set(attributes["observe_transform"]["facets"]["phase"], body["status"]["phase"])
+            - set(attributes["observe_transform"]["facets"]["currentAccessModes"], body["spec"]["accessModes"])
+          - conditions:
+            - body["kind"] == "Service"
+            context: log
+            statements:
+            - set(attributes["observe_transform"]["identifiers"]["serviceName"], body["metadata"]["name"])
+            - set(attributes["observe_transform"]["identifiers"]["serviceUid"], body["metadata"]["uid"])
+            - set(attributes["observe_transform"]["facets"]["serviceType"], body["spec"]["type"])
+            - set(attributes["observe_transform"]["facets"]["clusterIP"], body["spec"]["clusterIP"])
+            - set(attributes["observe_transform"]["facets"]["externalIPs"], body["spec"]["externalIPs"])
+            - set(attributes["observe_transform"]["facets"]["sessionAffinity"], body["spec"]["sessionAffinity"])
+            - set(attributes["observe_transform"]["facets"]["externalName"], body["spec"]["externalName"])
+            - set(attributes["observe_transform"]["facets"]["externalTrafficPolicy"], body["spec"]["externalTrafficPolicy"])
+            - set(attributes["observe_transform"]["facets"]["ipFamilies"], "IPv4,IPv6")
+              where Len(body["spec"]["ipFamilies"]) == 2
+            - set(attributes["observe_transform"]["facets"]["ipFamilies"], body["spec"]["ipFamilies"][0])
+              where Len(body["spec"]["ipFamilies"]) == 1
+          - conditions:
+            - body["kind"] == "Ingress"
+            context: log
+            statements:
+            - set(attributes["observe_transform"]["identifiers"]["ingressName"], body["metadata"]["name"])
+            - set(attributes["observe_transform"]["identifiers"]["ingressUid"], body["metadata"]["uid"])
+            - set(attributes["observe_transform"]["facets"]["class"], body["spec"]["ingressClassName"])
+            - set(attributes["observe_transform"]["facets"]["class"], body["metadata"]["annotations"]["kubernetes.io/ingress.class"])
+              where attributes["observe_transform"]["facets"]["class"] == nil
+          - conditions:
+            - body["kind"] == "RoleBinding"
+            context: log
+            statements:
+            - set(attributes["observe_transform"]["identifiers"]["roleBindingName"], body["metadata"]["name"])
+            - set(attributes["observe_transform"]["identifiers"]["roleBindingUid"], body["metadata"]["uid"])
+            - set(attributes["observe_transform"]["facets"]["subjects"], body["subjects"])
+            - set(attributes["observe_transform"]["facets"]["role"], body["roleRef"]["name"])
+          - conditions:
+            - body["kind"] == "Role"
+            context: log
+            statements:
+            - set(attributes["observe_transform"]["identifiers"]["roleName"], body["metadata"]["name"])
+            - set(attributes["observe_transform"]["identifiers"]["roleUid"], body["metadata"]["uid"])
+            - set(attributes["observe_transform"]["facets"]["rules"], body["rules"])
+            - set(attributes["observe_transform"]["facets"]["role"], body["roleRef"]["name"])
+          - conditions:
+            - body["kind"] == "ClusterRoleBinding"
+            context: log
+            statements:
+            - set(attributes["observe_transform"]["identifiers"]["clusterRoleBindingName"],
+              body["metadata"]["name"])
+            - set(attributes["observe_transform"]["identifiers"]["clusterRoleBindingUid"],
+              body["metadata"]["uid"])
+            - set(attributes["observe_transform"]["facets"]["subjects"], body["subjects"])
+            - set(attributes["observe_transform"]["facets"]["role"], body["roleRef"]["name"])
+          - conditions:
+            - body["kind"] == "ServiceAccount"
+            context: log
+            statements:
+            - set(attributes["observe_transform"]["identifiers"]["serviceAccountName"],
+              body["metadata"]["name"])
+            - set(attributes["observe_transform"]["identifiers"]["serviceAccountUid"], body["metadata"]["uid"])
+            - set(attributes["observe_transform"]["facets"]["automountToken"], body["automountServiceAccountToken"])
+        transform/unify:
+          error_mode: ignore
+          log_statements:
+          - context: log
+            statements:
+            - set(attributes["observe_transform"]["control"]["isDelete"], true) where body["object"]
+              != nil and body["type"] == "DELETED"
+            - set(attributes["observe_transform"]["control"]["debug_source"], "watch") where
+              body["object"] != nil and body["type"] != nil
+            - set(attributes["observe_transform"]["control"]["debug_source"], "pull") where
+              body["object"] == nil or body["type"] == nil
+            - set(body, body["object"]) where body["object"] != nil and body["type"] !=
+              nil
+      receivers:
+        k8sobjects/cluster:
+          auth_type: serviceAccount
+          objects:
+          - interval: 20m
+            mode: pull
+            name: namespaces
+        k8sobjects/objects:
+          auth_type: serviceAccount
+          objects:
+          - interval: 15m
+            mode: pull
+            name: events
+          - mode: watch
+            name: events
+          - interval: 15m
+            mode: pull
+            name: pods
+          - mode: watch
+            name: pods
+          - interval: 15m
+            mode: pull
+            name: namespaces
+          - mode: watch
+            name: namespaces
+          - interval: 15m
+            mode: pull
+            name: nodes
+          - mode: watch
+            name: nodes
+          - interval: 15m
+            mode: pull
+            name: deployments
+          - mode: watch
+            name: deployments
+          - interval: 15m
+            mode: pull
+            name: replicasets
+          - mode: watch
+            name: replicasets
+          - interval: 15m
+            mode: pull
+            name: configmaps
+          - mode: watch
+            name: configmaps
+          - interval: 15m
+            mode: pull
+            name: endpoints
+          - mode: watch
+            name: endpoints
+          - interval: 15m
+            mode: pull
+            name: jobs
+          - mode: watch
+            name: jobs
+          - interval: 15m
+            mode: pull
+            name: cronjobs
+          - mode: watch
+            name: cronjobs
+          - interval: 15m
+            mode: pull
+            name: daemonsets
+          - mode: watch
+            name: daemonsets
+          - interval: 15m
+            mode: pull
+            name: statefulsets
+          - mode: watch
+            name: statefulsets
+          - interval: 15m
+            mode: pull
+            name: services
+          - mode: watch
+            name: services
+          - interval: 15m
+            mode: pull
+            name: ingresses
+          - mode: watch
+            name: ingresses
+          - interval: 15m
+            mode: pull
+            name: secrets
+          - mode: watch
+            name: secrets
+          - interval: 15m
+            mode: pull
+            name: persistentvolumeclaims
+          - mode: watch
+            name: persistentvolumeclaims
+          - interval: 15m
+            mode: pull
+            name: persistentvolumes
+          - mode: watch
+            name: persistentvolumes
+          - interval: 15m
+            mode: pull
+            name: storageclasses
+          - mode: watch
+            name: storageclasses
+          - interval: 15m
+            mode: pull
+            name: roles
+          - mode: watch
+            name: roles
+          - interval: 15m
+            mode: pull
+            name: rolebindings
+          - mode: watch
+            name: rolebindings
+          - interval: 15m
+            mode: pull
+            name: clusterroles
+          - mode: watch
+            name: clusterroles
+          - interval: 15m
+            mode: pull
+            name: clusterrolebindings
+          - mode: watch
+            name: clusterrolebindings
+          - interval: 15m
+            mode: pull
+            name: serviceaccounts
+          - mode: watch
+            name: serviceaccounts
+          - interval: 15m
+            mode: pull
+            name: customresourcedefinitions
+          - mode: watch
+            name: customresourcedefinitions
+      service:
+        pipelines:
+          logs/cluster:
+            exporters:
+            - otlphttp/observe/entity
+            processors:
+            - memory_limiter
+            - batch
+            - resource/observe_common
+            - filter/cluster
+            - transform/cluster
+            receivers:
+            - k8sobjects/cluster
+          logs/objects:
+            exporters:
+            - otlphttp/observe/entity
+            processors:
+            - memory_limiter
+            - batch
+            - resource/observe_common
+            - transform/unify
+            - observek8sattributes
+            - transform/object
+            receivers:
+            - k8sobjects/objects

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/cluster-events/deployment.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/cluster-events/deployment.yaml
@@ -1,0 +1,171 @@
+---
+# Source: agent/charts/cluster-events/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-cluster-events
+  namespace: observe
+  labels:
+    helm.sh/chart: cluster-events-0.143.0
+    app.kubernetes.io/name: cluster-events
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-collector
+    app.kubernetes.io/component: standalone-collector
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: cluster-events
+      app.kubernetes.io/instance: example
+      component: standalone-collector
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+        observe_monitor_path: /metrics
+        observe_monitor_port: "8888"
+        observe_monitor_purpose: observecollection
+        observe_monitor_scrape: "true"
+        observeinc_com_scrape: "false"
+      labels:
+        app.kubernetes.io/name: cluster-events
+        app.kubernetes.io/instance: example
+        component: standalone-collector
+
+    spec:
+
+      serviceAccountName: observe-agent-service-account
+      automountServiceAccountToken: true
+      securityContext:
+        {}
+      containers:
+        - name: cluster-events
+          command:
+            - /observe-agent
+          args:
+            - --config=/conf/relay.yaml
+            - start
+            - --observe-config=/observe-agent-conf/observe-agent.yaml
+            - --config=/conf/relay.yaml
+          securityContext:
+            {}
+          image: "observeinc/observe-agent:2.15.0"
+          imagePullPolicy: IfNotPresent
+          ports:
+
+            - name: jaeger-compact
+              containerPort: 6831
+              protocol: UDP
+            - name: jaeger-grpc
+              containerPort: 14250
+              protocol: TCP
+            - name: jaeger-thrift
+              containerPort: 14268
+              protocol: TCP
+            - name: metrics
+              containerPort: 8888
+              protocol: TCP
+            - name: otlp
+              containerPort: 4317
+              protocol: TCP
+            - name: otlp-http
+              containerPort: 4318
+              protocol: TCP
+            - name: zipkin
+              containerPort: 9411
+              protocol: TCP
+          env:
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: GOMEMLIMIT
+              value: "204MiB"
+            - name: OTEL_K8S_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+            - name: OTEL_K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OBSERVE_CLUSTER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  key: name
+                  name: cluster-name
+            - name: OBSERVE_CLUSTER_UID
+              valueFrom:
+                configMapKeyRef:
+                  key: id
+                  name: cluster-info
+            - name: TOKEN
+              valueFrom:
+                secretKeyRef:
+                  key: OBSERVE_TOKEN
+                  name: agent-credentials
+                  optional: true
+          livenessProbe:
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            httpGet:
+              path: /status
+              port: 13133
+          readinessProbe:
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            httpGet:
+              path: /status
+              port: 13133
+          resources:
+            limits:
+              memory: 256Mi
+            requests:
+              cpu: 150m
+              memory: 256Mi
+          volumeMounts:
+            - mountPath: /conf
+              name: cluster-events-configmap
+            - mountPath: /observe-agent-conf
+              name: observe-agent-deployment-config
+      initContainers:
+        - env:
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          image: observeinc/kube-cluster-info:v0.11.6
+          imagePullPolicy: Always
+          name: kube-cluster-info
+      volumes:
+        - name: cluster-events-configmap
+          configMap:
+            name: cluster-events
+            items:
+              - key: relay
+                path: relay.yaml
+        - configMap:
+            defaultMode: 420
+            items:
+            - key: relay
+              path: observe-agent.yaml
+            name: observe-agent
+          name: observe-agent-deployment-config
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: observeinc.com/unschedulable
+                operator: DoesNotExist
+              - key: kubernetes.io/os
+                operator: NotIn
+                values:
+                - windows
+      hostNetwork: false

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/cluster-events/networkpolicy.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/cluster-events/networkpolicy.yaml
@@ -1,0 +1,39 @@
+---
+# Source: agent/charts/cluster-events/templates/networkpolicy.yaml
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: example-cluster-events
+  namespace: observe
+  labels:
+    helm.sh/chart: cluster-events-0.143.0
+    app.kubernetes.io/name: cluster-events
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-collector
+    app.kubernetes.io/component: standalone-collector
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: cluster-events
+      app.kubernetes.io/instance: example
+      component: standalone-collector
+  ingress:
+    - ports:
+        - port: 6831
+          protocol: UDP
+        - port: 14250
+          protocol: TCP
+        - port: 14268
+          protocol: TCP
+        - port: 8888
+          protocol: TCP
+        - port: 4317
+          protocol: TCP
+        - port: 4318
+          protocol: TCP
+        - port: 9411
+          protocol: TCP
+  egress:
+    - {}

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/cluster-events/service.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/cluster-events/service.yaml
@@ -1,0 +1,54 @@
+---
+# Source: agent/charts/cluster-events/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-cluster-events
+  namespace: observe
+  labels:
+    helm.sh/chart: cluster-events-0.143.0
+    app.kubernetes.io/name: cluster-events
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-collector
+    app.kubernetes.io/component: standalone-collector
+    component: standalone-collector
+spec:
+  type: ClusterIP
+  ports:
+
+    - name: jaeger-compact
+      port: 6831
+      targetPort: 6831
+      protocol: UDP
+    - name: jaeger-grpc
+      port: 14250
+      targetPort: 14250
+      protocol: TCP
+    - name: jaeger-thrift
+      port: 14268
+      targetPort: 14268
+      protocol: TCP
+    - name: metrics
+      port: 8888
+      targetPort: 8888
+      protocol: TCP
+    - name: otlp
+      port: 4317
+      targetPort: 4317
+      protocol: TCP
+      appProtocol: grpc
+    - name: otlp-http
+      port: 4318
+      targetPort: 4318
+      protocol: TCP
+    - name: zipkin
+      port: 9411
+      targetPort: 9411
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: cluster-events
+    app.kubernetes.io/instance: example
+    component: standalone-collector
+  internalTrafficPolicy: Cluster

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/cluster-metrics-configmap.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/cluster-metrics-configmap.yaml
@@ -1,0 +1,129 @@
+---
+# Source: agent/templates/cluster-metrics-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-metrics
+  namespace: observe
+data:
+  relay: |
+      exporters:
+        debug/override:
+          sampling_initial: 2
+          sampling_thereafter: 1
+          verbosity: basic
+        prometheusremotewrite/observe:
+          endpoint: ${env:OBSERVE_PROMETHEUS_ENDPOINT}
+          headers:
+            authorization: ${env:OBSERVE_AUTHORIZATION_HEADER}
+            x-observe-target-package: Kubernetes Explorer
+          max_batch_request_parallelism: 5
+          remote_write_queue:
+            num_consumers: 5
+          resource_to_telemetry_conversion:
+            enabled: true
+          retry_on_failure:
+            enabled: true
+            initial_interval: 1s
+            max_elapsed_time: 5m
+            max_interval: 30s
+          send_metadata: true
+          timeout: 10s
+      processors:
+        attributes/debug_source_cluster_metrics:
+          actions:
+          - action: insert
+            key: debug_source
+            value: cluster_metrics
+        batch:
+          send_batch_max_size: 4096
+          send_batch_size: 4096
+          timeout: 5s
+        k8sattributes:
+          extract:
+            labels:
+            - from: pod
+              key_regex: (app\.kubernetes\.io/.+)
+              tag_name: $1
+            metadata:
+            - k8s.namespace.name
+            - k8s.deployment.name
+            - k8s.replicaset.name
+            - k8s.statefulset.name
+            - k8s.daemonset.name
+            - k8s.cronjob.name
+            - k8s.job.name
+            - k8s.node.name
+            - k8s.node.uid
+            - k8s.pod.name
+            - k8s.pod.uid
+            - k8s.cluster.uid
+            - k8s.container.name
+            - service.namespace
+            - service.name
+            - service.version
+            - service.instance.id
+            otel_annotations: true
+          passthrough: false
+          pod_association:
+          - sources:
+            - from: resource_attribute
+              name: k8s.pod.ip
+          - sources:
+            - from: resource_attribute
+              name: k8s.pod.uid
+          - sources:
+            - from: connection
+          wait_for_metadata: false
+          wait_for_metadata_timeout: 10s
+        memory_limiter:
+          check_interval: 5s
+          limit_percentage: 80
+          spike_limit_percentage: 15
+        resource/drop_container_info:
+          attributes:
+          - action: delete
+            key: container.id
+        resource/drop_service_name:
+          attributes:
+          - action: delete
+            key: service.name
+        resource/observe_common:
+          attributes:
+          - action: upsert
+            key: k8s.cluster.name
+            value: ${env:OBSERVE_CLUSTER_NAME}
+          - action: upsert
+            key: k8s.cluster.uid
+            value: ${env:OBSERVE_CLUSTER_UID}
+      receivers:
+        k8s_cluster:
+          allocatable_types_to_report:
+          - cpu
+          - memory
+          - storage
+          - ephemeral-storage
+          auth_type: serviceAccount
+          collection_interval: 60s
+          metadata_collection_interval: 5m
+          metrics:
+            k8s.node.condition:
+              enabled: true
+          node_conditions_to_report:
+          - Ready
+          - MemoryPressure
+          - DiskPressure
+      service:
+        pipelines:
+          metrics:
+            exporters:
+            - prometheusremotewrite/observe
+            processors:
+            - memory_limiter
+            - k8sattributes
+            - batch
+            - resource/observe_common
+            - resource/drop_container_info
+            - attributes/debug_source_cluster_metrics
+            receivers:
+            - k8s_cluster

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/cluster-metrics/deployment.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/cluster-metrics/deployment.yaml
@@ -1,0 +1,172 @@
+---
+# Source: agent/charts/cluster-metrics/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-cluster-metrics
+  namespace: observe
+  labels:
+    helm.sh/chart: cluster-metrics-0.143.0
+    app.kubernetes.io/name: cluster-metrics
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-collector
+    app.kubernetes.io/component: standalone-collector
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: cluster-metrics
+      app.kubernetes.io/instance: example
+      component: standalone-collector
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+        observe_monitor_path: /metrics
+        observe_monitor_port: "8888"
+        observe_monitor_purpose: observecollection
+        observe_monitor_scrape: "true"
+        observeinc_com_scrape: "false"
+      labels:
+        app.kubernetes.io/name: cluster-metrics
+        app.kubernetes.io/instance: example
+        component: standalone-collector
+
+    spec:
+
+      serviceAccountName: observe-agent-service-account
+      automountServiceAccountToken: true
+      securityContext:
+        {}
+      containers:
+        - name: cluster-metrics
+          command:
+            - /observe-agent
+          args:
+            - --config=/conf/relay.yaml
+            - start
+            - --observe-config=/observe-agent-conf/observe-agent.yaml
+            - --config=/conf/relay.yaml
+            - --feature-gates=+exporter.prometheusremotewritexporter.EnableMultipleWorkers
+          securityContext:
+            {}
+          image: "observeinc/observe-agent:2.15.0"
+          imagePullPolicy: IfNotPresent
+          ports:
+
+            - name: jaeger-compact
+              containerPort: 6831
+              protocol: UDP
+            - name: jaeger-grpc
+              containerPort: 14250
+              protocol: TCP
+            - name: jaeger-thrift
+              containerPort: 14268
+              protocol: TCP
+            - name: metrics
+              containerPort: 8888
+              protocol: TCP
+            - name: otlp
+              containerPort: 4317
+              protocol: TCP
+            - name: otlp-http
+              containerPort: 4318
+              protocol: TCP
+            - name: zipkin
+              containerPort: 9411
+              protocol: TCP
+          env:
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: GOMEMLIMIT
+              value: "409MiB"
+            - name: OTEL_K8S_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+            - name: OTEL_K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OBSERVE_CLUSTER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  key: name
+                  name: cluster-name
+            - name: OBSERVE_CLUSTER_UID
+              valueFrom:
+                configMapKeyRef:
+                  key: id
+                  name: cluster-info
+            - name: TOKEN
+              valueFrom:
+                secretKeyRef:
+                  key: OBSERVE_TOKEN
+                  name: agent-credentials
+                  optional: true
+          livenessProbe:
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            httpGet:
+              path: /status
+              port: 13133
+          readinessProbe:
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            httpGet:
+              path: /status
+              port: 13133
+          resources:
+            limits:
+              memory: 512Mi
+            requests:
+              cpu: 250m
+              memory: 512Mi
+          volumeMounts:
+            - mountPath: /conf
+              name: cluster-metrics-configmap
+            - mountPath: /observe-agent-conf
+              name: observe-agent-deployment-config
+      initContainers:
+        - env:
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          image: observeinc/kube-cluster-info:v0.11.6
+          imagePullPolicy: Always
+          name: kube-cluster-info
+      volumes:
+        - name: cluster-metrics-configmap
+          configMap:
+            name: cluster-metrics
+            items:
+              - key: relay
+                path: relay.yaml
+        - configMap:
+            defaultMode: 420
+            items:
+            - key: relay
+              path: observe-agent.yaml
+            name: observe-agent
+          name: observe-agent-deployment-config
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: observeinc.com/unschedulable
+                operator: DoesNotExist
+              - key: kubernetes.io/os
+                operator: NotIn
+                values:
+                - windows
+      hostNetwork: false

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/cluster-metrics/networkpolicy.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/cluster-metrics/networkpolicy.yaml
@@ -1,0 +1,39 @@
+---
+# Source: agent/charts/cluster-metrics/templates/networkpolicy.yaml
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: example-cluster-metrics
+  namespace: observe
+  labels:
+    helm.sh/chart: cluster-metrics-0.143.0
+    app.kubernetes.io/name: cluster-metrics
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-collector
+    app.kubernetes.io/component: standalone-collector
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: cluster-metrics
+      app.kubernetes.io/instance: example
+      component: standalone-collector
+  ingress:
+    - ports:
+        - port: 6831
+          protocol: UDP
+        - port: 14250
+          protocol: TCP
+        - port: 14268
+          protocol: TCP
+        - port: 8888
+          protocol: TCP
+        - port: 4317
+          protocol: TCP
+        - port: 4318
+          protocol: TCP
+        - port: 9411
+          protocol: TCP
+  egress:
+    - {}

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/cluster-metrics/service.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/cluster-metrics/service.yaml
@@ -1,0 +1,54 @@
+---
+# Source: agent/charts/cluster-metrics/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-cluster-metrics
+  namespace: observe
+  labels:
+    helm.sh/chart: cluster-metrics-0.143.0
+    app.kubernetes.io/name: cluster-metrics
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-collector
+    app.kubernetes.io/component: standalone-collector
+    component: standalone-collector
+spec:
+  type: ClusterIP
+  ports:
+
+    - name: jaeger-compact
+      port: 6831
+      targetPort: 6831
+      protocol: UDP
+    - name: jaeger-grpc
+      port: 14250
+      targetPort: 14250
+      protocol: TCP
+    - name: jaeger-thrift
+      port: 14268
+      targetPort: 14268
+      protocol: TCP
+    - name: metrics
+      port: 8888
+      targetPort: 8888
+      protocol: TCP
+    - name: otlp
+      port: 4317
+      targetPort: 4317
+      protocol: TCP
+      appProtocol: grpc
+    - name: otlp-http
+      port: 4318
+      targetPort: 4318
+      protocol: TCP
+    - name: zipkin
+      port: 9411
+      targetPort: 9411
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: cluster-metrics
+    app.kubernetes.io/instance: example
+    component: standalone-collector
+  internalTrafficPolicy: Cluster

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/cluster-name-configmap.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/cluster-name-configmap.yaml
@@ -1,0 +1,9 @@
+---
+# Source: agent/templates/cluster-name-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-name
+  namespace: observe
+data:
+  name: observe-agent-monitored-cluster

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/cluster-role.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/cluster-role.yaml
@@ -1,0 +1,53 @@
+---
+# Source: agent/templates/cluster-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: observe-agent-cluster-role-observe
+  labels:
+    app.kubernetes.io/name: observe-agent-cluster-role
+    app.kubernetes.io/instance: observe-agent
+
+rules:
+  - apiGroups:
+    - ""
+    resources:
+    - configmaps
+    verbs:
+    - create
+    - get
+  - apiGroups:
+    - ""
+    - '*'
+    - apps
+    - authorization.k8s.io
+    - autoscaling
+    - batch
+    - networking.k8s.io
+    - events.k8s.io
+    - rbac.authorization.k8s.io
+    - storage.k8s.io
+    - vpcresources.k8s.aws
+    resources:
+    - '*'
+    verbs:
+    - get
+    - list
+    - watch
+---
+# Source: agent/templates/cluster-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: observe-agent-cluster-role-binding
+  labels:
+    app.kubernetes.io/name: observe-agent-cluster-role-binding-observe
+    app.kubernetes.io/instance: observe-agent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: observe-agent-cluster-role-observe
+subjects:
+- kind: ServiceAccount
+  name: observe-agent-service-account
+  namespace: observe

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/forwarder-configmap.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/forwarder-configmap.yaml
@@ -1,0 +1,237 @@
+---
+# Source: agent/templates/forwarder-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: forwarder
+  namespace: observe
+data:
+  relay: |
+      exporters:
+        debug/override:
+          sampling_initial: 2
+          sampling_thereafter: 1
+          verbosity: basic
+        otlphttp/observe/base:
+          compression: zstd
+          endpoint: ${env:OBSERVE_OTEL_ENDPOINT}
+          headers:
+            authorization: ${env:OBSERVE_AUTHORIZATION_HEADER}
+            x-observe-target-package: Kubernetes Explorer
+          retry_on_failure:
+            enabled: true
+            initial_interval: 1s
+            max_elapsed_time: 5m
+            max_interval: 30s
+          sending_queue:
+            enabled: true
+          timeout: 10s
+        otlphttp/observe/forward/trace:
+          compression: zstd
+          endpoint: ${env:OBSERVE_OTEL_ENDPOINT}
+          headers:
+            authorization: Bearer ${env:TRACE_TOKEN}
+            x-observe-target-package: Tracing
+          retry_on_failure:
+            enabled: true
+            initial_interval: 1s
+            max_elapsed_time: 5m
+            max_interval: 30s
+          sending_queue:
+            enabled: true
+          timeout: 10s
+        otlphttp/observe/otel_metrics:
+          compression: zstd
+          endpoint: ${env:OBSERVE_OTEL_ENDPOINT}
+          headers:
+            authorization: ${env:OBSERVE_AUTHORIZATION_HEADER}
+            x-observe-target-package: Metrics
+          retry_on_failure:
+            enabled: true
+            initial_interval: 1s
+            max_elapsed_time: 5m
+            max_interval: 30s
+          sending_queue:
+            enabled: true
+          timeout: 10s
+        prometheusremotewrite/observe:
+          endpoint: ${env:OBSERVE_PROMETHEUS_ENDPOINT}
+          headers:
+            authorization: ${env:OBSERVE_AUTHORIZATION_HEADER}
+            x-observe-target-package: Kubernetes Explorer
+          max_batch_request_parallelism: 5
+          remote_write_queue:
+            num_consumers: 5
+          resource_to_telemetry_conversion:
+            enabled: true
+          retry_on_failure:
+            enabled: true
+            initial_interval: 1s
+            max_elapsed_time: 5m
+            max_interval: 30s
+          send_metadata: true
+          timeout: 10s
+      processors:
+        attributes/debug_source_app_logs:
+          actions:
+          - action: insert
+            key: debug_source
+            value: app_logs
+        attributes/debug_source_app_metrics:
+          actions:
+          - action: insert
+            key: debug_source
+            value: app_metrics
+        attributes/debug_source_app_traces:
+          actions:
+          - action: insert
+            key: debug_source
+            value: app_traces
+        batch:
+          send_batch_max_size: 4096
+          send_batch_size: 4096
+          timeout: 5s
+        deltatocumulative/observe:
+          max_stale: 5m
+        filter/drop_long_spans:
+          error_mode: ignore
+          traces:
+            span:
+            - (span.end_time - span.start_time) > Duration("1h")
+        k8sattributes:
+          extract:
+            labels:
+            - from: pod
+              key_regex: (app\.kubernetes\.io/.+)
+              tag_name: $1
+            metadata:
+            - k8s.namespace.name
+            - k8s.deployment.name
+            - k8s.replicaset.name
+            - k8s.statefulset.name
+            - k8s.daemonset.name
+            - k8s.cronjob.name
+            - k8s.job.name
+            - k8s.node.name
+            - k8s.node.uid
+            - k8s.pod.name
+            - k8s.pod.uid
+            - k8s.cluster.uid
+            - k8s.container.name
+            - container.id
+            - service.namespace
+            - service.name
+            - service.version
+            - service.instance.id
+            otel_annotations: true
+          passthrough: false
+          pod_association:
+          - sources:
+            - from: resource_attribute
+              name: k8s.pod.ip
+          - sources:
+            - from: resource_attribute
+              name: k8s.pod.uid
+          - sources:
+            - from: connection
+          wait_for_metadata: false
+          wait_for_metadata_timeout: 10s
+        memory_limiter:
+          check_interval: 5s
+          limit_percentage: 80
+          spike_limit_percentage: 15
+        resource/add_empty_service_attributes:
+          attributes:
+          - action: insert
+            key: service.name
+            value: ""
+          - action: insert
+            key: service.namespace
+            value: ""
+          - action: insert
+            key: deployment.environment
+            value: ""
+        resource/observe_common:
+          attributes:
+          - action: upsert
+            key: k8s.cluster.name
+            value: ${env:OBSERVE_CLUSTER_NAME}
+          - action: upsert
+            key: k8s.cluster.uid
+            value: ${env:OBSERVE_CLUSTER_UID}
+        resourcedetection/cloud:
+          detectors:
+          - eks
+          - gcp
+          - ecs
+          - ec2
+          - azure
+          override: false
+          timeout: 2s
+        transform/add_span_status_code:
+          error_mode: ignore
+          trace_statements:
+          - set(span.attributes["observe.status_code"], Int(span.attributes["rpc.grpc.status_code"]))
+            where span.attributes["observe.status_code"] == nil and span.attributes["rpc.grpc.status_code"]
+            != nil
+          - set(span.attributes["observe.status_code"], Int(span.attributes["grpc.status_code"]))
+            where span.attributes["observe.status_code"] == nil and span.attributes["grpc.status_code"]
+            != nil
+          - set(span.attributes["observe.status_code"], Int(span.attributes["rpc.status_code"]))
+            where span.attributes["observe.status_code"] == nil and span.attributes["rpc.status_code"]
+            != nil
+          - set(span.attributes["observe.status_code"], Int(span.attributes["http.status_code"]))
+            where span.attributes["observe.status_code"] == nil and span.attributes["http.status_code"]
+            != nil
+          - set(span.attributes["observe.status_code"], Int(span.attributes["http.response.status_code"]))
+            where span.attributes["observe.status_code"] == nil and span.attributes["http.response.status_code"]
+            != nil
+      receivers:
+        otlp/app-telemetry:
+          protocols:
+            grpc:
+              endpoint: ${env:MY_POD_IP}:4317
+            http:
+              endpoint: ${env:MY_POD_IP}:4318
+      service:
+        pipelines:
+          logs/observe-forward:
+            exporters:
+            - otlphttp/observe/base
+            processors:
+            - memory_limiter
+            - k8sattributes
+            - batch
+            - resourcedetection/cloud
+            - resource/observe_common
+            - attributes/debug_source_app_logs
+            receivers:
+            - otlp/app-telemetry
+          metrics/observe-forward:
+            exporters:
+            - prometheusremotewrite/observe
+            processors:
+            - memory_limiter
+            - k8sattributes
+            - deltatocumulative/observe
+            - batch
+            - resourcedetection/cloud
+            - resource/observe_common
+            - attributes/debug_source_app_metrics
+            receivers:
+            - otlp/app-telemetry
+          traces/observe-forward:
+            exporters:
+            - otlphttp/observe/forward/trace
+            processors:
+            - filter/drop_long_spans
+            - memory_limiter
+            - transform/add_span_status_code
+            - resource/add_empty_service_attributes
+            - k8sattributes
+            - batch
+            - resourcedetection/cloud
+            - resource/observe_common
+            - attributes/debug_source_app_traces
+            receivers:
+            - otlp/app-telemetry

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/forwarder/daemonset.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/forwarder/daemonset.yaml
@@ -1,0 +1,186 @@
+---
+# Source: agent/charts/forwarder/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: example-forwarder-agent
+  namespace: observe
+  labels:
+    helm.sh/chart: forwarder-0.143.0
+    app.kubernetes.io/name: forwarder
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-collector
+    app.kubernetes.io/component: agent-collector
+spec:
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: forwarder
+      app.kubernetes.io/instance: example
+      component: agent-collector
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+        observe_monitor_path: /metrics
+        observe_monitor_port: "8888"
+        observe_monitor_purpose: observecollection
+        observe_monitor_scrape: "true"
+        observeinc_com_scrape: "false"
+      labels:
+        app.kubernetes.io/name: forwarder
+        app.kubernetes.io/instance: example
+        component: agent-collector
+
+    spec:
+
+      serviceAccountName: observe-agent-service-account
+      automountServiceAccountToken: true
+      securityContext:
+        {}
+      containers:
+        - name: forwarder
+          command:
+            - /observe-agent
+          args:
+            - --config=/conf/relay.yaml
+            - start
+            - --observe-config=/observe-agent-conf/observe-agent.yaml
+            - --config=/conf/relay.yaml
+          securityContext:
+            {}
+          image: "observeinc/observe-agent:2.15.0"
+          imagePullPolicy: IfNotPresent
+          ports:
+
+            - name: jaeger-compact
+              containerPort: 6831
+              protocol: UDP
+              hostPort: 6831
+            - name: jaeger-grpc
+              containerPort: 14250
+              protocol: TCP
+              hostPort: 14250
+            - name: jaeger-thrift
+              containerPort: 14268
+              protocol: TCP
+              hostPort: 14268
+            - name: metrics
+              containerPort: 8888
+              protocol: TCP
+            - name: otlp
+              containerPort: 4317
+              protocol: TCP
+              hostPort: 4317
+            - name: otlp-http
+              containerPort: 4318
+              protocol: TCP
+              hostPort: 4318
+            - name: zipkin
+              containerPort: 9411
+              protocol: TCP
+              hostPort: 9411
+          env:
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: GOMEMLIMIT
+              value: "409MiB"
+            - name: OTEL_K8S_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+            - name: OTEL_K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OBSERVE_CLUSTER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  key: name
+                  name: cluster-name
+            - name: OBSERVE_CLUSTER_UID
+              valueFrom:
+                configMapKeyRef:
+                  key: id
+                  name: cluster-info
+            - name: K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: TOKEN
+              valueFrom:
+                secretKeyRef:
+                  key: OBSERVE_TOKEN
+                  name: agent-credentials
+                  optional: true
+            - name: TRACE_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  key: TRACE_TOKEN
+                  name: agent-credentials
+                  optional: true
+          livenessProbe:
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            httpGet:
+              path: /status
+              port: 13133
+          readinessProbe:
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            httpGet:
+              path: /status
+              port: 13133
+          resources:
+            limits:
+              memory: 512Mi
+            requests:
+              cpu: 300m
+              memory: 512Mi
+          volumeMounts:
+            - mountPath: /conf
+              name: forwarder-configmap
+            - mountPath: /observe-agent-conf
+              name: observe-agent-deployment-config
+      initContainers:
+        - env:
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          image: observeinc/kube-cluster-info:v0.11.6
+          imagePullPolicy: Always
+          name: kube-cluster-info
+      volumes:
+        - name: forwarder-configmap
+          configMap:
+            name: forwarder
+            items:
+              - key: relay
+                path: relay.yaml
+        - configMap:
+            defaultMode: 420
+            items:
+            - key: relay
+              path: observe-agent.yaml
+            name: observe-agent
+          name: observe-agent-deployment-config
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: observeinc.com/unschedulable
+                operator: DoesNotExist
+              - key: kubernetes.io/os
+                operator: NotIn
+                values:
+                - windows
+      hostNetwork: false

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/forwarder/networkpolicy.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/forwarder/networkpolicy.yaml
@@ -1,0 +1,39 @@
+---
+# Source: agent/charts/forwarder/templates/networkpolicy.yaml
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: example-forwarder
+  namespace: observe
+  labels:
+    helm.sh/chart: forwarder-0.143.0
+    app.kubernetes.io/name: forwarder
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-collector
+    app.kubernetes.io/component: agent-collector
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: forwarder
+      app.kubernetes.io/instance: example
+      component: agent-collector
+  ingress:
+    - ports:
+        - port: 6831
+          protocol: UDP
+        - port: 14250
+          protocol: TCP
+        - port: 14268
+          protocol: TCP
+        - port: 8888
+          protocol: TCP
+        - port: 4317
+          protocol: TCP
+        - port: 4318
+          protocol: TCP
+        - port: 9411
+          protocol: TCP
+  egress:
+    - {}

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/forwarder/service.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/forwarder/service.yaml
@@ -1,0 +1,54 @@
+---
+# Source: agent/charts/forwarder/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-forwarder
+  namespace: observe
+  labels:
+    helm.sh/chart: forwarder-0.143.0
+    app.kubernetes.io/name: forwarder
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-collector
+    app.kubernetes.io/component: agent-collector
+    component: agent-collector
+spec:
+  type: ClusterIP
+  ports:
+
+    - name: jaeger-compact
+      port: 6831
+      targetPort: 6831
+      protocol: UDP
+    - name: jaeger-grpc
+      port: 14250
+      targetPort: 14250
+      protocol: TCP
+    - name: jaeger-thrift
+      port: 14268
+      targetPort: 14268
+      protocol: TCP
+    - name: metrics
+      port: 8888
+      targetPort: 8888
+      protocol: TCP
+    - name: otlp
+      port: 4317
+      targetPort: 4317
+      protocol: TCP
+      appProtocol: grpc
+    - name: otlp-http
+      port: 4318
+      targetPort: 4318
+      protocol: TCP
+    - name: zipkin
+      port: 9411
+      targetPort: 9411
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: forwarder
+    app.kubernetes.io/instance: example
+    component: agent-collector
+  internalTrafficPolicy: Local

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/monitor/deployment.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/monitor/deployment.yaml
@@ -1,0 +1,172 @@
+---
+# Source: agent/charts/monitor/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-monitor
+  namespace: observe
+  labels:
+    helm.sh/chart: monitor-0.143.0
+    app.kubernetes.io/name: monitor
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-collector
+    app.kubernetes.io/component: standalone-collector
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: monitor
+      app.kubernetes.io/instance: example
+      component: standalone-collector
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+        observe_monitor_path: /metrics
+        observe_monitor_port: "8888"
+        observe_monitor_purpose: observecollection
+        observe_monitor_scrape: "false"
+        observeinc_com_scrape: "false"
+      labels:
+        app.kubernetes.io/name: monitor
+        app.kubernetes.io/instance: example
+        component: standalone-collector
+
+    spec:
+
+      serviceAccountName: observe-agent-service-account
+      automountServiceAccountToken: true
+      securityContext:
+        {}
+      containers:
+        - name: monitor
+          command:
+            - /observe-agent
+          args:
+            - --config=/conf/relay.yaml
+            - start
+            - --observe-config=/observe-agent-conf/observe-agent.yaml
+            - --config=/conf/relay.yaml
+            - --feature-gates=+exporter.prometheusremotewritexporter.EnableMultipleWorkers
+          securityContext:
+            {}
+          image: "observeinc/observe-agent:2.15.0"
+          imagePullPolicy: IfNotPresent
+          ports:
+
+            - name: jaeger-compact
+              containerPort: 6831
+              protocol: UDP
+            - name: jaeger-grpc
+              containerPort: 14250
+              protocol: TCP
+            - name: jaeger-thrift
+              containerPort: 14268
+              protocol: TCP
+            - name: metrics
+              containerPort: 8888
+              protocol: TCP
+            - name: otlp
+              containerPort: 4317
+              protocol: TCP
+            - name: otlp-http
+              containerPort: 4318
+              protocol: TCP
+            - name: zipkin
+              containerPort: 9411
+              protocol: TCP
+          env:
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: GOMEMLIMIT
+              value: "204MiB"
+            - name: OTEL_K8S_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+            - name: OTEL_K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OBSERVE_CLUSTER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  key: name
+                  name: cluster-name
+            - name: OBSERVE_CLUSTER_UID
+              valueFrom:
+                configMapKeyRef:
+                  key: id
+                  name: cluster-info
+            - name: TOKEN
+              valueFrom:
+                secretKeyRef:
+                  key: OBSERVE_TOKEN
+                  name: agent-credentials
+                  optional: true
+          livenessProbe:
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            httpGet:
+              path: /status
+              port: 13133
+          readinessProbe:
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            httpGet:
+              path: /status
+              port: 13133
+          resources:
+            limits:
+              memory: 256Mi
+            requests:
+              cpu: 150m
+              memory: 256Mi
+          volumeMounts:
+            - mountPath: /conf
+              name: monitor-configmap
+            - mountPath: /observe-agent-conf
+              name: observe-agent-deployment-config
+      initContainers:
+        - env:
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          image: observeinc/kube-cluster-info:v0.11.6
+          imagePullPolicy: Always
+          name: kube-cluster-info
+      volumes:
+        - name: monitor-configmap
+          configMap:
+            name: monitor
+            items:
+              - key: relay
+                path: relay.yaml
+        - configMap:
+            defaultMode: 420
+            items:
+            - key: relay
+              path: observe-agent.yaml
+            name: observe-agent
+          name: observe-agent-deployment-config
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: observeinc.com/unschedulable
+                operator: DoesNotExist
+              - key: kubernetes.io/os
+                operator: NotIn
+                values:
+                - windows
+      hostNetwork: false

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/monitor/networkpolicy.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/monitor/networkpolicy.yaml
@@ -1,0 +1,39 @@
+---
+# Source: agent/charts/monitor/templates/networkpolicy.yaml
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: example-monitor
+  namespace: observe
+  labels:
+    helm.sh/chart: monitor-0.143.0
+    app.kubernetes.io/name: monitor
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-collector
+    app.kubernetes.io/component: standalone-collector
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: monitor
+      app.kubernetes.io/instance: example
+      component: standalone-collector
+  ingress:
+    - ports:
+        - port: 6831
+          protocol: UDP
+        - port: 14250
+          protocol: TCP
+        - port: 14268
+          protocol: TCP
+        - port: 8888
+          protocol: TCP
+        - port: 4317
+          protocol: TCP
+        - port: 4318
+          protocol: TCP
+        - port: 9411
+          protocol: TCP
+  egress:
+    - {}

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/monitor/service.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/monitor/service.yaml
@@ -1,0 +1,54 @@
+---
+# Source: agent/charts/monitor/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-monitor
+  namespace: observe
+  labels:
+    helm.sh/chart: monitor-0.143.0
+    app.kubernetes.io/name: monitor
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-collector
+    app.kubernetes.io/component: standalone-collector
+    component: standalone-collector
+spec:
+  type: ClusterIP
+  ports:
+
+    - name: jaeger-compact
+      port: 6831
+      targetPort: 6831
+      protocol: UDP
+    - name: jaeger-grpc
+      port: 14250
+      targetPort: 14250
+      protocol: TCP
+    - name: jaeger-thrift
+      port: 14268
+      targetPort: 14268
+      protocol: TCP
+    - name: metrics
+      port: 8888
+      targetPort: 8888
+      protocol: TCP
+    - name: otlp
+      port: 4317
+      targetPort: 4317
+      protocol: TCP
+      appProtocol: grpc
+    - name: otlp-http
+      port: 4318
+      targetPort: 4318
+      protocol: TCP
+    - name: zipkin
+      port: 9411
+      targetPort: 9411
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: monitor
+    app.kubernetes.io/instance: example
+    component: standalone-collector
+  internalTrafficPolicy: Cluster

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/node-logs-metrics-configmap.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/node-logs-metrics-configmap.yaml
@@ -1,0 +1,298 @@
+---
+# Source: agent/templates/node-logs-metrics-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: node-logs-metrics
+  namespace: observe
+data:
+  relay: |
+      exporters:
+        debug/override:
+          sampling_initial: 2
+          sampling_thereafter: 1
+          verbosity: basic
+        otlphttp/observe/base:
+          compression: zstd
+          endpoint: ${env:OBSERVE_OTEL_ENDPOINT}
+          headers:
+            authorization: ${env:OBSERVE_AUTHORIZATION_HEADER}
+            x-observe-target-package: Kubernetes Explorer
+          retry_on_failure:
+            enabled: true
+            initial_interval: 1s
+            max_elapsed_time: 5m
+            max_interval: 30s
+          sending_queue:
+            enabled: true
+          timeout: 10s
+        prometheusremotewrite/observe:
+          endpoint: ${env:OBSERVE_PROMETHEUS_ENDPOINT}
+          headers:
+            authorization: ${env:OBSERVE_AUTHORIZATION_HEADER}
+            x-observe-target-package: Kubernetes Explorer
+          max_batch_request_parallelism: 5
+          remote_write_queue:
+            num_consumers: 5
+          resource_to_telemetry_conversion:
+            enabled: true
+          retry_on_failure:
+            enabled: true
+            initial_interval: 1s
+            max_elapsed_time: 5m
+            max_interval: 30s
+          send_metadata: true
+          timeout: 10s
+      extensions:
+        file_storage:
+          create_directory: true
+      processors:
+        attributes/debug_source_hostmetrics:
+          actions:
+          - action: insert
+            key: debug_source
+            value: hostmetrics
+        attributes/debug_source_kubeletstats_metrics:
+          actions:
+          - action: insert
+            key: debug_source
+            value: kubeletstats_metrics
+        attributes/debug_source_pod_logs:
+          actions:
+          - action: insert
+            key: debug_source
+            value: pod_logs
+        batch:
+          send_batch_max_size: 4096
+          send_batch_size: 4096
+          timeout: 5s
+        k8sattributes:
+          extract:
+            labels:
+            - from: pod
+              key_regex: (app\.kubernetes\.io/.+)
+              tag_name: $1
+            metadata:
+            - k8s.namespace.name
+            - k8s.deployment.name
+            - k8s.replicaset.name
+            - k8s.statefulset.name
+            - k8s.daemonset.name
+            - k8s.cronjob.name
+            - k8s.job.name
+            - k8s.node.name
+            - k8s.node.uid
+            - k8s.pod.name
+            - k8s.pod.uid
+            - k8s.cluster.uid
+            - k8s.container.name
+            - container.id
+            - service.namespace
+            - service.name
+            - service.version
+            - service.instance.id
+            otel_annotations: true
+          passthrough: false
+          pod_association:
+          - sources:
+            - from: resource_attribute
+              name: k8s.pod.ip
+          - sources:
+            - from: resource_attribute
+              name: k8s.pod.uid
+          - sources:
+            - from: connection
+          wait_for_metadata: false
+          wait_for_metadata_timeout: 10s
+        memory_limiter:
+          check_interval: 5s
+          limit_percentage: 80
+          spike_limit_percentage: 15
+        metricstransform/duplicate_k8s_cpu_metrics:
+          transforms:
+          - action: insert
+            include: container.cpu.usage
+            new_name: container.cpu.utilization
+          - action: insert
+            include: k8s.pod.cpu.usage
+            new_name: k8s.pod.cpu.utilization
+          - action: insert
+            include: k8s.node.cpu.usage
+            new_name: k8s.node.cpu.utilization
+        resource/observe_common:
+          attributes:
+          - action: upsert
+            key: k8s.cluster.name
+            value: ${env:OBSERVE_CLUSTER_NAME}
+          - action: upsert
+            key: k8s.cluster.uid
+            value: ${env:OBSERVE_CLUSTER_UID}
+        resourcedetection/cloud:
+          detectors:
+          - eks
+          - gcp
+          - ecs
+          - ec2
+          - azure
+          override: false
+          timeout: 2s
+      receivers:
+        filelog:
+          exclude:
+          - '**/*.gz'
+          - '**/*.tmp'
+          exclude_older_than: 24h
+          include:
+          - /var/log/pods/*/*/*.log
+          - /var/log/pods/*/*/*.log.*
+          include_file_name: false
+          include_file_path: true
+          max_log_size: 1024kb
+          operators:
+          - id: container-parser
+            max_log_size: 102400
+            type: container
+          poll_interval: 20ms
+          retry_on_failure:
+            enabled: true
+            initial_interval: 1s
+            max_elapsed_time: 5m
+            max_interval: 30s
+          start_at: end
+          storage: file_storage
+        hostmetrics:
+          collection_interval: 60s
+          root_path: /hostfs
+          scrapers:
+            cpu: null
+            disk: null
+            filesystem:
+              exclude_fs_types:
+                fs_types:
+                - autofs
+                - binfmt_misc
+                - bpf
+                - cgroup2
+                - configfs
+                - debugfs
+                - devpts
+                - devtmpfs
+                - fusectl
+                - hugetlbfs
+                - iso9660
+                - mqueue
+                - nsfs
+                - overlay
+                - proc
+                - procfs
+                - pstore
+                - rpc_pipefs
+                - securityfs
+                - selinuxfs
+                - squashfs
+                - sysfs
+                - tracefs
+                match_type: strict
+              exclude_mount_points:
+                match_type: regexp
+                mount_points:
+                - /dev/*
+                - /proc/*
+                - /sys/*
+                - /run/k3s/containerd/*
+                - /var/lib/docker/*
+                - /var/lib/kubelet/*
+                - /snap/*
+            load: null
+            memory: null
+            network: null
+        kubeletstats:
+          auth_type: serviceAccount
+          collection_interval: 60s
+          endpoint: ${env:K8S_NODE_NAME}:10250
+          extra_metadata_labels:
+          - container.id
+          insecure_skip_verify: true
+          k8s_api_config:
+            auth_type: serviceAccount
+          metric_groups:
+          - node
+          - pod
+          - container
+          metrics:
+            container.cpu.usage:
+              enabled: true
+            container.uptime:
+              enabled: true
+            k8s.container.cpu.node.utilization:
+              enabled: true
+            k8s.container.cpu_limit_utilization:
+              enabled: true
+            k8s.container.cpu_request_utilization:
+              enabled: true
+            k8s.container.memory.node.utilization:
+              enabled: true
+            k8s.container.memory_limit_utilization:
+              enabled: true
+            k8s.container.memory_request_utilization:
+              enabled: true
+            k8s.node.cpu.usage:
+              enabled: true
+            k8s.node.uptime:
+              enabled: true
+            k8s.pod.cpu.node.utilization:
+              enabled: true
+            k8s.pod.cpu.usage:
+              enabled: true
+            k8s.pod.cpu_limit_utilization:
+              enabled: true
+            k8s.pod.cpu_request_utilization:
+              enabled: true
+            k8s.pod.memory.node.utilization:
+              enabled: true
+            k8s.pod.memory_limit_utilization:
+              enabled: true
+            k8s.pod.memory_request_utilization:
+              enabled: true
+            k8s.pod.uptime:
+              enabled: true
+          node: ${env:K8S_NODE_NAME}
+      service:
+        pipelines:
+          logs:
+            exporters:
+            - otlphttp/observe/base
+            processors:
+            - memory_limiter
+            - k8sattributes
+            - batch
+            - resourcedetection/cloud
+            - resource/observe_common
+            - attributes/debug_source_pod_logs
+            receivers:
+            - filelog
+          metrics/hostmetrics:
+            exporters:
+            - prometheusremotewrite/observe
+            processors:
+            - memory_limiter
+            - k8sattributes
+            - batch
+            - resourcedetection/cloud
+            - resource/observe_common
+            - attributes/debug_source_hostmetrics
+            receivers:
+            - hostmetrics
+          metrics/kubeletstats:
+            exporters:
+            - prometheusremotewrite/observe
+            processors:
+            - memory_limiter
+            - metricstransform/duplicate_k8s_cpu_metrics
+            - k8sattributes
+            - batch
+            - resourcedetection/cloud
+            - resource/observe_common
+            - attributes/debug_source_kubeletstats_metrics
+            receivers:
+            - kubeletstats

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/node-logs-metrics/daemonset.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/node-logs-metrics/daemonset.yaml
@@ -1,0 +1,193 @@
+---
+# Source: agent/charts/node-logs-metrics/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: example-node-logs-metrics-agent
+  namespace: observe
+  labels:
+    helm.sh/chart: node-logs-metrics-0.143.0
+    app.kubernetes.io/name: node-logs-metrics
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-collector
+    app.kubernetes.io/component: agent-collector
+spec:
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: node-logs-metrics
+      app.kubernetes.io/instance: example
+      component: agent-collector
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+        observe_monitor_path: /metrics
+        observe_monitor_port: "8888"
+        observe_monitor_purpose: observecollection
+        observe_monitor_scrape: "true"
+        observeinc_com_scrape: "false"
+      labels:
+        app.kubernetes.io/name: node-logs-metrics
+        app.kubernetes.io/instance: example
+        component: agent-collector
+
+    spec:
+
+      serviceAccountName: observe-agent-service-account
+      automountServiceAccountToken: true
+      securityContext:
+        {}
+      containers:
+        - name: node-logs-metrics
+          command:
+            - /observe-agent
+          args:
+            - --config=/conf/relay.yaml
+            - start
+            - --observe-config=/observe-agent-conf/observe-agent.yaml
+            - --config=/conf/relay.yaml
+            - --feature-gates=+exporter.prometheusremotewritexporter.EnableMultipleWorkers
+          securityContext:
+            runAsGroup: 0
+            runAsUser: 0
+          image: "observeinc/observe-agent:2.15.0"
+          imagePullPolicy: IfNotPresent
+          ports:
+
+            - name: metrics
+              containerPort: 8888
+              protocol: TCP
+          env:
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: GOMEMLIMIT
+              value: "409MiB"
+            - name: OTEL_K8S_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+            - name: OTEL_K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OBSERVE_CLUSTER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  key: name
+                  name: cluster-name
+            - name: OBSERVE_CLUSTER_UID
+              valueFrom:
+                configMapKeyRef:
+                  key: id
+                  name: cluster-info
+            - name: K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: K8S_NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: TOKEN
+              valueFrom:
+                secretKeyRef:
+                  key: OBSERVE_TOKEN
+                  name: agent-credentials
+                  optional: true
+            - name: TRACES_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  key: TRACES_TOKEN
+                  name: agent-credentials
+                  optional: true
+          livenessProbe:
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            httpGet:
+              path: /status
+              port: 13133
+          readinessProbe:
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            httpGet:
+              path: /status
+              port: 13133
+          resources:
+            limits:
+              memory: 512Mi
+            requests:
+              cpu: 250m
+              memory: 512Mi
+          volumeMounts:
+            - mountPath: /conf
+              name: node-logs-metrics-configmap
+            - mountPath: /observe-agent-conf
+              name: observe-agent-deployment-config
+            - mountPath: /var/log/pods
+              name: varlogpods
+              readOnly: true
+            - mountPath: /var/lib/docker/containers
+              name: varlibdockercontainers
+              readOnly: true
+            - mountPath: /var/lib/otelcol
+              name: varlibotelcol
+            - mountPath: /hostfs
+              mountPropagation: HostToContainer
+              name: hostfs
+              readOnly: true
+      initContainers:
+        - env:
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          image: observeinc/kube-cluster-info:v0.11.6
+          imagePullPolicy: Always
+          name: kube-cluster-info
+      volumes:
+        - name: node-logs-metrics-configmap
+          configMap:
+            name: node-logs-metrics
+            items:
+              - key: relay
+                path: relay.yaml
+        - configMap:
+            defaultMode: 420
+            items:
+            - key: relay
+              path: observe-agent.yaml
+            name: observe-agent
+          name: observe-agent-deployment-config
+        - hostPath:
+            path: /var/log/pods
+          name: varlogpods
+        - hostPath:
+            path: /var/lib/docker/containers
+          name: varlibdockercontainers
+        - hostPath:
+            path: /var/lib/otelcol
+            type: DirectoryOrCreate
+          name: varlibotelcol
+        - hostPath:
+            path: /
+          name: hostfs
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: observeinc.com/unschedulable
+                operator: DoesNotExist
+              - key: kubernetes.io/os
+                operator: NotIn
+                values:
+                - windows
+      hostNetwork: false

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/observe-agent-configmap.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/observe-agent-configmap.yaml
@@ -1,0 +1,42 @@
+---
+# Source: agent/templates/observe-agent-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: observe-agent
+  namespace: observe
+data:
+  relay: |
+    observe_url:
+    token:
+
+    debug: false
+
+    health_check:
+      enabled: true
+      endpoint: "${env:MY_POD_IP}:13133"
+      path: "/status"
+
+    internal_telemetry:
+      enabled: true
+      metrics:
+        enabled: true
+        host: "${env:MY_POD_IP}"
+        port: 8888
+        level: normal
+      logs:
+        enabled: true
+        level: WARN
+        encoding: console
+
+
+    forwarding:
+      enabled: false
+
+    self_monitoring:
+      enabled: false
+      fleet:
+        enabled: false
+
+    host_monitoring:
+      enabled: false

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/prometheus-scraper-configmap.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/prometheus-scraper-configmap.yaml
@@ -1,0 +1,239 @@
+---
+# Source: agent/templates/prometheus-scraper-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-scraper
+  namespace: observe
+data:
+  relay: |
+      exporters:
+        debug/override:
+          sampling_initial: 2
+          sampling_thereafter: 1
+          verbosity: basic
+        prometheusremotewrite/observe:
+          endpoint: ${env:OBSERVE_PROMETHEUS_ENDPOINT}
+          headers:
+            authorization: ${env:OBSERVE_AUTHORIZATION_HEADER}
+            x-observe-target-package: Kubernetes Explorer
+          max_batch_request_parallelism: 5
+          remote_write_queue:
+            num_consumers: 5
+          resource_to_telemetry_conversion:
+            enabled: true
+          retry_on_failure:
+            enabled: true
+            initial_interval: 1s
+            max_elapsed_time: 5m
+            max_interval: 30s
+          send_metadata: true
+          timeout: 10s
+      processors:
+        attributes/debug_source_cadvisor_metrics:
+          actions:
+          - action: insert
+            key: debug_source
+            value: cadvisor_metrics
+        attributes/debug_source_pod_metrics:
+          actions:
+          - action: insert
+            key: debug_source
+            value: pod_metrics
+        batch:
+          send_batch_max_size: 4096
+          send_batch_size: 4096
+          timeout: 5s
+        filter/cadvisor:
+          error_mode: ignore
+          metrics:
+            metric:
+            - resource.attributes["service.name"] != "kubernetes-nodes-cadvisor"
+        filter/pod_metrics:
+          error_mode: ignore
+          metrics:
+            metric:
+            - resource.attributes["service.name"] != "pod-metrics"
+        k8sattributes:
+          extract:
+            labels:
+            - from: pod
+              key_regex: (app\.kubernetes\.io/.+)
+              tag_name: $1
+            metadata:
+            - k8s.namespace.name
+            - k8s.deployment.name
+            - k8s.replicaset.name
+            - k8s.statefulset.name
+            - k8s.daemonset.name
+            - k8s.cronjob.name
+            - k8s.job.name
+            - k8s.node.name
+            - k8s.node.uid
+            - k8s.pod.name
+            - k8s.pod.uid
+            - k8s.cluster.uid
+            - k8s.container.name
+            - container.id
+            - service.namespace
+            - service.name
+            - service.version
+            - service.instance.id
+            otel_annotations: true
+          passthrough: false
+          pod_association:
+          - sources:
+            - from: resource_attribute
+              name: k8s.pod.ip
+          - sources:
+            - from: resource_attribute
+              name: k8s.pod.uid
+          - sources:
+            - from: connection
+          wait_for_metadata: false
+          wait_for_metadata_timeout: 10s
+        memory_limiter:
+          check_interval: 5s
+          limit_percentage: 80
+          spike_limit_percentage: 15
+        resource/drop_service_name:
+          attributes:
+          - action: delete
+            key: service.name
+        resource/observe_common:
+          attributes:
+          - action: upsert
+            key: k8s.cluster.name
+            value: ${env:OBSERVE_CLUSTER_NAME}
+          - action: upsert
+            key: k8s.cluster.uid
+            value: ${env:OBSERVE_CLUSTER_UID}
+      receivers:
+        prometheus/k8s_metrics:
+          config:
+            scrape_configs:
+            - honor_labels: true
+              job_name: pod-metrics
+              kubernetes_sd_configs:
+              - role: pod
+              metric_relabel_configs:
+              - action: drop
+                regex: null
+                source_labels:
+                - __name__
+              - action: keep
+                regex: (.*)
+                source_labels:
+                - __name__
+              relabel_configs:
+              - action: keep
+              - action: drop
+                regex: (.*istio.*|.*ingress.*|kube-system)
+                source_labels:
+                - __meta_kubernetes_namespace
+              - action: keep
+                regex: (.*)
+                source_labels:
+                - __meta_kubernetes_namespace
+              - action: keep
+                regex: (.*metrics;|.*;\d+)
+                source_labels:
+                - __meta_kubernetes_pod_container_port_name
+                - __meta_kubernetes_pod_annotation_prometheus_io_port
+              - action: drop
+                regex: Succeeded|Failed
+                source_labels:
+                - __meta_kubernetes_pod_phase
+              - action: drop
+                regex: "false"
+                source_labels:
+                - __meta_kubernetes_pod_annotation_observeinc_com_scrape
+              - action: drop
+                regex: "false"
+                source_labels:
+                - __meta_kubernetes_pod_annotation_prometheus_io_scrape
+              - action: replace
+                regex: (https?)
+                replacement: $1
+                source_labels:
+                - __meta_kubernetes_pod_annotation_prometheus_io_scheme
+                target_label: __scheme__
+              - action: replace
+                regex: (.+)
+                replacement: $1
+                source_labels:
+                - __meta_kubernetes_pod_annotation_prometheus_io_path
+                target_label: __metrics_path__
+              - action: replace
+                regex: (.+?)(\:\d+)?;(\d+)
+                replacement: $1:$3
+                source_labels:
+                - __address__
+                - __meta_kubernetes_pod_annotation_prometheus_io_port
+                target_label: __address__
+              - action: replace
+                regex: (.+)
+                source_labels:
+                - __meta_kubernetes_pod_annotation_observeinc_com_path
+                target_label: __metrics_path__
+              - action: replace
+                regex: ([^:]+)(?::\d+)?;(\d+)
+                replacement: $1:$2
+                source_labels:
+                - __address__
+                - __meta_kubernetes_pod_annotation_observeinc_com_port
+                target_label: __address__
+              - action: labelmap
+                regex: __meta_kubernetes_pod_label_(.+)
+              - action: replace
+                source_labels:
+                - __meta_kubernetes_namespace
+                target_label: kubernetes_namespace
+              - action: replace
+                source_labels:
+                - __meta_kubernetes_pod_name
+                target_label: kubernetes_pod_name
+              scrape_interval: 60s
+            - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+              job_name: kubernetes-nodes-cadvisor
+              kubernetes_sd_configs:
+              - role: node
+              relabel_configs:
+              - replacement: kubernetes.default.svc:443
+                target_label: __address__
+              - regex: (.+)
+                replacement: /api/v1/nodes/$$1/proxy/metrics/cadvisor
+                source_labels:
+                - __meta_kubernetes_node_name
+                target_label: __metrics_path__
+              scheme: https
+              tls_config:
+                ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                insecure_skip_verify: true
+      service:
+        pipelines:
+          metrics/cadvisor:
+            exporters:
+            - prometheusremotewrite/observe
+            processors:
+            - memory_limiter
+            - filter/cadvisor
+            - k8sattributes
+            - batch
+            - resource/observe_common
+            - attributes/debug_source_cadvisor_metrics
+            receivers:
+            - prometheus/k8s_metrics
+          metrics/pod_metrics:
+            exporters:
+            - prometheusremotewrite/observe
+            processors:
+            - memory_limiter
+            - filter/pod_metrics
+            - resource/drop_service_name
+            - k8sattributes
+            - batch
+            - resource/observe_common
+            - attributes/debug_source_pod_metrics
+            receivers:
+            - prometheus/k8s_metrics

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/prometheus-scraper/deployment.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/prometheus-scraper/deployment.yaml
@@ -1,0 +1,172 @@
+---
+# Source: agent/charts/prometheus-scraper/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-prometheus-scraper
+  namespace: observe
+  labels:
+    helm.sh/chart: prometheus-scraper-0.143.0
+    app.kubernetes.io/name: prometheus-scraper
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-collector
+    app.kubernetes.io/component: standalone-collector
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus-scraper
+      app.kubernetes.io/instance: example
+      component: standalone-collector
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+        observe_monitor_path: /metrics
+        observe_monitor_port: "8888"
+        observe_monitor_purpose: observecollection
+        observe_monitor_scrape: "true"
+        observeinc_com_scrape: "false"
+      labels:
+        app.kubernetes.io/name: prometheus-scraper
+        app.kubernetes.io/instance: example
+        component: standalone-collector
+
+    spec:
+
+      serviceAccountName: observe-agent-service-account
+      automountServiceAccountToken: true
+      securityContext:
+        {}
+      containers:
+        - name: prometheus-scraper
+          command:
+            - /observe-agent
+          args:
+            - --config=/conf/relay.yaml
+            - start
+            - --observe-config=/observe-agent-conf/observe-agent.yaml
+            - --config=/conf/relay.yaml
+            - --feature-gates=+exporter.prometheusremotewritexporter.EnableMultipleWorkers
+          securityContext:
+            {}
+          image: "observeinc/observe-agent:2.15.0"
+          imagePullPolicy: IfNotPresent
+          ports:
+
+            - name: jaeger-compact
+              containerPort: 6831
+              protocol: UDP
+            - name: jaeger-grpc
+              containerPort: 14250
+              protocol: TCP
+            - name: jaeger-thrift
+              containerPort: 14268
+              protocol: TCP
+            - name: metrics
+              containerPort: 8888
+              protocol: TCP
+            - name: otlp
+              containerPort: 4317
+              protocol: TCP
+            - name: otlp-http
+              containerPort: 4318
+              protocol: TCP
+            - name: zipkin
+              containerPort: 9411
+              protocol: TCP
+          env:
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: GOMEMLIMIT
+              value: "409MiB"
+            - name: OTEL_K8S_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+            - name: OTEL_K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OBSERVE_CLUSTER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  key: name
+                  name: cluster-name
+            - name: OBSERVE_CLUSTER_UID
+              valueFrom:
+                configMapKeyRef:
+                  key: id
+                  name: cluster-info
+            - name: TOKEN
+              valueFrom:
+                secretKeyRef:
+                  key: OBSERVE_TOKEN
+                  name: agent-credentials
+                  optional: true
+          livenessProbe:
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            httpGet:
+              path: /status
+              port: 13133
+          readinessProbe:
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            httpGet:
+              path: /status
+              port: 13133
+          resources:
+            limits:
+              memory: 512Mi
+            requests:
+              cpu: 250m
+              memory: 512Mi
+          volumeMounts:
+            - mountPath: /conf
+              name: prometheus-scraper-configmap
+            - mountPath: /observe-agent-conf
+              name: observe-agent-deployment-config
+      initContainers:
+        - env:
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          image: observeinc/kube-cluster-info:v0.11.6
+          imagePullPolicy: Always
+          name: kube-cluster-info
+      volumes:
+        - name: prometheus-scraper-configmap
+          configMap:
+            name: prometheus-scraper
+            items:
+              - key: relay
+                path: relay.yaml
+        - configMap:
+            defaultMode: 420
+            items:
+            - key: relay
+              path: observe-agent.yaml
+            name: observe-agent
+          name: observe-agent-deployment-config
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: observeinc.com/unschedulable
+                operator: DoesNotExist
+              - key: kubernetes.io/os
+                operator: NotIn
+                values:
+                - windows
+      hostNetwork: false

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/prometheus-scraper/networkpolicy.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/prometheus-scraper/networkpolicy.yaml
@@ -1,0 +1,39 @@
+---
+# Source: agent/charts/prometheus-scraper/templates/networkpolicy.yaml
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: example-prometheus-scraper
+  namespace: observe
+  labels:
+    helm.sh/chart: prometheus-scraper-0.143.0
+    app.kubernetes.io/name: prometheus-scraper
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-collector
+    app.kubernetes.io/component: standalone-collector
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus-scraper
+      app.kubernetes.io/instance: example
+      component: standalone-collector
+  ingress:
+    - ports:
+        - port: 6831
+          protocol: UDP
+        - port: 14250
+          protocol: TCP
+        - port: 14268
+          protocol: TCP
+        - port: 8888
+          protocol: TCP
+        - port: 4317
+          protocol: TCP
+        - port: 4318
+          protocol: TCP
+        - port: 9411
+          protocol: TCP
+  egress:
+    - {}

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/prometheus-scraper/service.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/prometheus-scraper/service.yaml
@@ -1,0 +1,54 @@
+---
+# Source: agent/charts/prometheus-scraper/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-prometheus-scraper
+  namespace: observe
+  labels:
+    helm.sh/chart: prometheus-scraper-0.143.0
+    app.kubernetes.io/name: prometheus-scraper
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-collector
+    app.kubernetes.io/component: standalone-collector
+    component: standalone-collector
+spec:
+  type: ClusterIP
+  ports:
+
+    - name: jaeger-compact
+      port: 6831
+      targetPort: 6831
+      protocol: UDP
+    - name: jaeger-grpc
+      port: 14250
+      targetPort: 14250
+      protocol: TCP
+    - name: jaeger-thrift
+      port: 14268
+      targetPort: 14268
+      protocol: TCP
+    - name: metrics
+      port: 8888
+      targetPort: 8888
+      protocol: TCP
+    - name: otlp
+      port: 4317
+      targetPort: 4317
+      protocol: TCP
+      appProtocol: grpc
+    - name: otlp-http
+      port: 4318
+      targetPort: 4318
+      protocol: TCP
+    - name: zipkin
+      port: 9411
+      targetPort: 9411
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: prometheus-scraper
+    app.kubernetes.io/instance: example
+    component: standalone-collector
+  internalTrafficPolicy: Cluster

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/secret.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/secret.yaml
@@ -1,0 +1,9 @@
+---
+# Source: agent/templates/secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: agent-credentials
+type: Opaque
+data:
+  OBSERVE_TOKEN: ""

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/serviceaccount.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/serviceaccount.yaml
@@ -1,0 +1,7 @@
+---
+# Source: agent/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: observe-agent-service-account
+  namespace: observe

--- a/charts/agent/examples/prometheus-ta-enabled/values.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/values.yaml
@@ -1,0 +1,18 @@
+# Example: enable the merged prometheus/k8s_metrics receiver for pod-metrics + cadvisor.
+# In this PR the flag only merges the two receivers into one and splits them back via
+# filter processors. Target Allocator infrastructure itself lands in a follow-up PR.
+observe:
+  token:
+    create: true
+
+application:
+  prometheusScrape:
+    enabled: true
+    independentDeployment: true
+    targetAllocator:
+      enabled: true
+
+node:
+  metrics:
+    cadvisor:
+      enabled: true

--- a/charts/agent/templates/_config-pipelines.tpl
+++ b/charts/agent/templates/_config-pipelines.tpl
@@ -41,6 +41,47 @@ metrics/spanmetrics:
 {{- end -}}
 
 {{- define "config.pipelines.prometheus_scrapers" -}}
+{{- $ta := and .Values.application.prometheusScrape.independentDeployment .Values.application.prometheusScrape.targetAllocator.enabled }}
+{{- if $ta }}
+
+metrics/pod_metrics:
+  receivers: [prometheus/k8s_metrics]
+  processors:
+    - memory_limiter
+    - filter/pod_metrics
+    - resource/drop_service_name
+    - k8sattributes
+    {{- if not .Values.agent.config.global.exporters.sendingQueue.batch.enabled }}
+    - batch
+    {{- end }}
+    - resource/observe_common
+    - attributes/debug_source_pod_metrics
+  exporters:
+    - prometheusremotewrite/observe
+    {{- if eq .Values.agent.config.global.debug.enabled true }}
+    - debug/override
+    {{- end }}
+
+{{- if .Values.node.metrics.cadvisor.enabled }}
+metrics/cadvisor:
+  receivers: [prometheus/k8s_metrics]
+  processors:
+    - memory_limiter
+    - filter/cadvisor
+    - k8sattributes
+    {{- if not .Values.agent.config.global.exporters.sendingQueue.batch.enabled }}
+    - batch
+    {{- end }}
+    - resource/observe_common
+    - attributes/debug_source_cadvisor_metrics
+  exporters:
+    - prometheusremotewrite/observe
+    {{- if eq .Values.agent.config.global.debug.enabled true }}
+    - debug/override
+    {{- end }}
+{{- end }}
+
+{{- else }}
 
 metrics/pod_metrics:
   receivers: [prometheus/pod_metrics]
@@ -76,6 +117,8 @@ metrics/cadvisor:
     {{- if eq .Values.agent.config.global.debug.enabled true }}
     - debug/override
     {{- end }}
+{{- end }}
+
 {{- end }}
 
 {{- end }}

--- a/charts/agent/templates/_config-processors.tpl
+++ b/charts/agent/templates/_config-processors.tpl
@@ -244,6 +244,29 @@ metricstransform/duplicate_k8s_cpu_metrics:
       new_name: k8s.node.cpu.utilization
 {{- end -}}
 
+{{/*
+  Filter processors for the TA single-receiver path. The prometheus receiver sets
+  service.name to the scrape job name, so these split the shared stream into the
+  correct per-job pipeline without any cross-contamination.
+*/}}
+{{- define "config.processors.filter.pod_metrics" -}}
+filter/pod_metrics:
+  error_mode: ignore
+  metrics:
+    metric:
+      - resource.attributes["service.name"] != "pod-metrics"
+{{- end -}}
+
+{{- define "config.processors.filter.cadvisor" -}}
+{{- if .Values.node.metrics.cadvisor.enabled }}
+filter/cadvisor:
+  error_mode: ignore
+  metrics:
+    metric:
+      - resource.attributes["service.name"] != "kubernetes-nodes-cadvisor"
+{{- end -}}
+{{- end -}}
+
 {{- define "config.processors.filter.drop_long_spans" -}}
 {{- if eq .Values.node.forwarder.traces.maxSpanDuration "none" }}
 {{- else if (regexMatch "^[0-9]+(ns|us|ms|s|m|h)$" .Values.node.forwarder.traces.maxSpanDuration) }}

--- a/charts/agent/templates/_config-receivers.tpl
+++ b/charts/agent/templates/_config-receivers.tpl
@@ -114,6 +114,30 @@
         - __name__
 {{- end -}}
 
+{{/*
+  Prometheus scrape_configs entry for cadvisor (Kubernetes node SD via the API-server proxy).
+  Used by the parent-rendered TA ConfigMap. Uses $1 (not $$1) — the TA reads this YAML
+  directly, no OTel collector config-expansion happens, so Prometheus SD receives the
+  literal $1 backreference.
+*/}}
+{{- define "observe.prometheus.cadvisor.scrape_job" -}}
+- job_name: 'kubernetes-nodes-cadvisor'
+  scheme: https
+  tls_config:
+    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    insecure_skip_verify: true
+  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+  kubernetes_sd_configs:
+    - role: node
+  relabel_configs:
+    - target_label: __address__
+      replacement: kubernetes.default.svc:443
+    - source_labels: [__meta_kubernetes_node_name]
+      regex: (.+)
+      target_label: __metrics_path__
+      replacement: /api/v1/nodes/$1/proxy/metrics/cadvisor
+{{- end -}}
+
 {{- define "config.receivers.prometheus.pod_metrics" -}}
 prometheus/pod_metrics:
   config:
@@ -147,33 +171,17 @@ prometheus/cadvisor:
 {{ end }}
 
 {{/*
-  Merged receiver for the TA-enabled path. Combines pod-metrics and cadvisor jobs into
-  a single receiver so that one Target Allocator (introduced in a follow-up PR) can serve
-  both jobs. Filter processors in the pipelines split the stream by service.name.
-  NOTE: uses $$1 (OTel expands $$ → $) unlike the standalone cadvisor receiver.
+  Merged receiver for the TA-enabled path. Polls the upstream Target Allocator
+  (deployed via the opentelemetry-target-allocator subchart) for both pod-metrics
+  and cadvisor jobs. Filter processors in the pipelines split the stream by service.name.
+  Each scraper pod identifies itself to TA via collector_id (= pod name) for sharding.
 */}}
 {{- define "config.receivers.prometheus.k8s_metrics" -}}
 prometheus/k8s_metrics:
-  config:
-    scrape_configs:
-{{ include "observe.prometheus.pod_metrics.scrape_job" . | nindent 4 }}
-{{- if .Values.node.metrics.cadvisor.enabled }}
-    - job_name: 'kubernetes-nodes-cadvisor'
-      scheme: https
-      tls_config:
-        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-        insecure_skip_verify: true
-      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-      kubernetes_sd_configs:
-        - role: node
-      relabel_configs:
-        - target_label: __address__
-          replacement: kubernetes.default.svc:443
-        - source_labels: [__meta_kubernetes_node_name]
-          regex: (.+)
-          target_label: __metrics_path__
-          replacement: /api/v1/nodes/$$1/proxy/metrics/cadvisor
-{{- end }}
+  target_allocator:
+    endpoint: http://{{ .Release.Name }}-prometheus-ta-ta.{{ .Release.Namespace }}.svc.cluster.local
+    interval: 30s
+    collector_id: ${env:OTEL_K8S_POD_NAME}
 {{- end -}}
 
 {{- define "config.receivers.observe.heartbeat" -}}

--- a/charts/agent/templates/_config-receivers.tpl
+++ b/charts/agent/templates/_config-receivers.tpl
@@ -1,116 +1,124 @@
+{{/*
+  Prometheus scrape_configs entry for pod-metrics (Kubernetes pod SD + relabel).
+  Shared between the non-TA receiver (prometheus/pod_metrics) and the merged receiver (prometheus/k8s_metrics).
+*/}}
+{{- define "observe.prometheus.pod_metrics.scrape_job" -}}
+- job_name: pod-metrics
+  scrape_interval: {{.Values.application.prometheusScrape.interval}}
+  honor_labels: true
+  kubernetes_sd_configs:
+  - role: pod
+  relabel_configs:
+  # this is defaulted to keep so we start with everything
+  - action: keep
+
+  # Drop anything matching the configured namespace.
+  - action: 'drop'
+    source_labels: ['__meta_kubernetes_namespace']
+    regex: {{.Values.application.prometheusScrape.namespaceDropRegex}}
+
+  # Drop anything not matching the configured namespace.
+  - action: 'keep'
+    source_labels: ['__meta_kubernetes_namespace']
+    regex: {{.Values.application.prometheusScrape.namespaceKeepRegex}}
+
+  # Drop endpoints without one of: a port name suffixed with the configured regex, or an explicit prometheus port annotation.
+  - action: 'keep'
+    source_labels: ['__meta_kubernetes_pod_container_port_name', '__meta_kubernetes_pod_annotation_prometheus_io_port']
+    regex: '({{.Values.application.prometheusScrape.portKeepRegex}};|.*;\d+)'
+
+  # Drop pods with phase Succeeded or Failed.
+  - action: 'drop'
+    regex: 'Succeeded|Failed'
+    source_labels: ['__meta_kubernetes_pod_phase']
+
+  ################################################################
+  # Drop anything annotated with 'observeinc.com.scrape=false' or 'observeinc_com_scrape=false' .
+  - action: 'drop'
+    regex: 'false'
+    source_labels: ['__meta_kubernetes_pod_annotation_observeinc_com_scrape']
+
+  ################################################################
+  # Prometheus Configs
+  # Drop anything annotated with 'prometheus.io.scrape=false'.
+  - action: 'drop'
+    regex: 'false'
+    source_labels: ['__meta_kubernetes_pod_annotation_prometheus_io_scrape']
+
+  # Allow pods to override the scrape scheme with 'prometheus.io.scheme=https'.
+  - action: 'replace'
+    regex: '(https?)'
+    replacement: '$1'
+    source_labels: ['__meta_kubernetes_pod_annotation_prometheus_io_scheme']
+    target_label: '__scheme__'
+
+  # Allow service to override the scrape path with 'prometheus.io.path=/other_metrics_path'.
+  - action: 'replace'
+    regex: '(.+)'
+    replacement: '$1'
+    source_labels: ['__meta_kubernetes_pod_annotation_prometheus_io_path']
+    target_label: '__metrics_path__'
+
+  # Allow services to override the scrape port with 'prometheus.io.port=1234'.
+  - action: 'replace'
+    regex: '(.+?)(\:\d+)?;(\d+)'
+    replacement: '$1:$3'
+    source_labels: ['__address__', '__meta_kubernetes_pod_annotation_prometheus_io_port']
+    target_label: '__address__'
+
+
+  ################################################################
+
+  #podAnnotations: {
+  #  observeinc_com_scrape: 'true',
+  #  observeinc_com_path: '/metrics',
+  #  observeinc_com_port: '8080',
+  #}
+
+  # set metrics_path (default is /metrics) to the metrics path specified in "observeinc_com_path: <metric path>" annotation.
+  - source_labels: [__meta_kubernetes_pod_annotation_observeinc_com_path]
+    action: replace
+    target_label: __metrics_path__
+    regex: (.+)
+
+  # set the scrapping port to the port specified in "observeinc_com_port: <port>" annotation and set address accordingly.
+  - source_labels: [__address__, __meta_kubernetes_pod_annotation_observeinc_com_port]
+    action: replace
+    regex: ([^:]+)(?::\d+)?;(\d+)
+    replacement: '$1:$2'
+    target_label: __address__
+  ################################################################
+
+  # Maps all Kubernetes pod labels to Prometheus labels with the prefix removed (e.g., __meta_kubernetes_pod_label_app becomes app).
+  - action: labelmap
+    regex: __meta_kubernetes_pod_label_(.+)
+
+  # adds new label
+  - source_labels: [__meta_kubernetes_namespace]
+    action: replace
+    target_label: kubernetes_namespace
+
+  # adds new label
+  - source_labels: [__meta_kubernetes_pod_name]
+    action: replace
+    target_label: kubernetes_pod_name
+
+  metric_relabel_configs:
+    - action: drop
+      regex: {{ .Values.application.prometheusScrape.metricDropRegex }}
+      source_labels:
+        - __name__
+    - action: keep
+      regex: {{ .Values.application.prometheusScrape.metricKeepRegex }}
+      source_labels:
+        - __name__
+{{- end -}}
+
 {{- define "config.receivers.prometheus.pod_metrics" -}}
 prometheus/pod_metrics:
   config:
     scrape_configs:
-    - job_name: pod-metrics
-      scrape_interval: {{.Values.application.prometheusScrape.interval}}
-      honor_labels: true
-      kubernetes_sd_configs:
-      - role: pod
-      relabel_configs:
-      # this is defaulted to keep so we start with everything
-      - action: keep
-
-      # Drop anything matching the configured namespace.
-      - action: 'drop'
-        source_labels: ['__meta_kubernetes_namespace']
-        regex: {{.Values.application.prometheusScrape.namespaceDropRegex}}
-
-      # Drop anything not matching the configured namespace.
-      - action: 'keep'
-        source_labels: ['__meta_kubernetes_namespace']
-        regex: {{.Values.application.prometheusScrape.namespaceKeepRegex}}
-
-      # Drop endpoints without one of: a port name suffixed with the configured regex, or an explicit prometheus port annotation.
-      - action: 'keep'
-        source_labels: ['__meta_kubernetes_pod_container_port_name', '__meta_kubernetes_pod_annotation_prometheus_io_port']
-        regex: '({{.Values.application.prometheusScrape.portKeepRegex}};|.*;\d+)'
-
-      # Drop pods with phase Succeeded or Failed.
-      - action: 'drop'
-        regex: 'Succeeded|Failed'
-        source_labels: ['__meta_kubernetes_pod_phase']
-
-      ################################################################
-      # Drop anything annotated with 'observeinc.com.scrape=false' or 'observeinc_com_scrape=false' .
-      - action: 'drop'
-        regex: 'false'
-        source_labels: ['__meta_kubernetes_pod_annotation_observeinc_com_scrape']
-
-      ################################################################
-      # Prometheus Configs
-      # Drop anything annotated with 'prometheus.io.scrape=false'.
-      - action: 'drop'
-        regex: 'false'
-        source_labels: ['__meta_kubernetes_pod_annotation_prometheus_io_scrape']
-
-      # Allow pods to override the scrape scheme with 'prometheus.io.scheme=https'.
-      - action: 'replace'
-        regex: '(https?)'
-        replacement: '$1'
-        source_labels: ['__meta_kubernetes_pod_annotation_prometheus_io_scheme']
-        target_label: '__scheme__'
-
-      # Allow service to override the scrape path with 'prometheus.io.path=/other_metrics_path'.
-      - action: 'replace'
-        regex: '(.+)'
-        replacement: '$1'
-        source_labels: ['__meta_kubernetes_pod_annotation_prometheus_io_path']
-        target_label: '__metrics_path__'
-
-      # Allow services to override the scrape port with 'prometheus.io.port=1234'.
-      - action: 'replace'
-        regex: '(.+?)(\:\d+)?;(\d+)'
-        replacement: '$1:$3'
-        source_labels: ['__address__', '__meta_kubernetes_pod_annotation_prometheus_io_port']
-        target_label: '__address__'
-
-
-      ################################################################
-
-      #podAnnotations: {
-      #  observeinc_com_scrape: 'true',
-      #  observeinc_com_path: '/metrics',
-      #  observeinc_com_port: '8080',
-      #}
-
-      # set metrics_path (default is /metrics) to the metrics path specified in "observeinc_com_path: <metric path>" annotation.
-      - source_labels: [__meta_kubernetes_pod_annotation_observeinc_com_path]
-        action: replace
-        target_label: __metrics_path__
-        regex: (.+)
-
-      # set the scrapping port to the port specified in "observeinc_com_port: <port>" annotation and set address accordingly.
-      - source_labels: [__address__, __meta_kubernetes_pod_annotation_observeinc_com_port]
-        action: replace
-        regex: ([^:]+)(?::\d+)?;(\d+)
-        replacement: '$1:$2'
-        target_label: __address__
-      ################################################################
-
-      # Maps all Kubernetes pod labels to Prometheus labels with the prefix removed (e.g., __meta_kubernetes_pod_label_app becomes app).
-      - action: labelmap
-        regex: __meta_kubernetes_pod_label_(.+)
-
-      # adds new label
-      - source_labels: [__meta_kubernetes_namespace]
-        action: replace
-        target_label: kubernetes_namespace
-
-      # adds new label
-      - source_labels: [__meta_kubernetes_pod_name]
-        action: replace
-        target_label: kubernetes_pod_name
-
-      metric_relabel_configs:
-        - action: drop
-          regex: {{.Values.application.prometheusScrape.metricDropRegex}}
-          source_labels:
-            - __name__
-        - action: keep
-          regex: {{.Values.application.prometheusScrape.metricKeepRegex}}
-          source_labels:
-            - __name__
+{{ include "observe.prometheus.pod_metrics.scrape_job" . | nindent 4 }}
 {{- end -}}
 
 {{- define "config.receivers.prometheus.cadvisor" -}}
@@ -137,6 +145,36 @@ prometheus/cadvisor:
             replacement: /api/v1/nodes/$$1/proxy/metrics/cadvisor
 {{ end }}
 {{ end }}
+
+{{/*
+  Merged receiver for the TA-enabled path. Combines pod-metrics and cadvisor jobs into
+  a single receiver so that one Target Allocator (introduced in a follow-up PR) can serve
+  both jobs. Filter processors in the pipelines split the stream by service.name.
+  NOTE: uses $$1 (OTel expands $$ → $) unlike the standalone cadvisor receiver.
+*/}}
+{{- define "config.receivers.prometheus.k8s_metrics" -}}
+prometheus/k8s_metrics:
+  config:
+    scrape_configs:
+{{ include "observe.prometheus.pod_metrics.scrape_job" . | nindent 4 }}
+{{- if .Values.node.metrics.cadvisor.enabled }}
+    - job_name: 'kubernetes-nodes-cadvisor'
+      scheme: https
+      tls_config:
+        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        insecure_skip_verify: true
+      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+      kubernetes_sd_configs:
+        - role: node
+      relabel_configs:
+        - target_label: __address__
+          replacement: kubernetes.default.svc:443
+        - source_labels: [__meta_kubernetes_node_name]
+          regex: (.+)
+          target_label: __metrics_path__
+          replacement: /api/v1/nodes/$$1/proxy/metrics/cadvisor
+{{- end }}
+{{- end -}}
 
 {{- define "config.receivers.observe.heartbeat" -}}
 heartbeat:

--- a/charts/agent/templates/_prometheus-scraper-config.tpl
+++ b/charts/agent/templates/_prometheus-scraper-config.tpl
@@ -1,4 +1,5 @@
 {{- define "observe.deployment.prometheusScraper.config" -}}
+{{- $ta := and .Values.application.prometheusScrape.independentDeployment .Values.application.prometheusScrape.targetAllocator.enabled }}
 
 exporters:
 {{- if eq .Values.application.prometheusScrape.enabled true }}
@@ -14,8 +15,12 @@ exporters:
 
 receivers:
 {{- if eq .Values.application.prometheusScrape.enabled true }}
+  {{- if $ta }}
+  {{- include "config.receivers.prometheus.k8s_metrics" . | nindent 2 }}
+  {{- else }}
   {{- include "config.receivers.prometheus.pod_metrics" . | nindent 2 }}
   {{- include "config.receivers.prometheus.cadvisor" . | nindent 2 }}
+  {{- end }}
 {{- else }}
   nop:
 {{- end }}
@@ -33,6 +38,10 @@ processors:
   {{- include "config.processors.attributes.pod_metrics" . | nindent 2 }}
   {{- include "config.processors.attributes.cadvisor_metrics" . | nindent 2 }}
   {{- include "config.processors.attributes.drop_service_name" . | nindent 2 }}
+  {{- if $ta }}
+  {{- include "config.processors.filter.pod_metrics" . | nindent 2 }}
+  {{- include "config.processors.filter.cadvisor" . | nindent 2 }}
+  {{- end }}
 {{- else if .Values.agent.config.global.fleet.enabled }}
   # k8sattributes is needed for the heartbeat pipeline even when prometheusScrape is disabled
   {{- include "config.processors.attributes.k8sattributes" . | nindent 2 }}

--- a/charts/agent/templates/prometheus-scraper-configmap.yaml
+++ b/charts/agent/templates/prometheus-scraper-configmap.yaml
@@ -1,4 +1,7 @@
 {{ if .Values.application.prometheusScrape.independentDeployment }}
+{{- if and .Values.application.prometheusScrape.targetAllocator.enabled (not .Values.application.prometheusScrape.independentDeployment) }}
+{{- fail "application.prometheusScrape.targetAllocator.enabled requires application.prometheusScrape.independentDeployment=true" }}
+{{- end }}
 {{- include "observe-agent.validateOtelPodUid" (dict "componentName" "prometheus-scraper" "extraEnvs" (index .Values "prometheus-scraper" "extraEnvs") "fleetEnabled" .Values.agent.config.global.fleet.enabled) -}}
 apiVersion: v1
 kind: ConfigMap

--- a/charts/agent/templates/prometheus-scraper-configmap.yaml
+++ b/charts/agent/templates/prometheus-scraper-configmap.yaml
@@ -2,6 +2,9 @@
 {{- if and .Values.application.prometheusScrape.targetAllocator.enabled (not .Values.application.prometheusScrape.independentDeployment) }}
 {{- fail "application.prometheusScrape.targetAllocator.enabled requires application.prometheusScrape.independentDeployment=true" }}
 {{- end }}
+{{- if and (index .Values "prometheus-scraper" "autoscaling" "enabled") (not .Values.application.prometheusScrape.targetAllocator.enabled) }}
+{{- fail "prometheus-scraper.autoscaling.enabled requires application.prometheusScrape.targetAllocator.enabled=true (without TA, every replica scrapes every target — scaling up just duplicates metrics)" }}
+{{- end }}
 {{- include "observe-agent.validateOtelPodUid" (dict "componentName" "prometheus-scraper" "extraEnvs" (index .Values "prometheus-scraper" "extraEnvs") "fleetEnabled" .Values.agent.config.global.fleet.enabled) -}}
 apiVersion: v1
 kind: ConfigMap

--- a/charts/agent/templates/prometheus-ta-configmap.yaml
+++ b/charts/agent/templates/prometheus-ta-configmap.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.application.prometheusScrape.independentDeployment .Values.application.prometheusScrape.targetAllocator.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-ta
+  namespace: {{ .Release.Namespace }}
+data:
+  targetallocator.yaml: |
+    allocation_strategy: consistent-hashing
+    filter_strategy: relabel-config
+    prometheus_cr:
+      enabled: false
+    collector_selector:
+      matchlabels:
+        app.kubernetes.io/name: prometheus-scraper
+    config:
+      scrape_configs:
+{{ include "observe.prometheus.pod_metrics.scrape_job" . | nindent 8 }}
+{{- if .Values.node.metrics.cadvisor.enabled }}
+{{ include "observe.prometheus.cadvisor.scrape_job" . | nindent 8 }}
+{{- end }}
+{{- end }}

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -144,6 +144,11 @@ application:
     metricDropRegex: ""
     # metrics to keep
     metricKeepRegex: (.*)
+    # Merge pod-metrics and cadvisor into a single receiver with filter processors to split pipelines.
+    # Requires application.prometheusScrape.independentDeployment=true.
+    # Sharding across replicas via Target Allocator will be introduced in a follow-up PR.
+    targetAllocator:
+      enabled: false
   REDMetrics:
     # -- (bool) Whether to enable generating RED metrics from spans. See https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/spanmetricsconnector#overview
     enabled: false

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -615,6 +615,30 @@ cluster-metrics:
   # ----------------------------------------- #
 
 ################################################
+# Target Allocator subchart (opentelemetry-target-allocator).
+# Only deployed when application.prometheusScrape.targetAllocator.enabled=true.
+# When enabled, the prometheus-scraper's prometheus/k8s_metrics receiver fetches
+# scrape configs and target assignments from this TA via its HTTP API.
+#
+# The TA's targetallocator.yaml ConfigMap is rendered by THIS chart (templates/
+# prometheus-ta-configmap.yaml) using the same scrape-job partials as the
+# non-TA path. The subchart mounts that ConfigMap by name (existingName).
+prometheus-ta:
+  replicaCount: 1
+  configMap:
+    create: false
+    existingName: "prometheus-ta"
+  targetAllocator:
+    image:
+      tag: "0.150.0"
+    resources:
+      requests:
+        cpu: 50m
+        memory: 128Mi
+      limits:
+        memory: 256Mi
+
+################################################
 prometheus-scraper:
   mode: deployment
   # ----------------------------------------- #

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -651,6 +651,29 @@ prometheus-scraper:
     create: false
     existingName: "prometheus-scraper"
 
+  # Horizontal Pod Autoscaling for the prometheus-scraper.
+  # Only meaningful when application.prometheusScrape.targetAllocator.enabled=true,
+  # because without TA every replica scrapes every target (so scaling up just
+  # multiplies the metrics). The chart fails install if autoscaling.enabled=true
+  # without targetAllocator.enabled=true.
+  autoscaling:
+    enabled: false
+    minReplicas: 2
+    maxReplicas: 10
+    # CPU is a coarse proxy for scrape load; consider tuning or adding a
+    # custom metric (e.g. otelcol_processor_incoming_items_total rate) via
+    # additionalMetrics if you need tighter control.
+    targetCPUUtilizationPercentage: 70
+    # Optional: also scale on memory (memory is often the binding constraint
+    # for high-cardinality scrape targets). Uncomment to enable.
+    # targetMemoryUtilizationPercentage: 75
+    # Optional: cooldown windows to prevent thrashing during rapid scale events.
+    # behavior:
+    #   scaleDown:
+    #     stabilizationWindowSeconds: 300
+    #   scaleUp:
+    #     stabilizationWindowSeconds: 60
+
   resources:
     requests:
       cpu: 250m

--- a/test/verify_agent_prometheus_ta_template.sh
+++ b/test/verify_agent_prometheus_ta_template.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CHART_DIR="$(cd "$(dirname "$0")/../charts/agent" && pwd)"
+TA_VALUES="${CHART_DIR}/ci/prometheus-ta-values.yaml"
+DEFAULT_VALUES="${CHART_DIR}/ci/test-values.yaml"
+
+pass() { echo "PASS: $1"; }
+fail() { echo "FAIL: $1"; exit 1; }
+
+# ─── Render the merged-receiver template ──────────────────────────────────────
+TA_MANIFEST=$(helm template test-release "${CHART_DIR}" -f "${TA_VALUES}")
+
+COLLECTOR_CM=$(echo "${TA_MANIFEST}" | awk 'BEGIN{RS="---\n"} /kind: ConfigMap/ && /name: prometheus-scraper/')
+
+# 1. Collector uses single prometheus/k8s_metrics receiver
+echo "${COLLECTOR_CM}" | grep -q 'prometheus/k8s_metrics' \
+  && pass "Collector uses prometheus/k8s_metrics receiver" \
+  || fail "Collector is missing prometheus/k8s_metrics receiver"
+
+# 2. Collector does NOT use the old per-job receivers in merged mode
+echo "${COLLECTOR_CM}" | grep -q 'prometheus/pod_metrics' \
+  && fail "Collector still has prometheus/pod_metrics in merged mode" \
+  || pass "Collector has no prometheus/pod_metrics in merged mode"
+
+# 3. Merged receiver has pod-metrics job inline
+echo "${COLLECTOR_CM}" | grep -q 'job_name: pod-metrics' \
+  && pass "Merged receiver has pod-metrics job inline" \
+  || fail "Merged receiver missing pod-metrics job"
+
+# 4. Merged receiver has cadvisor job inline
+echo "${COLLECTOR_CM}" | grep -q 'job_name.*kubernetes-nodes-cadvisor' \
+  && pass "Merged receiver has cadvisor job inline" \
+  || fail "Merged receiver missing cadvisor job"
+
+# 5. Collector config has filter processors
+echo "${COLLECTOR_CM}" | grep -q 'filter/pod_metrics' \
+  && pass "Collector has filter/pod_metrics processor" \
+  || fail "Collector missing filter/pod_metrics processor"
+echo "${COLLECTOR_CM}" | grep -q 'filter/cadvisor' \
+  && pass "Collector has filter/cadvisor processor" \
+  || fail "Collector missing filter/cadvisor processor"
+
+# ─── Render the default (non-merged) template ─────────────────────────────────
+DEFAULT_MANIFEST=$(helm template test-release "${CHART_DIR}" -f "${DEFAULT_VALUES}")
+
+# 6. Default path uses original per-job receivers
+DEFAULT_CM=$(echo "${DEFAULT_MANIFEST}" | awk 'BEGIN{RS="---\n"} /kind: ConfigMap/ && /name: prometheus-scraper/')
+echo "${DEFAULT_CM}" | grep -q 'prometheus/pod_metrics' \
+  && pass "Default path has prometheus/pod_metrics receiver" \
+  || fail "Default path missing prometheus/pod_metrics receiver"
+
+echo ""
+echo "All checks passed."


### PR DESCRIPTION
> Stacked on top of #486. Review #486 first; this PR adds only the HPA-related delta.

## Summary

Surfaces the upstream `opentelemetry-collector` chart's `autoscaling` values through this chart's `prometheus-scraper:` block. When enabled, an `HorizontalPodAutoscaler` (apiVersion `autoscaling/v2`) is rendered targeting the prometheus-scraper Deployment.

Defaults: `enabled: false` (no change for existing users), `minReplicas: 2`, `maxReplicas: 10`, `targetCPUUtilizationPercentage: 70`. Memory targets, custom metrics via `additionalMetrics`, and `behavior` cooldown windows are all available via the same upstream values shape.

A render-time guard fails install if `autoscaling.enabled=true` is set without `targetAllocator.enabled=true`. Rationale: without TA, every replica runs its own service discovery and scrapes every target — scaling up multiplies metrics rather than sharing load. HPA without TA is a footgun, rejected at template time with a clear error message.

## Changes

- `charts/agent/values.yaml` — new `autoscaling:` block under `prometheus-scraper:` with sensible defaults and inline comments documenting memory/behaviour knobs.
- `charts/agent/templates/prometheus-scraper-configmap.yaml` — render-time guard for `autoscaling.enabled=true` without `targetAllocator.enabled=true`.
- `charts/agent/README.md` — auto-generated by `helm-docs`.

## Test status

### Render scenarios (template-level)

| Scenario | Expected | Result |
|---|---|---|
| TA on + autoscaling on | HPA renders with min=2/max=10/CPU=70% | ✅ |
| TA on + autoscaling off | no HPA emitted | ✅ |
| autoscaling on without TA | install fails with guard error | ✅ |
| Default values (TA off, autoscaling off) | byte-identical to PR #486's tip | ✅ |

### Minikube end-to-end (scale-up + scale-down)

Environment: minikube v1.36.0 (Kubernetes v1.33.1), `metrics-server` addon enabled, helm v4.1.3.

Test values (low CPU request + low threshold to make scaling trigger easily on baseline scrape load):

```yaml
prometheus-scraper:
  replicaCount: 2
  resources:
    requests: { cpu: 50m, memory: 256Mi }
  autoscaling:
    enabled: true
    minReplicas: 2
    maxReplicas: 5
    targetCPUUtilizationPercentage: 30
```

Phases:

| Phase | Action | Observation | Result |
|---|---|---|---|
| Install | TA + autoscaling on | HPA created, `AbleToScale=True`, `ScalingActive=True` | ✅ |
| Steady state | 2 scrapers idle | `cpu: 6%/30%`, 2 replicas | ✅ |
| Drive load | Deploy 30 prom-load pods (annotated `prometheus.io/scrape: true`) | CPU climbs to 21% (still < 30%) | — |
| Trigger scale-up | `helm upgrade` lowering threshold to 15% | Within ~30s: HPA scales **2 → 3** | ✅ |
| Convergence | new pod registers with TA, takes share of targets | CPU drops to 16% across 3 pods | ✅ |
| Trigger scale-down | `helm upgrade` raising threshold back to 30% | Held at 3 replicas during 5-min cooldown | ✅ |
| Scale-down fire | 5 min later | Drops **3 → 2** exactly at `t=300s` (default `scaleDown.stabilizationWindowSeconds`) | ✅ |

### Lint and render commands

```bash
$ helm lint charts/agent -f charts/agent/ci/test-values.yaml
1 chart(s) linted, 0 chart(s) failed

# TA on + autoscaling on → HPA emitted
$ helm template ... | grep "kind: HorizontalPodAutoscaler"
kind: HorizontalPodAutoscaler

# TA on + autoscaling off → no HPA
$ helm template ... | grep -c "kind: HorizontalPodAutoscaler"
0

# autoscaling on without TA → guard fires
$ helm template ...
Error: execution error at (agent/templates/prometheus-scraper-configmap.yaml:6:4):
prometheus-scraper.autoscaling.enabled requires
application.prometheusScrape.targetAllocator.enabled=true (without TA, every
replica scrapes every target — scaling up just duplicates metrics)
```

## Stacked PR notes

This PR's base is `feat/prometheus-ta-upstream-chart` (PR #486), not `main`. The diff shown is just the HPA delta — receiver-merge changes are reviewed in #485, TA subchart changes in #486. Merge order should be #485 → #486 → this.