### PR TITLE
fix: use startsWith for chore-skip gate in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, 'chore')"
+    if: "!startsWith(github.event.head_commit.message, 'chore')"
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
The current gate matches "chore" anywhere in the commit message. For squash-merges, that body includes every squashed commit's subject, so a non-chore PR can be incorrectly skipped if any of its squashed commits started with `chore:`.

For example, the current gate skipped #505's release([run](https://github.com/observeinc/helm-charts/actions/runs/26652468322)) even though the merge commit's subject starts with `feat:`. `startsWith` only checks the first line (the subject), which is what the gate is actually filtering on.