### PR TITLE
feat: expose target allocator metrics to the agent monitor

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent
 description: Chart to install K8s collection stack based on Observe Agent
 type: application
-version: 0.91.3
+version: 0.91.4
 appVersion: "2.16.0"
 dependencies:
   - name: opentelemetry-collector

--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent
 description: Chart to install K8s collection stack based on Observe Agent
 type: application
-version: 0.91.4
+version: 0.92.0
 appVersion: "2.16.0"
 dependencies:
   - name: opentelemetry-collector

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -1,6 +1,6 @@
 # agent
 
-![Version: 0.91.4](https://img.shields.io/badge/Version-0.91.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.16.0](https://img.shields.io/badge/AppVersion-2.16.0-informational?style=flat-square)
+![Version: 0.92.0](https://img.shields.io/badge/Version-0.92.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.16.0](https://img.shields.io/badge/AppVersion-2.16.0-informational?style=flat-square)
 
 Chart to install K8s collection stack based on Observe Agent
 

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -1,6 +1,6 @@
 # agent
 
-![Version: 0.91.3](https://img.shields.io/badge/Version-0.91.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.16.0](https://img.shields.io/badge/AppVersion-2.16.0-informational?style=flat-square)
+![Version: 0.91.4](https://img.shields.io/badge/Version-0.91.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.16.0](https://img.shields.io/badge/AppVersion-2.16.0-informational?style=flat-square)
 
 Chart to install K8s collection stack based on Observe Agent
 
@@ -754,6 +754,10 @@ This service is an *OpenTelemetryCollector*, a custom resource that is managed b
 | prometheus-ta.configMap.create | bool | `false` |  |
 | prometheus-ta.configMap.existingName | string | `"prometheus-ta"` |  |
 | prometheus-ta.namespaceOverride | string | `"observe"` |  |
+| prometheus-ta.targetAllocator.podAnnotations.observe_monitor_path | string | `"/metrics"` |  |
+| prometheus-ta.targetAllocator.podAnnotations.observe_monitor_port | string | `"8080"` |  |
+| prometheus-ta.targetAllocator.podAnnotations.observe_monitor_purpose | string | `"observecollection"` |  |
+| prometheus-ta.targetAllocator.podAnnotations.observe_monitor_scrape | string | `"true"` |  |
 | prometheus-ta.targetAllocator.resources.limits.memory | string | `"256Mi"` |  |
 | prometheus-ta.targetAllocator.resources.requests.cpu | string | `"50m"` |  |
 | prometheus-ta.targetAllocator.resources.requests.memory | string | `"256Mi"` |  |

--- a/charts/agent/examples/prometheus-ta-cr-discovery/rendered/prometheus-ta/deployment.yaml
+++ b/charts/agent/examples/prometheus-ta-cr-discovery/rendered/prometheus-ta/deployment.yaml
@@ -22,6 +22,10 @@ spec:
     metadata:
       annotations:
         checksum/config: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+        observe_monitor_path: /metrics
+        observe_monitor_port: "8080"
+        observe_monitor_purpose: observecollection
+        observe_monitor_scrape: "true"
       labels:
         helm.sh/chart: prometheus-ta-0.128.1
         app.kubernetes.io/managed-by: Helm

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/prometheus-ta/deployment.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/prometheus-ta/deployment.yaml
@@ -22,6 +22,10 @@ spec:
     metadata:
       annotations:
         checksum/config: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+        observe_monitor_path: /metrics
+        observe_monitor_port: "8080"
+        observe_monitor_purpose: observecollection
+        observe_monitor_scrape: "true"
       labels:
         helm.sh/chart: prometheus-ta-0.128.1
         app.kubernetes.io/managed-by: Helm

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -682,6 +682,16 @@ prometheus-ta:
     create: false
     existingName: "prometheus-ta"
   targetAllocator:
+    # Expose the target allocator's own metrics (opentelemetry_allocator_*:
+    # targets, collectors_allocatable, targets_per_collector, time_to_allocate)
+    # to the agent monitor. The monitor discovers pods carrying these annotations
+    # and scrapes the TA on its :8080 /metrics endpoint, giving direct visibility
+    # into TA target distribution and shard balance.
+    podAnnotations:
+      observe_monitor_purpose: observecollection
+      observe_monitor_scrape: "true"
+      observe_monitor_path: /metrics
+      observe_monitor_port: "8080"
     resources:
       requests:
         cpu: 50m

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -683,10 +683,10 @@ prometheus-ta:
     existingName: "prometheus-ta"
   targetAllocator:
     # Expose the target allocator's own metrics (opentelemetry_allocator_*:
-    # targets, collectors_allocatable, targets_per_collector, time_to_allocate)
-    # to the agent monitor. The monitor discovers pods carrying these annotations
-    # and scrapes the TA on its :8080 /metrics endpoint, giving direct visibility
-    # into TA target distribution and shard balance.
+    # targets, collectors_allocatable, targets_per_collector, time_to_allocate).
+    # The agent monitor discovers pods carrying these annotations and scrapes the
+    # TA on its :8080 /metrics endpoint, giving visibility into target
+    # distribution and shard balance.
     podAnnotations:
       observe_monitor_purpose: observecollection
       observe_monitor_scrape: "true"


### PR DESCRIPTION
## What
Expose the Target Allocator's own metrics to Observe.

## Why
The TA serves `opentelemetry_allocator_*` metrics (`targets`, `collectors_allocatable`, `targets_per_collector`, `time_to_allocate`) on `:8080/metrics`, but nothing scraped them. These give visibility into target distribution and shard balance.

## How
Add `observe_monitor_*` pod annotations to `prometheus-ta.targetAllocator`. The agent monitor already discovers and scrapes any pod carrying these annotations — the same mechanism `prometheus-scraper` uses for its own `:8888` metrics — so this just enrolls the TA pod into that pipeline.

Resources stay at the upstream 256Mi default; cluster-specific sizing remains an operator override.

## Test
- `helm lint charts/agent` passes
- Rendered examples confirm the annotations land on the TA pod
