### PR TITLE
fix: add a compatability transform processor to handle both deployment.environment.name and deployment.environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ __pycache__
 
 local*
 integration/source
+
+# tooling
+.snowflake/cortex/plans

--- a/Makefile
+++ b/Makefile
@@ -130,4 +130,4 @@ generate-examples:
 			done; \
 		done; \
 	done; \
-	find charts/*/examples -type f -name '*.yaml' -exec perl -pi -e 's/\s+$$/\n/' {} +
+	find charts/*/examples -type f -name '*.yaml' -exec perl -0777 -i -pe 's/[ \t]+$$//mg; s/\s+\z/\n/' {} +

--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent
 description: Chart to install K8s collection stack based on Observe Agent
 type: application
-version: 0.88.2
+version: 0.88.3
 appVersion: "2.16.0"
 dependencies:
   - name: opentelemetry-collector

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -1,6 +1,6 @@
 # agent
 
-![Version: 0.88.2](https://img.shields.io/badge/Version-0.88.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.16.0](https://img.shields.io/badge/AppVersion-2.16.0-informational?style=flat-square)
+![Version: 0.88.3](https://img.shields.io/badge/Version-0.88.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.16.0](https://img.shields.io/badge/AppVersion-2.16.0-informational?style=flat-square)
 
 Chart to install K8s collection stack based on Observe Agent
 

--- a/charts/agent/examples/aws-eks-fargate/rendered/forwarder-configmap.yaml
+++ b/charts/agent/examples/aws-eks-fargate/rendered/forwarder-configmap.yaml
@@ -131,6 +131,29 @@ data:
           - azure
           override: false
           timeout: 2s
+        transform/deployment_environment_compatability:
+          error_mode: ignore
+          log_statements:
+          - set(resource.attributes["deployment.environment.name"], resource.attributes["deployment.environment"])
+            where resource.attributes["deployment.environment.name"] == nil and resource.attributes["deployment.environment"]
+            != nil
+          - set(resource.attributes["deployment.environment"], resource.attributes["deployment.environment.name"])
+            where resource.attributes["deployment.environment"] == nil and resource.attributes["deployment.environment.name"]
+            != nil
+          metric_statements:
+          - set(resource.attributes["deployment.environment.name"], resource.attributes["deployment.environment"])
+            where resource.attributes["deployment.environment.name"] == nil and resource.attributes["deployment.environment"]
+            != nil
+          - set(resource.attributes["deployment.environment"], resource.attributes["deployment.environment.name"])
+            where resource.attributes["deployment.environment"] == nil and resource.attributes["deployment.environment.name"]
+            != nil
+          trace_statements:
+          - set(resource.attributes["deployment.environment.name"], resource.attributes["deployment.environment"])
+            where resource.attributes["deployment.environment.name"] == nil and resource.attributes["deployment.environment"]
+            != nil
+          - set(resource.attributes["deployment.environment"], resource.attributes["deployment.environment.name"])
+            where resource.attributes["deployment.environment"] == nil and resource.attributes["deployment.environment.name"]
+            != nil
         transform/k8sheartbeat:
           error_mode: ignore
           log_statements:

--- a/charts/agent/examples/aws-eks-fargate/rendered/gateway-configmap.yaml
+++ b/charts/agent/examples/aws-eks-fargate/rendered/gateway-configmap.yaml
@@ -245,6 +245,29 @@ data:
           - set(span.attributes["observe.status_code"], Int(span.attributes["http.response.status_code"]))
             where span.attributes["observe.status_code"] == nil and span.attributes["http.response.status_code"]
             != nil
+        transform/deployment_environment_compatability:
+          error_mode: ignore
+          log_statements:
+          - set(resource.attributes["deployment.environment.name"], resource.attributes["deployment.environment"])
+            where resource.attributes["deployment.environment.name"] == nil and resource.attributes["deployment.environment"]
+            != nil
+          - set(resource.attributes["deployment.environment"], resource.attributes["deployment.environment.name"])
+            where resource.attributes["deployment.environment"] == nil and resource.attributes["deployment.environment.name"]
+            != nil
+          metric_statements:
+          - set(resource.attributes["deployment.environment.name"], resource.attributes["deployment.environment"])
+            where resource.attributes["deployment.environment.name"] == nil and resource.attributes["deployment.environment"]
+            != nil
+          - set(resource.attributes["deployment.environment"], resource.attributes["deployment.environment.name"])
+            where resource.attributes["deployment.environment"] == nil and resource.attributes["deployment.environment.name"]
+            != nil
+          trace_statements:
+          - set(resource.attributes["deployment.environment.name"], resource.attributes["deployment.environment"])
+            where resource.attributes["deployment.environment.name"] == nil and resource.attributes["deployment.environment"]
+            != nil
+          - set(resource.attributes["deployment.environment"], resource.attributes["deployment.environment.name"])
+            where resource.attributes["deployment.environment"] == nil and resource.attributes["deployment.environment.name"]
+            != nil
         transform/fix_peer_attributes:
           error_mode: ignore
           metric_statements:
@@ -337,6 +360,7 @@ data:
             - memory_limiter
             - k8sattributes
             - resource/observe_common
+            - transform/deployment_environment_compatability
             - attributes/debug_source_gateway
             receivers:
             - otlp/app-telemetry
@@ -348,6 +372,7 @@ data:
             - k8sattributes
             - cumulativetodelta/observe
             - resource/observe_common
+            - transform/deployment_environment_compatability
             - attributes/debug_source_gateway
             receivers:
             - otlp/app-telemetry
@@ -375,6 +400,7 @@ data:
             - attributes/debug_source_gateway
             - tail_sampling/observe
             - resource/observe_common
+            - transform/deployment_environment_compatability
             receivers:
             - otlp/app-telemetry
           traces/spanmetrics:

--- a/charts/agent/examples/aws-eks-fargate/rendered/prometheus-scraper-configmap.yaml
+++ b/charts/agent/examples/aws-eks-fargate/rendered/prometheus-scraper-configmap.yaml
@@ -134,6 +134,29 @@ data:
           - system
           override: false
           timeout: 2s
+        transform/deployment_environment_compatability:
+          error_mode: ignore
+          log_statements:
+          - set(resource.attributes["deployment.environment.name"], resource.attributes["deployment.environment"])
+            where resource.attributes["deployment.environment.name"] == nil and resource.attributes["deployment.environment"]
+            != nil
+          - set(resource.attributes["deployment.environment"], resource.attributes["deployment.environment.name"])
+            where resource.attributes["deployment.environment"] == nil and resource.attributes["deployment.environment.name"]
+            != nil
+          metric_statements:
+          - set(resource.attributes["deployment.environment.name"], resource.attributes["deployment.environment"])
+            where resource.attributes["deployment.environment.name"] == nil and resource.attributes["deployment.environment"]
+            != nil
+          - set(resource.attributes["deployment.environment"], resource.attributes["deployment.environment.name"])
+            where resource.attributes["deployment.environment"] == nil and resource.attributes["deployment.environment.name"]
+            != nil
+          trace_statements:
+          - set(resource.attributes["deployment.environment.name"], resource.attributes["deployment.environment"])
+            where resource.attributes["deployment.environment.name"] == nil and resource.attributes["deployment.environment"]
+            != nil
+          - set(resource.attributes["deployment.environment"], resource.attributes["deployment.environment.name"])
+            where resource.attributes["deployment.environment"] == nil and resource.attributes["deployment.environment.name"]
+            != nil
         transform/k8sheartbeat:
           error_mode: ignore
           log_statements:
@@ -296,6 +319,7 @@ data:
             - resource/drop_service_name
             - k8sattributes
             - resource/observe_common
+            - transform/deployment_environment_compatability
             - attributes/debug_source_pod_metrics
             receivers:
             - prometheus/pod_metrics

--- a/charts/agent/examples/recommended-config/rendered/forwarder-configmap.yaml
+++ b/charts/agent/examples/recommended-config/rendered/forwarder-configmap.yaml
@@ -132,6 +132,29 @@ data:
           - azure
           override: false
           timeout: 2s
+        transform/deployment_environment_compatability:
+          error_mode: ignore
+          log_statements:
+          - set(resource.attributes["deployment.environment.name"], resource.attributes["deployment.environment"])
+            where resource.attributes["deployment.environment.name"] == nil and resource.attributes["deployment.environment"]
+            != nil
+          - set(resource.attributes["deployment.environment"], resource.attributes["deployment.environment.name"])
+            where resource.attributes["deployment.environment"] == nil and resource.attributes["deployment.environment.name"]
+            != nil
+          metric_statements:
+          - set(resource.attributes["deployment.environment.name"], resource.attributes["deployment.environment"])
+            where resource.attributes["deployment.environment.name"] == nil and resource.attributes["deployment.environment"]
+            != nil
+          - set(resource.attributes["deployment.environment"], resource.attributes["deployment.environment.name"])
+            where resource.attributes["deployment.environment"] == nil and resource.attributes["deployment.environment.name"]
+            != nil
+          trace_statements:
+          - set(resource.attributes["deployment.environment.name"], resource.attributes["deployment.environment"])
+            where resource.attributes["deployment.environment.name"] == nil and resource.attributes["deployment.environment"]
+            != nil
+          - set(resource.attributes["deployment.environment"], resource.attributes["deployment.environment.name"])
+            where resource.attributes["deployment.environment"] == nil and resource.attributes["deployment.environment.name"]
+            != nil
         transform/k8sheartbeat:
           error_mode: ignore
           log_statements:

--- a/charts/agent/examples/recommended-config/rendered/gateway-configmap.yaml
+++ b/charts/agent/examples/recommended-config/rendered/gateway-configmap.yaml
@@ -246,6 +246,29 @@ data:
           - set(span.attributes["observe.status_code"], Int(span.attributes["http.response.status_code"]))
             where span.attributes["observe.status_code"] == nil and span.attributes["http.response.status_code"]
             != nil
+        transform/deployment_environment_compatability:
+          error_mode: ignore
+          log_statements:
+          - set(resource.attributes["deployment.environment.name"], resource.attributes["deployment.environment"])
+            where resource.attributes["deployment.environment.name"] == nil and resource.attributes["deployment.environment"]
+            != nil
+          - set(resource.attributes["deployment.environment"], resource.attributes["deployment.environment.name"])
+            where resource.attributes["deployment.environment"] == nil and resource.attributes["deployment.environment.name"]
+            != nil
+          metric_statements:
+          - set(resource.attributes["deployment.environment.name"], resource.attributes["deployment.environment"])
+            where resource.attributes["deployment.environment.name"] == nil and resource.attributes["deployment.environment"]
+            != nil
+          - set(resource.attributes["deployment.environment"], resource.attributes["deployment.environment.name"])
+            where resource.attributes["deployment.environment"] == nil and resource.attributes["deployment.environment.name"]
+            != nil
+          trace_statements:
+          - set(resource.attributes["deployment.environment.name"], resource.attributes["deployment.environment"])
+            where resource.attributes["deployment.environment.name"] == nil and resource.attributes["deployment.environment"]
+            != nil
+          - set(resource.attributes["deployment.environment"], resource.attributes["deployment.environment.name"])
+            where resource.attributes["deployment.environment"] == nil and resource.attributes["deployment.environment.name"]
+            != nil
         transform/fix_peer_attributes:
           error_mode: ignore
           metric_statements:
@@ -338,6 +361,7 @@ data:
             - memory_limiter
             - k8sattributes
             - resource/observe_common
+            - transform/deployment_environment_compatability
             - attributes/debug_source_gateway
             receivers:
             - otlp/app-telemetry
@@ -349,6 +373,7 @@ data:
             - k8sattributes
             - cumulativetodelta/observe
             - resource/observe_common
+            - transform/deployment_environment_compatability
             - attributes/debug_source_gateway
             receivers:
             - otlp/app-telemetry
@@ -376,6 +401,7 @@ data:
             - attributes/debug_source_gateway
             - tail_sampling/observe
             - resource/observe_common
+            - transform/deployment_environment_compatability
             receivers:
             - otlp/app-telemetry
           traces/spanmetrics:

--- a/charts/agent/examples/recommended-config/rendered/prometheus-scraper-configmap.yaml
+++ b/charts/agent/examples/recommended-config/rendered/prometheus-scraper-configmap.yaml
@@ -134,6 +134,29 @@ data:
           - system
           override: false
           timeout: 2s
+        transform/deployment_environment_compatability:
+          error_mode: ignore
+          log_statements:
+          - set(resource.attributes["deployment.environment.name"], resource.attributes["deployment.environment"])
+            where resource.attributes["deployment.environment.name"] == nil and resource.attributes["deployment.environment"]
+            != nil
+          - set(resource.attributes["deployment.environment"], resource.attributes["deployment.environment.name"])
+            where resource.attributes["deployment.environment"] == nil and resource.attributes["deployment.environment.name"]
+            != nil
+          metric_statements:
+          - set(resource.attributes["deployment.environment.name"], resource.attributes["deployment.environment"])
+            where resource.attributes["deployment.environment.name"] == nil and resource.attributes["deployment.environment"]
+            != nil
+          - set(resource.attributes["deployment.environment"], resource.attributes["deployment.environment.name"])
+            where resource.attributes["deployment.environment"] == nil and resource.attributes["deployment.environment.name"]
+            != nil
+          trace_statements:
+          - set(resource.attributes["deployment.environment.name"], resource.attributes["deployment.environment"])
+            where resource.attributes["deployment.environment.name"] == nil and resource.attributes["deployment.environment"]
+            != nil
+          - set(resource.attributes["deployment.environment"], resource.attributes["deployment.environment.name"])
+            where resource.attributes["deployment.environment"] == nil and resource.attributes["deployment.environment.name"]
+            != nil
         transform/k8sheartbeat:
           error_mode: ignore
           log_statements:
@@ -296,6 +319,7 @@ data:
             - resource/drop_service_name
             - k8sattributes
             - resource/observe_common
+            - transform/deployment_environment_compatability
             - attributes/debug_source_pod_metrics
             receivers:
             - prometheus/pod_metrics

--- a/charts/agent/templates/_cluster-metrics-config.tpl
+++ b/charts/agent/templates/_cluster-metrics-config.tpl
@@ -48,6 +48,7 @@ processors:
 {{- include "config.processors.resource.observe_common" . | nindent 2 }}
 
 {{- if $podMetrics }}
+{{- include "config.processors.transform.deployment_environment_compatibility" . | nindent 2 }}
 {{- include "config.processors.attributes.pod_metrics" . | nindent 2 }}
 {{- include "config.processors.attributes.cadvisor_metrics" . | nindent 2 }}
 {{- end }}

--- a/charts/agent/templates/_config-pipelines.tpl
+++ b/charts/agent/templates/_config-pipelines.tpl
@@ -53,6 +53,9 @@ metrics/pod_metrics:
     - batch
     {{- end }}
     - resource/observe_common
+    {{- if not .Values.cluster.deploymentEnvironment.name }}
+    - transform/deployment_environment_compatability
+    {{- end }}
     - attributes/debug_source_pod_metrics
   exporters:
     - prometheusremotewrite/observe

--- a/charts/agent/templates/_config-processors.tpl
+++ b/charts/agent/templates/_config-processors.tpl
@@ -101,6 +101,9 @@ resource/observe_common:
     - key: deployment.environment.name
       action: upsert
       value: {{ .Values.cluster.deploymentEnvironment.name }}
+    - key: deployment.environment
+      action: upsert
+      value: {{ .Values.cluster.deploymentEnvironment.name }}
     {{ end }}
 {{- end -}}
 
@@ -270,6 +273,28 @@ resource/add_empty_service_attributes:
         - action: insert
           key: deployment.environment
           value: ""
+{{- end -}}
+
+{{- define "config.processors.transform.deployment_environment_compatibility" -}}
+{{- if not .Values.cluster.deploymentEnvironment.name }}
+transform/deployment_environment_compatability:
+  error_mode: ignore
+  trace_statements:
+    # deployment.environment.name = coalesce(deployment.environment.name, deployment.environment)
+    - set(resource.attributes["deployment.environment.name"], resource.attributes["deployment.environment"]) where resource.attributes["deployment.environment.name"] == nil and resource.attributes["deployment.environment"] != nil
+    # deployment.environment = coalesce(deployment.environment, deployment.environment.name)
+    - set(resource.attributes["deployment.environment"], resource.attributes["deployment.environment.name"]) where resource.attributes["deployment.environment"] == nil and resource.attributes["deployment.environment.name"] != nil
+  log_statements:
+    # deployment.environment.name = coalesce(deployment.environment.name, deployment.environment)
+    - set(resource.attributes["deployment.environment.name"], resource.attributes["deployment.environment"]) where resource.attributes["deployment.environment.name"] == nil and resource.attributes["deployment.environment"] != nil
+    # deployment.environment = coalesce(deployment.environment, deployment.environment.name)
+    - set(resource.attributes["deployment.environment"], resource.attributes["deployment.environment.name"]) where resource.attributes["deployment.environment"] == nil and resource.attributes["deployment.environment.name"] != nil
+  metric_statements:
+    # deployment.environment.name = coalesce(deployment.environment.name, deployment.environment)
+    - set(resource.attributes["deployment.environment.name"], resource.attributes["deployment.environment"]) where resource.attributes["deployment.environment.name"] == nil and resource.attributes["deployment.environment"] != nil
+    # deployment.environment = coalesce(deployment.environment, deployment.environment.name)
+    - set(resource.attributes["deployment.environment"], resource.attributes["deployment.environment.name"]) where resource.attributes["deployment.environment"] == nil and resource.attributes["deployment.environment.name"] != nil
+{{- end }}
 {{- end -}}
 
 {{- define "config.processors.transform.add_span_status_code" -}}

--- a/charts/agent/templates/_forwarder-config.tpl
+++ b/charts/agent/templates/_forwarder-config.tpl
@@ -58,6 +58,7 @@ processors:
 {{- include "config.processors.resource_detection.cloud" . | nindent 2 }}
 {{- include "config.processors.filter.drop_long_spans" . | nindent 2 }}
 {{- include "config.processors.resource.observe_common" . | nindent 2 }}
+{{- include "config.processors.transform.deployment_environment_compatibility" . | nindent 2 }}
 
 {{- if .Values.gatewayDeployment.enabled }}
   # Use passthrough mode to reduce forwarder compute and push the lookup to the gateway whenever it is enabled.
@@ -156,7 +157,11 @@ processors:
   {{- if not .Values.agent.config.global.exporters.sendingQueue.batch.enabled }}
   {{- $metricsProcessors = concat $metricsProcessors (list "batch") }}
   {{- end }}
-  {{- $metricsProcessors = concat $metricsProcessors (list "resourcedetection/cloud" "resource/observe_common" "attributes/debug_source_app_metrics") }}
+  {{- $metricsProcessors = concat $metricsProcessors (list "resourcedetection/cloud" "resource/observe_common") }}
+  {{- if not .Values.cluster.deploymentEnvironment.name }}
+    {{- $metricsProcessors = concat $metricsProcessors (list "transform/deployment_environment_compatability") }}
+  {{- end }}
+  {{- $metricsProcessors = concat $metricsProcessors (list "attributes/debug_source_app_metrics") }}
 {{- end }}
 
 service:
@@ -181,6 +186,9 @@ service:
         - resourcedetection/cloud
         {{- if not .Values.gatewayDeployment.enabled }}
         - resource/observe_common
+        {{- if not .Values.cluster.deploymentEnvironment.name }}
+        - transform/deployment_environment_compatability
+        {{- end }}
         - attributes/debug_source_app_traces
         {{- end }}
       exporters: [{{ join ", " $traceExporters }}]
@@ -199,6 +207,9 @@ service:
         - resourcedetection/cloud
         {{- if not .Values.gatewayDeployment.enabled }}
         - resource/observe_common
+        {{- if not .Values.cluster.deploymentEnvironment.name }}
+        - transform/deployment_environment_compatability
+        {{- end }}
         - attributes/debug_source_app_logs
         {{- end }}
       exporters: [{{ join ", " $logsExporters }}]

--- a/charts/agent/templates/_gateway-config.tpl
+++ b/charts/agent/templates/_gateway-config.tpl
@@ -37,6 +37,7 @@ processors:
 {{- include "config.processors.attributes.k8sattributes" . | nindent 2 }}
 {{- include "config.processors.deltatocumulative" . | nindent 2 }}
 {{- include "config.processors.resource.observe_common" . | nindent 2 }}
+{{- include "config.processors.transform.deployment_environment_compatibility" . | nindent 2 }}
 {{- include "config.processors.filter.drop_long_spans" . | nindent 2 }}
 {{- include "config.processors.transform.add_span_status_code" . | nindent 2 }}
 {{- include "config.processors.attributes.add_empty_service_attributes" . | nindent 2 }}
@@ -102,6 +103,9 @@ service:
         - batch
         {{- end }}
         - resource/observe_common
+        {{- if not .Values.cluster.deploymentEnvironment.name }}
+        - transform/deployment_environment_compatability
+        {{- end }}
       exporters: [{{ join ", " $traceExporters }}]
     logs/observe-forward:
       receivers: [otlp/app-telemetry]
@@ -112,6 +116,9 @@ service:
         - batch
         {{- end }}
         - resource/observe_common
+        {{- if not .Values.cluster.deploymentEnvironment.name }}
+        - transform/deployment_environment_compatability
+        {{- end }}
         - attributes/debug_source_gateway
       exporters: [{{ join ", " $logsExporters }}]
     metrics/observe-forward:
@@ -129,6 +136,9 @@ service:
         - batch
         {{- end }}
         - resource/observe_common
+        {{- if not .Values.cluster.deploymentEnvironment.name }}
+        - transform/deployment_environment_compatability
+        {{- end }}
         - attributes/debug_source_gateway
       exporters: [{{ join ", " $metricsExporters }}]
     {{- if .Values.application.REDMetrics.enabled }}

--- a/charts/agent/templates/_prometheus-scraper-config.tpl
+++ b/charts/agent/templates/_prometheus-scraper-config.tpl
@@ -30,6 +30,7 @@ processors:
   {{- include "config.processors.batch" . | nindent 2 }}
   {{- include "config.processors.attributes.k8sattributes" . | nindent 2 }}
   {{- include "config.processors.resource.observe_common" . | nindent 2 }}
+  {{- include "config.processors.transform.deployment_environment_compatibility" . | nindent 2 }}
   {{- include "config.processors.attributes.pod_metrics" . | nindent 2 }}
   {{- include "config.processors.attributes.cadvisor_metrics" . | nindent 2 }}
   {{- include "config.processors.attributes.drop_service_name" . | nindent 2 }}


### PR DESCRIPTION
This will act as a stopgap to handle multiple semantic conventions simultaneously until the new Observe tag feature is fully adopted.