### PR TITLE
feat: add emitPrometheusTargetInfoMetrics config value, default to false so target_info metrics will no longer be written

### DIFF
--- a/.orca-security.yaml
+++ b/.orca-security.yaml
@@ -4,3 +4,10 @@ global:
     - "./examples/**"
     - "./integration/scripts/benchmark/**"
     - "./charts/stack/templates/tests/**"
+
+iac:
+  excluded_paths:
+    - "**/examples/**"
+    - "./examples/**"
+    - "./integration/scripts/benchmark/**"
+    - "./charts/stack/templates/tests/**"

--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent
 description: Chart to install K8s collection stack based on Observe Agent
 type: application
-version: 0.86.1
+version: 0.87.0
 appVersion: "2.15.0"
 dependencies:
   - name: opentelemetry-collector

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -1,6 +1,6 @@
 # agent
 
-![Version: 0.86.1](https://img.shields.io/badge/Version-0.86.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.15.0](https://img.shields.io/badge/AppVersion-2.15.0-informational?style=flat-square)
+![Version: 0.87.0](https://img.shields.io/badge/Version-0.87.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.15.0](https://img.shields.io/badge/AppVersion-2.15.0-informational?style=flat-square)
 
 Chart to install K8s collection stack based on Observe Agent
 
@@ -62,6 +62,7 @@ This service is an *OpenTelemetryCollector*, a custom resource that is managed b
 | agent.config.gateway | string | `nil` | Additional OTel collector config for gateway deployment |
 | agent.config.global.debug.enabled | bool | `false` |  |
 | agent.config.global.debug.verbosity | string | `"basic"` |  |
+| agent.config.global.exporters.emitPrometheusTargetInfoMetrics | bool | `false` |  |
 | agent.config.global.exporters.retryOnFailure.enabled | bool | `true` |  |
 | agent.config.global.exporters.retryOnFailure.initialInterval | string | `"1s"` |  |
 | agent.config.global.exporters.retryOnFailure.maxElapsedTime | string | `"5m"` |  |

--- a/charts/agent/examples/aws-eks-fargate/rendered/agent-monitor-configmap.yaml
+++ b/charts/agent/examples/aws-eks-fargate/rendered/agent-monitor-configmap.yaml
@@ -48,6 +48,8 @@ data:
             max_elapsed_time: 5m
             max_interval: 30s
           send_metadata: true
+          target_info:
+            enabled: false
           timeout: 10s
       processors:
         attributes/debug_source_agent_monitor:

--- a/charts/agent/examples/aws-eks-fargate/rendered/cluster-events-configmap.yaml
+++ b/charts/agent/examples/aws-eks-fargate/rendered/cluster-events-configmap.yaml
@@ -188,7 +188,7 @@ data:
             - set(attributes["observe_transform"]["control"]["isDelete"], false) where attributes["observe_transform"]["control"]["isDelete"]
               == nil
             - set(attributes["observe_transform"]["control"]["version"], body["metadata"]["resourceVersion"])
-            - set(attributes["observe_transform"]["control"]["agentVersion"], "2.14.0")
+            - set(attributes["observe_transform"]["control"]["agentVersion"], "2.15.0")
             - set(attributes["observe_transform"]["identifiers"]["clusterName"], resource.attributes["k8s.cluster.name"])
             - set(attributes["observe_transform"]["identifiers"]["clusterUid"], resource.attributes["k8s.cluster.uid"])
             - set(attributes["observe_transform"]["identifiers"]["kind"], body["kind"])

--- a/charts/agent/examples/aws-eks-fargate/rendered/cluster-events/deployment.yaml
+++ b/charts/agent/examples/aws-eks-fargate/rendered/cluster-events/deployment.yaml
@@ -54,7 +54,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "observeinc/observe-agent:2.14.0"
+          image: "observeinc/observe-agent:2.15.0"
           imagePullPolicy: IfNotPresent
           ports:
 

--- a/charts/agent/examples/aws-eks-fargate/rendered/cluster-metrics-configmap.yaml
+++ b/charts/agent/examples/aws-eks-fargate/rendered/cluster-metrics-configmap.yaml
@@ -48,6 +48,8 @@ data:
             max_elapsed_time: 5m
             max_interval: 30s
           send_metadata: true
+          target_info:
+            enabled: false
           timeout: 10s
       processors:
         attributes/debug_source_cluster_metrics:

--- a/charts/agent/examples/aws-eks-fargate/rendered/cluster-metrics/deployment.yaml
+++ b/charts/agent/examples/aws-eks-fargate/rendered/cluster-metrics/deployment.yaml
@@ -55,7 +55,7 @@ spec:
             - --feature-gates=+exporter.prometheusremotewritexporter.EnableMultipleWorkers
           securityContext:
             {}
-          image: "observeinc/observe-agent:2.14.0"
+          image: "observeinc/observe-agent:2.15.0"
           imagePullPolicy: IfNotPresent
           ports:
 

--- a/charts/agent/examples/aws-eks-fargate/rendered/forwarder-configmap.yaml
+++ b/charts/agent/examples/aws-eks-fargate/rendered/forwarder-configmap.yaml
@@ -125,7 +125,6 @@ data:
           timeout: 2s
         resourcedetection/cloud:
           detectors:
-          - eks
           - gcp
           - ecs
           - ec2

--- a/charts/agent/examples/aws-eks-fargate/rendered/forwarder/deployment.yaml
+++ b/charts/agent/examples/aws-eks-fargate/rendered/forwarder/deployment.yaml
@@ -54,7 +54,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "observeinc/observe-agent:2.14.0"
+          image: "observeinc/observe-agent:2.15.0"
           imagePullPolicy: IfNotPresent
           ports:
 

--- a/charts/agent/examples/aws-eks-fargate/rendered/gateway-configmap.yaml
+++ b/charts/agent/examples/aws-eks-fargate/rendered/gateway-configmap.yaml
@@ -210,7 +210,6 @@ data:
           timeout: 2s
         resourcedetection/cloud:
           detectors:
-          - eks
           - gcp
           - ecs
           - ec2

--- a/charts/agent/examples/aws-eks-fargate/rendered/gateway/deployment.yaml
+++ b/charts/agent/examples/aws-eks-fargate/rendered/gateway/deployment.yaml
@@ -54,7 +54,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "observeinc/observe-agent:2.14.0"
+          image: "observeinc/observe-agent:2.15.0"
           imagePullPolicy: IfNotPresent
           ports:
 

--- a/charts/agent/examples/aws-eks-fargate/rendered/monitor/deployment.yaml
+++ b/charts/agent/examples/aws-eks-fargate/rendered/monitor/deployment.yaml
@@ -55,7 +55,7 @@ spec:
             - --feature-gates=+exporter.prometheusremotewritexporter.EnableMultipleWorkers
           securityContext:
             {}
-          image: "observeinc/observe-agent:2.14.0"
+          image: "observeinc/observe-agent:2.15.0"
           imagePullPolicy: IfNotPresent
           ports:
 

--- a/charts/agent/examples/aws-eks-fargate/rendered/nodeless-otelcollector.yaml
+++ b/charts/agent/examples/aws-eks-fargate/rendered/nodeless-otelcollector.yaml
@@ -74,6 +74,8 @@ spec:
             max_elapsed_time: 5m
             max_interval: 30s
           send_metadata: true
+          target_info:
+            enabled: false
           timeout: 10s
       extensions:
         file_storage/fargate:
@@ -170,7 +172,6 @@ spec:
             value: ${env:OBSERVE_CLUSTER_UID}
         resourcedetection/cloud:
           detectors:
-          - eks
           - gcp
           - ecs
           - ec2

--- a/charts/agent/examples/aws-eks-fargate/rendered/prometheus-scraper-configmap.yaml
+++ b/charts/agent/examples/aws-eks-fargate/rendered/prometheus-scraper-configmap.yaml
@@ -48,6 +48,8 @@ data:
             max_elapsed_time: 5m
             max_interval: 30s
           send_metadata: true
+          target_info:
+            enabled: false
           timeout: 10s
       processors:
         attributes/debug_source_cadvisor_metrics:

--- a/charts/agent/examples/aws-eks-fargate/rendered/prometheus-scraper/deployment.yaml
+++ b/charts/agent/examples/aws-eks-fargate/rendered/prometheus-scraper/deployment.yaml
@@ -55,7 +55,7 @@ spec:
             - --feature-gates=+exporter.prometheusremotewritexporter.EnableMultipleWorkers
           securityContext:
             {}
-          image: "observeinc/observe-agent:2.14.0"
+          image: "observeinc/observe-agent:2.15.0"
           imagePullPolicy: IfNotPresent
           ports:
 

--- a/charts/agent/examples/recommended-config/rendered/agent-monitor-configmap.yaml
+++ b/charts/agent/examples/recommended-config/rendered/agent-monitor-configmap.yaml
@@ -48,6 +48,8 @@ data:
             max_elapsed_time: 5m
             max_interval: 30s
           send_metadata: true
+          target_info:
+            enabled: false
           timeout: 10s
       processors:
         attributes/debug_source_agent_monitor:

--- a/charts/agent/examples/recommended-config/rendered/cluster-events-configmap.yaml
+++ b/charts/agent/examples/recommended-config/rendered/cluster-events-configmap.yaml
@@ -188,7 +188,7 @@ data:
             - set(attributes["observe_transform"]["control"]["isDelete"], false) where attributes["observe_transform"]["control"]["isDelete"]
               == nil
             - set(attributes["observe_transform"]["control"]["version"], body["metadata"]["resourceVersion"])
-            - set(attributes["observe_transform"]["control"]["agentVersion"], "2.14.0")
+            - set(attributes["observe_transform"]["control"]["agentVersion"], "2.15.0")
             - set(attributes["observe_transform"]["identifiers"]["clusterName"], resource.attributes["k8s.cluster.name"])
             - set(attributes["observe_transform"]["identifiers"]["clusterUid"], resource.attributes["k8s.cluster.uid"])
             - set(attributes["observe_transform"]["identifiers"]["kind"], body["kind"])

--- a/charts/agent/examples/recommended-config/rendered/cluster-events/deployment.yaml
+++ b/charts/agent/examples/recommended-config/rendered/cluster-events/deployment.yaml
@@ -54,7 +54,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "observeinc/observe-agent:2.14.0"
+          image: "observeinc/observe-agent:2.15.0"
           imagePullPolicy: IfNotPresent
           ports:
 

--- a/charts/agent/examples/recommended-config/rendered/cluster-metrics-configmap.yaml
+++ b/charts/agent/examples/recommended-config/rendered/cluster-metrics-configmap.yaml
@@ -48,6 +48,8 @@ data:
             max_elapsed_time: 5m
             max_interval: 30s
           send_metadata: true
+          target_info:
+            enabled: false
           timeout: 10s
       processors:
         attributes/debug_source_cluster_metrics:

--- a/charts/agent/examples/recommended-config/rendered/cluster-metrics/deployment.yaml
+++ b/charts/agent/examples/recommended-config/rendered/cluster-metrics/deployment.yaml
@@ -55,7 +55,7 @@ spec:
             - --feature-gates=+exporter.prometheusremotewritexporter.EnableMultipleWorkers
           securityContext:
             {}
-          image: "observeinc/observe-agent:2.14.0"
+          image: "observeinc/observe-agent:2.15.0"
           imagePullPolicy: IfNotPresent
           ports:
 

--- a/charts/agent/examples/recommended-config/rendered/forwarder/daemonset.yaml
+++ b/charts/agent/examples/recommended-config/rendered/forwarder/daemonset.yaml
@@ -53,7 +53,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "observeinc/observe-agent:2.14.0"
+          image: "observeinc/observe-agent:2.15.0"
           imagePullPolicy: IfNotPresent
           ports:
 

--- a/charts/agent/examples/recommended-config/rendered/gateway/deployment.yaml
+++ b/charts/agent/examples/recommended-config/rendered/gateway/deployment.yaml
@@ -54,7 +54,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "observeinc/observe-agent:2.14.0"
+          image: "observeinc/observe-agent:2.15.0"
           imagePullPolicy: IfNotPresent
           ports:
 

--- a/charts/agent/examples/recommended-config/rendered/monitor/deployment.yaml
+++ b/charts/agent/examples/recommended-config/rendered/monitor/deployment.yaml
@@ -55,7 +55,7 @@ spec:
             - --feature-gates=+exporter.prometheusremotewritexporter.EnableMultipleWorkers
           securityContext:
             {}
-          image: "observeinc/observe-agent:2.14.0"
+          image: "observeinc/observe-agent:2.15.0"
           imagePullPolicy: IfNotPresent
           ports:
 

--- a/charts/agent/examples/recommended-config/rendered/node-logs-metrics-configmap.yaml
+++ b/charts/agent/examples/recommended-config/rendered/node-logs-metrics-configmap.yaml
@@ -67,6 +67,8 @@ data:
             max_elapsed_time: 5m
             max_interval: 30s
           send_metadata: true
+          target_info:
+            enabled: false
           timeout: 10s
       extensions:
         file_storage:

--- a/charts/agent/examples/recommended-config/rendered/node-logs-metrics/daemonset.yaml
+++ b/charts/agent/examples/recommended-config/rendered/node-logs-metrics/daemonset.yaml
@@ -55,7 +55,7 @@ spec:
           securityContext:
             runAsGroup: 0
             runAsUser: 0
-          image: "observeinc/observe-agent:2.14.0"
+          image: "observeinc/observe-agent:2.15.0"
           imagePullPolicy: IfNotPresent
           ports:
 

--- a/charts/agent/examples/recommended-config/rendered/prometheus-scraper-configmap.yaml
+++ b/charts/agent/examples/recommended-config/rendered/prometheus-scraper-configmap.yaml
@@ -48,6 +48,8 @@ data:
             max_elapsed_time: 5m
             max_interval: 30s
           send_metadata: true
+          target_info:
+            enabled: false
           timeout: 10s
       processors:
         attributes/debug_source_cadvisor_metrics:

--- a/charts/agent/examples/recommended-config/rendered/prometheus-scraper/deployment.yaml
+++ b/charts/agent/examples/recommended-config/rendered/prometheus-scraper/deployment.yaml
@@ -55,7 +55,7 @@ spec:
             - --feature-gates=+exporter.prometheusremotewritexporter.EnableMultipleWorkers
           securityContext:
             {}
-          image: "observeinc/observe-agent:2.14.0"
+          image: "observeinc/observe-agent:2.15.0"
           imagePullPolicy: IfNotPresent
           ports:
 

--- a/charts/agent/templates/_config-exporters.tpl
+++ b/charts/agent/templates/_config-exporters.tpl
@@ -143,6 +143,8 @@ prometheusremotewrite/observe:
   resource_to_telemetry_conversion:
     enabled: true # Convert resource attributes to metric labels
   send_metadata: true
+  target_info:
+    enabled: {{ .Values.agent.config.global.exporters.emitPrometheusTargetInfoMetrics }}
   retry_on_failure:
     enabled: {{ .Values.agent.config.global.exporters.retryOnFailure.enabled }}
     initial_interval: {{ .Values.agent.config.global.exporters.retryOnFailure.initialInterval }}

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -261,6 +261,7 @@ agent:
           # Maximum amount of time (including retries) spent trying to send a logs batch to a downstream consumer. Once this value is reached, the data is discarded. Retrying never stops if set to 0.
           maxElapsedTime: 5m
         timeout: 10s
+        emitPrometheusTargetInfoMetrics: false
       service:
         telemetry:
           metricsLevel: normal


### PR DESCRIPTION
Observe doesn't use the value, so we can ignore by default.

Replaces: #488 