### PR TITLE
feat(deps): bump opentelemetry-collector subchart from 0.143.0 to 0.159.0

### DIFF
--- a/charts/agent/Chart.lock
+++ b/charts/agent/Chart.lock
@@ -1,27 +1,27 @@
 dependencies:
 - name: opentelemetry-collector
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
-  version: 0.143.0
+  version: 0.159.0
 - name: opentelemetry-collector
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
-  version: 0.143.0
+  version: 0.159.0
 - name: opentelemetry-collector
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
-  version: 0.143.0
+  version: 0.159.0
 - name: opentelemetry-target-allocator
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
   version: 0.128.1
 - name: opentelemetry-collector
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
-  version: 0.143.0
+  version: 0.159.0
 - name: opentelemetry-collector
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
-  version: 0.143.0
+  version: 0.159.0
 - name: opentelemetry-collector
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
-  version: 0.143.0
+  version: 0.159.0
 - name: opentelemetry-collector
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
-  version: 0.143.0
-digest: sha256:fa72eb07ef5502b8aef5e22b69e03a736f19ee8ea2abfee6c8ed2c12f36199e3
-generated: "2026-06-04T17:48:18.505714-07:00"
+  version: 0.159.0
+digest: sha256:e17c76f5413d89cc4ef73fe0a1428c2c2af97b6672429f3c4b2bb11e990823d1
+generated: "2026-06-24T13:20:17.767586-07:00"

--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -2,21 +2,21 @@ apiVersion: v2
 name: agent
 description: Chart to install K8s collection stack based on Observe Agent
 type: application
-version: 0.92.2
+version: 0.93.0
 appVersion: "2.16.0"
 dependencies:
   - name: opentelemetry-collector
-    version: 0.143.0
+    version: 0.159.0
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
     alias: cluster-events
     condition: cluster.events.enabled
   - name: opentelemetry-collector
-    version: 0.143.0
+    version: 0.159.0
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
     alias: cluster-metrics
     condition: cluster.metrics.enabled
   - name: opentelemetry-collector
-    version: 0.143.0
+    version: 0.159.0
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
     alias: prometheus-scraper
     condition: application.prometheusScrape.independentDeployment
@@ -29,22 +29,22 @@ dependencies:
     alias: prometheus-ta
     condition: application.prometheusScrape.targetAllocator.enabled
   - name: opentelemetry-collector
-    version: 0.143.0
+    version: 0.159.0
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
     alias: node-logs-metrics
     condition: node.enabled
   - name: opentelemetry-collector
-    version: 0.143.0
+    version: 0.159.0
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
     alias: monitor
     condition: agent.selfMonitor.enabled
   - name: opentelemetry-collector
-    version: 0.143.0
+    version: 0.159.0
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
     alias: forwarder
     condition: node.forwarder.enabled
   - name: opentelemetry-collector
-    version: 0.143.0
+    version: 0.159.0
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
     alias: gateway
     condition: gatewayDeployment.enabled

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -1,6 +1,6 @@
 # agent
 
-![Version: 0.92.2](https://img.shields.io/badge/Version-0.92.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.16.0](https://img.shields.io/badge/AppVersion-2.16.0-informational?style=flat-square)
+![Version: 0.93.0](https://img.shields.io/badge/Version-0.93.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.16.0](https://img.shields.io/badge/AppVersion-2.16.0-informational?style=flat-square)
 
 Chart to install K8s collection stack based on Observe Agent
 
@@ -44,13 +44,13 @@ This service is an *OpenTelemetryCollector*, a custom resource that is managed b
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://open-telemetry.github.io/opentelemetry-helm-charts | cluster-events(opentelemetry-collector) | 0.143.0 |
-| https://open-telemetry.github.io/opentelemetry-helm-charts | cluster-metrics(opentelemetry-collector) | 0.143.0 |
-| https://open-telemetry.github.io/opentelemetry-helm-charts | prometheus-scraper(opentelemetry-collector) | 0.143.0 |
-| https://open-telemetry.github.io/opentelemetry-helm-charts | node-logs-metrics(opentelemetry-collector) | 0.143.0 |
-| https://open-telemetry.github.io/opentelemetry-helm-charts | monitor(opentelemetry-collector) | 0.143.0 |
-| https://open-telemetry.github.io/opentelemetry-helm-charts | forwarder(opentelemetry-collector) | 0.143.0 |
-| https://open-telemetry.github.io/opentelemetry-helm-charts | gateway(opentelemetry-collector) | 0.143.0 |
+| https://open-telemetry.github.io/opentelemetry-helm-charts | cluster-events(opentelemetry-collector) | 0.159.0 |
+| https://open-telemetry.github.io/opentelemetry-helm-charts | cluster-metrics(opentelemetry-collector) | 0.159.0 |
+| https://open-telemetry.github.io/opentelemetry-helm-charts | prometheus-scraper(opentelemetry-collector) | 0.159.0 |
+| https://open-telemetry.github.io/opentelemetry-helm-charts | node-logs-metrics(opentelemetry-collector) | 0.159.0 |
+| https://open-telemetry.github.io/opentelemetry-helm-charts | monitor(opentelemetry-collector) | 0.159.0 |
+| https://open-telemetry.github.io/opentelemetry-helm-charts | forwarder(opentelemetry-collector) | 0.159.0 |
+| https://open-telemetry.github.io/opentelemetry-helm-charts | gateway(opentelemetry-collector) | 0.159.0 |
 | https://open-telemetry.github.io/opentelemetry-helm-charts | prometheus-ta(opentelemetry-target-allocator) | 0.128.1 |
 
 ## Values
@@ -131,22 +131,16 @@ This service is an *OpenTelemetryCollector*, a custom resource that is managed b
 | cluster-events.extraEnvsFrom | list | `[]` |  |
 | cluster-events.extraEnvs[0].name | string | `"OTEL_K8S_POD_UID"` |  |
 | cluster-events.extraEnvs[0].valueFrom.fieldRef.fieldPath | string | `"metadata.uid"` |  |
-| cluster-events.extraEnvs[1].name | string | `"OTEL_K8S_POD_NAME"` |  |
-| cluster-events.extraEnvs[1].valueFrom.fieldRef.apiVersion | string | `"v1"` |  |
-| cluster-events.extraEnvs[1].valueFrom.fieldRef.fieldPath | string | `"metadata.name"` |  |
-| cluster-events.extraEnvs[2].name | string | `"OTEL_K8S_POD_IP"` |  |
-| cluster-events.extraEnvs[2].valueFrom.fieldRef.apiVersion | string | `"v1"` |  |
-| cluster-events.extraEnvs[2].valueFrom.fieldRef.fieldPath | string | `"status.podIP"` |  |
-| cluster-events.extraEnvs[3].name | string | `"OBSERVE_CLUSTER_NAME"` |  |
-| cluster-events.extraEnvs[3].valueFrom.configMapKeyRef.key | string | `"name"` |  |
-| cluster-events.extraEnvs[3].valueFrom.configMapKeyRef.name | string | `"cluster-name"` |  |
-| cluster-events.extraEnvs[4].name | string | `"OBSERVE_CLUSTER_UID"` |  |
-| cluster-events.extraEnvs[4].valueFrom.configMapKeyRef.key | string | `"id"` |  |
-| cluster-events.extraEnvs[4].valueFrom.configMapKeyRef.name | string | `"cluster-info"` |  |
-| cluster-events.extraEnvs[5].name | string | `"TOKEN"` |  |
-| cluster-events.extraEnvs[5].valueFrom.secretKeyRef.key | string | `"OBSERVE_TOKEN"` |  |
-| cluster-events.extraEnvs[5].valueFrom.secretKeyRef.name | string | `"agent-credentials"` |  |
-| cluster-events.extraEnvs[5].valueFrom.secretKeyRef.optional | bool | `true` |  |
+| cluster-events.extraEnvs[1].name | string | `"OBSERVE_CLUSTER_NAME"` |  |
+| cluster-events.extraEnvs[1].valueFrom.configMapKeyRef.key | string | `"name"` |  |
+| cluster-events.extraEnvs[1].valueFrom.configMapKeyRef.name | string | `"cluster-name"` |  |
+| cluster-events.extraEnvs[2].name | string | `"OBSERVE_CLUSTER_UID"` |  |
+| cluster-events.extraEnvs[2].valueFrom.configMapKeyRef.key | string | `"id"` |  |
+| cluster-events.extraEnvs[2].valueFrom.configMapKeyRef.name | string | `"cluster-info"` |  |
+| cluster-events.extraEnvs[3].name | string | `"TOKEN"` |  |
+| cluster-events.extraEnvs[3].valueFrom.secretKeyRef.key | string | `"OBSERVE_TOKEN"` |  |
+| cluster-events.extraEnvs[3].valueFrom.secretKeyRef.name | string | `"agent-credentials"` |  |
+| cluster-events.extraEnvs[3].valueFrom.secretKeyRef.optional | bool | `true` |  |
 | cluster-events.extraVolumeMounts[0].mountPath | string | `"/observe-agent-conf"` |  |
 | cluster-events.extraVolumeMounts[0].name | string | `"observe-agent-deployment-config"` |  |
 | cluster-events.extraVolumes[0].configMap.defaultMode | int | `420` |  |
@@ -205,22 +199,16 @@ This service is an *OpenTelemetryCollector*, a custom resource that is managed b
 | cluster-metrics.extraEnvsFrom | list | `[]` |  |
 | cluster-metrics.extraEnvs[0].name | string | `"OTEL_K8S_POD_UID"` |  |
 | cluster-metrics.extraEnvs[0].valueFrom.fieldRef.fieldPath | string | `"metadata.uid"` |  |
-| cluster-metrics.extraEnvs[1].name | string | `"OTEL_K8S_POD_NAME"` |  |
-| cluster-metrics.extraEnvs[1].valueFrom.fieldRef.apiVersion | string | `"v1"` |  |
-| cluster-metrics.extraEnvs[1].valueFrom.fieldRef.fieldPath | string | `"metadata.name"` |  |
-| cluster-metrics.extraEnvs[2].name | string | `"OTEL_K8S_POD_IP"` |  |
-| cluster-metrics.extraEnvs[2].valueFrom.fieldRef.apiVersion | string | `"v1"` |  |
-| cluster-metrics.extraEnvs[2].valueFrom.fieldRef.fieldPath | string | `"status.podIP"` |  |
-| cluster-metrics.extraEnvs[3].name | string | `"OBSERVE_CLUSTER_NAME"` |  |
-| cluster-metrics.extraEnvs[3].valueFrom.configMapKeyRef.key | string | `"name"` |  |
-| cluster-metrics.extraEnvs[3].valueFrom.configMapKeyRef.name | string | `"cluster-name"` |  |
-| cluster-metrics.extraEnvs[4].name | string | `"OBSERVE_CLUSTER_UID"` |  |
-| cluster-metrics.extraEnvs[4].valueFrom.configMapKeyRef.key | string | `"id"` |  |
-| cluster-metrics.extraEnvs[4].valueFrom.configMapKeyRef.name | string | `"cluster-info"` |  |
-| cluster-metrics.extraEnvs[5].name | string | `"TOKEN"` |  |
-| cluster-metrics.extraEnvs[5].valueFrom.secretKeyRef.key | string | `"OBSERVE_TOKEN"` |  |
-| cluster-metrics.extraEnvs[5].valueFrom.secretKeyRef.name | string | `"agent-credentials"` |  |
-| cluster-metrics.extraEnvs[5].valueFrom.secretKeyRef.optional | bool | `true` |  |
+| cluster-metrics.extraEnvs[1].name | string | `"OBSERVE_CLUSTER_NAME"` |  |
+| cluster-metrics.extraEnvs[1].valueFrom.configMapKeyRef.key | string | `"name"` |  |
+| cluster-metrics.extraEnvs[1].valueFrom.configMapKeyRef.name | string | `"cluster-name"` |  |
+| cluster-metrics.extraEnvs[2].name | string | `"OBSERVE_CLUSTER_UID"` |  |
+| cluster-metrics.extraEnvs[2].valueFrom.configMapKeyRef.key | string | `"id"` |  |
+| cluster-metrics.extraEnvs[2].valueFrom.configMapKeyRef.name | string | `"cluster-info"` |  |
+| cluster-metrics.extraEnvs[3].name | string | `"TOKEN"` |  |
+| cluster-metrics.extraEnvs[3].valueFrom.secretKeyRef.key | string | `"OBSERVE_TOKEN"` |  |
+| cluster-metrics.extraEnvs[3].valueFrom.secretKeyRef.name | string | `"agent-credentials"` |  |
+| cluster-metrics.extraEnvs[3].valueFrom.secretKeyRef.optional | bool | `true` |  |
 | cluster-metrics.extraVolumeMounts[0].mountPath | string | `"/observe-agent-conf"` |  |
 | cluster-metrics.extraVolumeMounts[0].name | string | `"observe-agent-deployment-config"` |  |
 | cluster-metrics.extraVolumes[0].configMap.defaultMode | int | `420` |  |
@@ -290,28 +278,22 @@ This service is an *OpenTelemetryCollector*, a custom resource that is managed b
 | forwarder.extraEnvsFrom | list | `[]` |  |
 | forwarder.extraEnvs[0].name | string | `"OTEL_K8S_POD_UID"` |  |
 | forwarder.extraEnvs[0].valueFrom.fieldRef.fieldPath | string | `"metadata.uid"` |  |
-| forwarder.extraEnvs[1].name | string | `"OTEL_K8S_POD_NAME"` |  |
-| forwarder.extraEnvs[1].valueFrom.fieldRef.apiVersion | string | `"v1"` |  |
-| forwarder.extraEnvs[1].valueFrom.fieldRef.fieldPath | string | `"metadata.name"` |  |
-| forwarder.extraEnvs[2].name | string | `"OTEL_K8S_POD_IP"` |  |
-| forwarder.extraEnvs[2].valueFrom.fieldRef.apiVersion | string | `"v1"` |  |
-| forwarder.extraEnvs[2].valueFrom.fieldRef.fieldPath | string | `"status.podIP"` |  |
-| forwarder.extraEnvs[3].name | string | `"OBSERVE_CLUSTER_NAME"` |  |
-| forwarder.extraEnvs[3].valueFrom.configMapKeyRef.key | string | `"name"` |  |
-| forwarder.extraEnvs[3].valueFrom.configMapKeyRef.name | string | `"cluster-name"` |  |
-| forwarder.extraEnvs[4].name | string | `"OBSERVE_CLUSTER_UID"` |  |
-| forwarder.extraEnvs[4].valueFrom.configMapKeyRef.key | string | `"id"` |  |
-| forwarder.extraEnvs[4].valueFrom.configMapKeyRef.name | string | `"cluster-info"` |  |
-| forwarder.extraEnvs[5].name | string | `"K8S_NODE_NAME"` |  |
-| forwarder.extraEnvs[5].valueFrom.fieldRef.fieldPath | string | `"spec.nodeName"` |  |
-| forwarder.extraEnvs[6].name | string | `"TOKEN"` |  |
-| forwarder.extraEnvs[6].valueFrom.secretKeyRef.key | string | `"OBSERVE_TOKEN"` |  |
-| forwarder.extraEnvs[6].valueFrom.secretKeyRef.name | string | `"agent-credentials"` |  |
-| forwarder.extraEnvs[6].valueFrom.secretKeyRef.optional | bool | `true` |  |
-| forwarder.extraEnvs[7].name | string | `"TRACE_TOKEN"` |  |
-| forwarder.extraEnvs[7].valueFrom.secretKeyRef.key | string | `"TRACE_TOKEN"` |  |
-| forwarder.extraEnvs[7].valueFrom.secretKeyRef.name | string | `"agent-credentials"` |  |
-| forwarder.extraEnvs[7].valueFrom.secretKeyRef.optional | bool | `true` |  |
+| forwarder.extraEnvs[1].name | string | `"OBSERVE_CLUSTER_NAME"` |  |
+| forwarder.extraEnvs[1].valueFrom.configMapKeyRef.key | string | `"name"` |  |
+| forwarder.extraEnvs[1].valueFrom.configMapKeyRef.name | string | `"cluster-name"` |  |
+| forwarder.extraEnvs[2].name | string | `"OBSERVE_CLUSTER_UID"` |  |
+| forwarder.extraEnvs[2].valueFrom.configMapKeyRef.key | string | `"id"` |  |
+| forwarder.extraEnvs[2].valueFrom.configMapKeyRef.name | string | `"cluster-info"` |  |
+| forwarder.extraEnvs[3].name | string | `"K8S_NODE_NAME"` |  |
+| forwarder.extraEnvs[3].valueFrom.fieldRef.fieldPath | string | `"spec.nodeName"` |  |
+| forwarder.extraEnvs[4].name | string | `"TOKEN"` |  |
+| forwarder.extraEnvs[4].valueFrom.secretKeyRef.key | string | `"OBSERVE_TOKEN"` |  |
+| forwarder.extraEnvs[4].valueFrom.secretKeyRef.name | string | `"agent-credentials"` |  |
+| forwarder.extraEnvs[4].valueFrom.secretKeyRef.optional | bool | `true` |  |
+| forwarder.extraEnvs[5].name | string | `"TRACE_TOKEN"` |  |
+| forwarder.extraEnvs[5].valueFrom.secretKeyRef.key | string | `"TRACE_TOKEN"` |  |
+| forwarder.extraEnvs[5].valueFrom.secretKeyRef.name | string | `"agent-credentials"` |  |
+| forwarder.extraEnvs[5].valueFrom.secretKeyRef.optional | bool | `true` |  |
 | forwarder.extraVolumeMounts[0].mountPath | string | `"/observe-agent-conf"` |  |
 | forwarder.extraVolumeMounts[0].name | string | `"observe-agent-deployment-config"` |  |
 | forwarder.extraVolumes[0].configMap.defaultMode | int | `420` |  |
@@ -373,24 +355,18 @@ This service is an *OpenTelemetryCollector*, a custom resource that is managed b
 | gateway.extraEnvsFrom | list | `[]` |  |
 | gateway.extraEnvs[0].name | string | `"OTEL_K8S_POD_UID"` |  |
 | gateway.extraEnvs[0].valueFrom.fieldRef.fieldPath | string | `"metadata.uid"` |  |
-| gateway.extraEnvs[1].name | string | `"OTEL_K8S_POD_NAME"` |  |
-| gateway.extraEnvs[1].valueFrom.fieldRef.apiVersion | string | `"v1"` |  |
-| gateway.extraEnvs[1].valueFrom.fieldRef.fieldPath | string | `"metadata.name"` |  |
-| gateway.extraEnvs[2].name | string | `"OTEL_K8S_POD_IP"` |  |
-| gateway.extraEnvs[2].valueFrom.fieldRef.apiVersion | string | `"v1"` |  |
-| gateway.extraEnvs[2].valueFrom.fieldRef.fieldPath | string | `"status.podIP"` |  |
-| gateway.extraEnvs[3].name | string | `"OBSERVE_CLUSTER_NAME"` |  |
-| gateway.extraEnvs[3].valueFrom.configMapKeyRef.key | string | `"name"` |  |
-| gateway.extraEnvs[3].valueFrom.configMapKeyRef.name | string | `"cluster-name"` |  |
-| gateway.extraEnvs[4].name | string | `"OBSERVE_CLUSTER_UID"` |  |
-| gateway.extraEnvs[4].valueFrom.configMapKeyRef.key | string | `"id"` |  |
-| gateway.extraEnvs[4].valueFrom.configMapKeyRef.name | string | `"cluster-info"` |  |
-| gateway.extraEnvs[5].name | string | `"K8S_NODE_NAME"` |  |
-| gateway.extraEnvs[5].valueFrom.fieldRef.fieldPath | string | `"spec.nodeName"` |  |
-| gateway.extraEnvs[6].name | string | `"TOKEN"` |  |
-| gateway.extraEnvs[6].valueFrom.secretKeyRef.key | string | `"OBSERVE_TOKEN"` |  |
-| gateway.extraEnvs[6].valueFrom.secretKeyRef.name | string | `"agent-credentials"` |  |
-| gateway.extraEnvs[6].valueFrom.secretKeyRef.optional | bool | `true` |  |
+| gateway.extraEnvs[1].name | string | `"OBSERVE_CLUSTER_NAME"` |  |
+| gateway.extraEnvs[1].valueFrom.configMapKeyRef.key | string | `"name"` |  |
+| gateway.extraEnvs[1].valueFrom.configMapKeyRef.name | string | `"cluster-name"` |  |
+| gateway.extraEnvs[2].name | string | `"OBSERVE_CLUSTER_UID"` |  |
+| gateway.extraEnvs[2].valueFrom.configMapKeyRef.key | string | `"id"` |  |
+| gateway.extraEnvs[2].valueFrom.configMapKeyRef.name | string | `"cluster-info"` |  |
+| gateway.extraEnvs[3].name | string | `"K8S_NODE_NAME"` |  |
+| gateway.extraEnvs[3].valueFrom.fieldRef.fieldPath | string | `"spec.nodeName"` |  |
+| gateway.extraEnvs[4].name | string | `"TOKEN"` |  |
+| gateway.extraEnvs[4].valueFrom.secretKeyRef.key | string | `"OBSERVE_TOKEN"` |  |
+| gateway.extraEnvs[4].valueFrom.secretKeyRef.name | string | `"agent-credentials"` |  |
+| gateway.extraEnvs[4].valueFrom.secretKeyRef.optional | bool | `true` |  |
 | gateway.extraVolumeMounts[0].mountPath | string | `"/observe-agent-conf"` |  |
 | gateway.extraVolumeMounts[0].name | string | `"observe-agent-deployment-config"` |  |
 | gateway.extraVolumes[0].configMap.defaultMode | int | `420` |  |
@@ -458,22 +434,16 @@ This service is an *OpenTelemetryCollector*, a custom resource that is managed b
 | monitor.extraEnvsFrom | list | `[]` |  |
 | monitor.extraEnvs[0].name | string | `"OTEL_K8S_POD_UID"` |  |
 | monitor.extraEnvs[0].valueFrom.fieldRef.fieldPath | string | `"metadata.uid"` |  |
-| monitor.extraEnvs[1].name | string | `"OTEL_K8S_POD_NAME"` |  |
-| monitor.extraEnvs[1].valueFrom.fieldRef.apiVersion | string | `"v1"` |  |
-| monitor.extraEnvs[1].valueFrom.fieldRef.fieldPath | string | `"metadata.name"` |  |
-| monitor.extraEnvs[2].name | string | `"OTEL_K8S_POD_IP"` |  |
-| monitor.extraEnvs[2].valueFrom.fieldRef.apiVersion | string | `"v1"` |  |
-| monitor.extraEnvs[2].valueFrom.fieldRef.fieldPath | string | `"status.podIP"` |  |
-| monitor.extraEnvs[3].name | string | `"OBSERVE_CLUSTER_NAME"` |  |
-| monitor.extraEnvs[3].valueFrom.configMapKeyRef.key | string | `"name"` |  |
-| monitor.extraEnvs[3].valueFrom.configMapKeyRef.name | string | `"cluster-name"` |  |
-| monitor.extraEnvs[4].name | string | `"OBSERVE_CLUSTER_UID"` |  |
-| monitor.extraEnvs[4].valueFrom.configMapKeyRef.key | string | `"id"` |  |
-| monitor.extraEnvs[4].valueFrom.configMapKeyRef.name | string | `"cluster-info"` |  |
-| monitor.extraEnvs[5].name | string | `"TOKEN"` |  |
-| monitor.extraEnvs[5].valueFrom.secretKeyRef.key | string | `"OBSERVE_TOKEN"` |  |
-| monitor.extraEnvs[5].valueFrom.secretKeyRef.name | string | `"agent-credentials"` |  |
-| monitor.extraEnvs[5].valueFrom.secretKeyRef.optional | bool | `true` |  |
+| monitor.extraEnvs[1].name | string | `"OBSERVE_CLUSTER_NAME"` |  |
+| monitor.extraEnvs[1].valueFrom.configMapKeyRef.key | string | `"name"` |  |
+| monitor.extraEnvs[1].valueFrom.configMapKeyRef.name | string | `"cluster-name"` |  |
+| monitor.extraEnvs[2].name | string | `"OBSERVE_CLUSTER_UID"` |  |
+| monitor.extraEnvs[2].valueFrom.configMapKeyRef.key | string | `"id"` |  |
+| monitor.extraEnvs[2].valueFrom.configMapKeyRef.name | string | `"cluster-info"` |  |
+| monitor.extraEnvs[3].name | string | `"TOKEN"` |  |
+| monitor.extraEnvs[3].valueFrom.secretKeyRef.key | string | `"OBSERVE_TOKEN"` |  |
+| monitor.extraEnvs[3].valueFrom.secretKeyRef.name | string | `"agent-credentials"` |  |
+| monitor.extraEnvs[3].valueFrom.secretKeyRef.optional | bool | `true` |  |
 | monitor.extraVolumeMounts[0].mountPath | string | `"/observe-agent-conf"` |  |
 | monitor.extraVolumeMounts[0].name | string | `"observe-agent-deployment-config"` |  |
 | monitor.extraVolumes[0].configMap.defaultMode | int | `420` |  |
@@ -532,30 +502,24 @@ This service is an *OpenTelemetryCollector*, a custom resource that is managed b
 | node-logs-metrics.extraEnvsFrom | list | `[]` |  |
 | node-logs-metrics.extraEnvs[0].name | string | `"OTEL_K8S_POD_UID"` |  |
 | node-logs-metrics.extraEnvs[0].valueFrom.fieldRef.fieldPath | string | `"metadata.uid"` |  |
-| node-logs-metrics.extraEnvs[1].name | string | `"OTEL_K8S_POD_NAME"` |  |
-| node-logs-metrics.extraEnvs[1].valueFrom.fieldRef.apiVersion | string | `"v1"` |  |
-| node-logs-metrics.extraEnvs[1].valueFrom.fieldRef.fieldPath | string | `"metadata.name"` |  |
-| node-logs-metrics.extraEnvs[2].name | string | `"OTEL_K8S_POD_IP"` |  |
-| node-logs-metrics.extraEnvs[2].valueFrom.fieldRef.apiVersion | string | `"v1"` |  |
-| node-logs-metrics.extraEnvs[2].valueFrom.fieldRef.fieldPath | string | `"status.podIP"` |  |
-| node-logs-metrics.extraEnvs[3].name | string | `"OBSERVE_CLUSTER_NAME"` |  |
-| node-logs-metrics.extraEnvs[3].valueFrom.configMapKeyRef.key | string | `"name"` |  |
-| node-logs-metrics.extraEnvs[3].valueFrom.configMapKeyRef.name | string | `"cluster-name"` |  |
-| node-logs-metrics.extraEnvs[4].name | string | `"OBSERVE_CLUSTER_UID"` |  |
-| node-logs-metrics.extraEnvs[4].valueFrom.configMapKeyRef.key | string | `"id"` |  |
-| node-logs-metrics.extraEnvs[4].valueFrom.configMapKeyRef.name | string | `"cluster-info"` |  |
-| node-logs-metrics.extraEnvs[5].name | string | `"K8S_NODE_NAME"` |  |
-| node-logs-metrics.extraEnvs[5].valueFrom.fieldRef.fieldPath | string | `"spec.nodeName"` |  |
-| node-logs-metrics.extraEnvs[6].name | string | `"K8S_NODE_IP"` |  |
-| node-logs-metrics.extraEnvs[6].valueFrom.fieldRef.fieldPath | string | `"status.hostIP"` |  |
-| node-logs-metrics.extraEnvs[7].name | string | `"TOKEN"` |  |
-| node-logs-metrics.extraEnvs[7].valueFrom.secretKeyRef.key | string | `"OBSERVE_TOKEN"` |  |
-| node-logs-metrics.extraEnvs[7].valueFrom.secretKeyRef.name | string | `"agent-credentials"` |  |
-| node-logs-metrics.extraEnvs[7].valueFrom.secretKeyRef.optional | bool | `true` |  |
-| node-logs-metrics.extraEnvs[8].name | string | `"TRACES_TOKEN"` |  |
-| node-logs-metrics.extraEnvs[8].valueFrom.secretKeyRef.key | string | `"TRACES_TOKEN"` |  |
-| node-logs-metrics.extraEnvs[8].valueFrom.secretKeyRef.name | string | `"agent-credentials"` |  |
-| node-logs-metrics.extraEnvs[8].valueFrom.secretKeyRef.optional | bool | `true` |  |
+| node-logs-metrics.extraEnvs[1].name | string | `"OBSERVE_CLUSTER_NAME"` |  |
+| node-logs-metrics.extraEnvs[1].valueFrom.configMapKeyRef.key | string | `"name"` |  |
+| node-logs-metrics.extraEnvs[1].valueFrom.configMapKeyRef.name | string | `"cluster-name"` |  |
+| node-logs-metrics.extraEnvs[2].name | string | `"OBSERVE_CLUSTER_UID"` |  |
+| node-logs-metrics.extraEnvs[2].valueFrom.configMapKeyRef.key | string | `"id"` |  |
+| node-logs-metrics.extraEnvs[2].valueFrom.configMapKeyRef.name | string | `"cluster-info"` |  |
+| node-logs-metrics.extraEnvs[3].name | string | `"K8S_NODE_NAME"` |  |
+| node-logs-metrics.extraEnvs[3].valueFrom.fieldRef.fieldPath | string | `"spec.nodeName"` |  |
+| node-logs-metrics.extraEnvs[4].name | string | `"K8S_NODE_IP"` |  |
+| node-logs-metrics.extraEnvs[4].valueFrom.fieldRef.fieldPath | string | `"status.hostIP"` |  |
+| node-logs-metrics.extraEnvs[5].name | string | `"TOKEN"` |  |
+| node-logs-metrics.extraEnvs[5].valueFrom.secretKeyRef.key | string | `"OBSERVE_TOKEN"` |  |
+| node-logs-metrics.extraEnvs[5].valueFrom.secretKeyRef.name | string | `"agent-credentials"` |  |
+| node-logs-metrics.extraEnvs[5].valueFrom.secretKeyRef.optional | bool | `true` |  |
+| node-logs-metrics.extraEnvs[6].name | string | `"TRACES_TOKEN"` |  |
+| node-logs-metrics.extraEnvs[6].valueFrom.secretKeyRef.key | string | `"TRACES_TOKEN"` |  |
+| node-logs-metrics.extraEnvs[6].valueFrom.secretKeyRef.name | string | `"agent-credentials"` |  |
+| node-logs-metrics.extraEnvs[6].valueFrom.secretKeyRef.optional | bool | `true` |  |
 | node-logs-metrics.extraVolumeMounts[0].mountPath | string | `"/observe-agent-conf"` |  |
 | node-logs-metrics.extraVolumeMounts[0].name | string | `"observe-agent-deployment-config"` |  |
 | node-logs-metrics.extraVolumeMounts[1].mountPath | string | `"/var/log/pods"` |  |
@@ -694,22 +658,16 @@ This service is an *OpenTelemetryCollector*, a custom resource that is managed b
 | prometheus-scraper.extraEnvsFrom | list | `[]` |  |
 | prometheus-scraper.extraEnvs[0].name | string | `"OTEL_K8S_POD_UID"` |  |
 | prometheus-scraper.extraEnvs[0].valueFrom.fieldRef.fieldPath | string | `"metadata.uid"` |  |
-| prometheus-scraper.extraEnvs[1].name | string | `"OTEL_K8S_POD_NAME"` |  |
-| prometheus-scraper.extraEnvs[1].valueFrom.fieldRef.apiVersion | string | `"v1"` |  |
-| prometheus-scraper.extraEnvs[1].valueFrom.fieldRef.fieldPath | string | `"metadata.name"` |  |
-| prometheus-scraper.extraEnvs[2].name | string | `"OTEL_K8S_POD_IP"` |  |
-| prometheus-scraper.extraEnvs[2].valueFrom.fieldRef.apiVersion | string | `"v1"` |  |
-| prometheus-scraper.extraEnvs[2].valueFrom.fieldRef.fieldPath | string | `"status.podIP"` |  |
-| prometheus-scraper.extraEnvs[3].name | string | `"OBSERVE_CLUSTER_NAME"` |  |
-| prometheus-scraper.extraEnvs[3].valueFrom.configMapKeyRef.key | string | `"name"` |  |
-| prometheus-scraper.extraEnvs[3].valueFrom.configMapKeyRef.name | string | `"cluster-name"` |  |
-| prometheus-scraper.extraEnvs[4].name | string | `"OBSERVE_CLUSTER_UID"` |  |
-| prometheus-scraper.extraEnvs[4].valueFrom.configMapKeyRef.key | string | `"id"` |  |
-| prometheus-scraper.extraEnvs[4].valueFrom.configMapKeyRef.name | string | `"cluster-info"` |  |
-| prometheus-scraper.extraEnvs[5].name | string | `"TOKEN"` |  |
-| prometheus-scraper.extraEnvs[5].valueFrom.secretKeyRef.key | string | `"OBSERVE_TOKEN"` |  |
-| prometheus-scraper.extraEnvs[5].valueFrom.secretKeyRef.name | string | `"agent-credentials"` |  |
-| prometheus-scraper.extraEnvs[5].valueFrom.secretKeyRef.optional | bool | `true` |  |
+| prometheus-scraper.extraEnvs[1].name | string | `"OBSERVE_CLUSTER_NAME"` |  |
+| prometheus-scraper.extraEnvs[1].valueFrom.configMapKeyRef.key | string | `"name"` |  |
+| prometheus-scraper.extraEnvs[1].valueFrom.configMapKeyRef.name | string | `"cluster-name"` |  |
+| prometheus-scraper.extraEnvs[2].name | string | `"OBSERVE_CLUSTER_UID"` |  |
+| prometheus-scraper.extraEnvs[2].valueFrom.configMapKeyRef.key | string | `"id"` |  |
+| prometheus-scraper.extraEnvs[2].valueFrom.configMapKeyRef.name | string | `"cluster-info"` |  |
+| prometheus-scraper.extraEnvs[3].name | string | `"TOKEN"` |  |
+| prometheus-scraper.extraEnvs[3].valueFrom.secretKeyRef.key | string | `"OBSERVE_TOKEN"` |  |
+| prometheus-scraper.extraEnvs[3].valueFrom.secretKeyRef.name | string | `"agent-credentials"` |  |
+| prometheus-scraper.extraEnvs[3].valueFrom.secretKeyRef.optional | bool | `true` |  |
 | prometheus-scraper.extraVolumeMounts[0].mountPath | string | `"/observe-agent-conf"` |  |
 | prometheus-scraper.extraVolumeMounts[0].name | string | `"observe-agent-deployment-config"` |  |
 | prometheus-scraper.extraVolumes[0].configMap.defaultMode | int | `420` |  |

--- a/charts/agent/examples/aws-eks-fargate/rendered/cluster-events/deployment.yaml
+++ b/charts/agent/examples/aws-eks-fargate/rendered/cluster-events/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-cluster-events
   namespace: observe
   labels:
-    helm.sh/chart: cluster-events-0.143.0
+    helm.sh/chart: cluster-events-0.159.0
     app.kubernetes.io/name: cluster-events
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector
@@ -85,12 +85,19 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
-            - name: GOMEMLIMIT
-              value: "204MiB"
-            - name: OTEL_K8S_POD_UID
+            - name: OTEL_K8S_NODE_NAME
               valueFrom:
                 fieldRef:
-                  fieldPath: metadata.uid
+                  fieldPath: spec.nodeName
+            - name: OTEL_K8S_NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: OTEL_K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
             - name: OTEL_K8S_POD_NAME
               valueFrom:
                 fieldRef:
@@ -101,6 +108,12 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
+            - name: GOMEMLIMIT
+              value: "204MiB"
+            - name: OTEL_K8S_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
             - name: OBSERVE_CLUSTER_NAME
               valueFrom:
                 configMapKeyRef:
@@ -149,6 +162,7 @@ spec:
           image: observeinc/kube-cluster-info:v0.11.6
           imagePullPolicy: Always
           name: kube-cluster-info
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: cluster-events-configmap
           configMap:
@@ -175,3 +189,4 @@ spec:
                 values:
                 - windows
       hostNetwork: false
+      hostPID: false

--- a/charts/agent/examples/aws-eks-fargate/rendered/cluster-events/networkpolicy.yaml
+++ b/charts/agent/examples/aws-eks-fargate/rendered/cluster-events/networkpolicy.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-cluster-events
   namespace: observe
   labels:
-    helm.sh/chart: cluster-events-0.143.0
+    helm.sh/chart: cluster-events-0.159.0
     app.kubernetes.io/name: cluster-events
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector

--- a/charts/agent/examples/aws-eks-fargate/rendered/cluster-events/service.yaml
+++ b/charts/agent/examples/aws-eks-fargate/rendered/cluster-events/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-cluster-events
   namespace: observe
   labels:
-    helm.sh/chart: cluster-events-0.143.0
+    helm.sh/chart: cluster-events-0.159.0
     app.kubernetes.io/name: cluster-events
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector

--- a/charts/agent/examples/aws-eks-fargate/rendered/cluster-metrics/deployment.yaml
+++ b/charts/agent/examples/aws-eks-fargate/rendered/cluster-metrics/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-cluster-metrics
   namespace: observe
   labels:
-    helm.sh/chart: cluster-metrics-0.143.0
+    helm.sh/chart: cluster-metrics-0.159.0
     app.kubernetes.io/name: cluster-metrics
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector
@@ -86,12 +86,19 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
-            - name: GOMEMLIMIT
-              value: "409MiB"
-            - name: OTEL_K8S_POD_UID
+            - name: OTEL_K8S_NODE_NAME
               valueFrom:
                 fieldRef:
-                  fieldPath: metadata.uid
+                  fieldPath: spec.nodeName
+            - name: OTEL_K8S_NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: OTEL_K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
             - name: OTEL_K8S_POD_NAME
               valueFrom:
                 fieldRef:
@@ -102,6 +109,12 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
+            - name: GOMEMLIMIT
+              value: "409MiB"
+            - name: OTEL_K8S_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
             - name: OBSERVE_CLUSTER_NAME
               valueFrom:
                 configMapKeyRef:
@@ -150,6 +163,7 @@ spec:
           image: observeinc/kube-cluster-info:v0.11.6
           imagePullPolicy: Always
           name: kube-cluster-info
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: cluster-metrics-configmap
           configMap:
@@ -176,3 +190,4 @@ spec:
                 values:
                 - windows
       hostNetwork: false
+      hostPID: false

--- a/charts/agent/examples/aws-eks-fargate/rendered/cluster-metrics/networkpolicy.yaml
+++ b/charts/agent/examples/aws-eks-fargate/rendered/cluster-metrics/networkpolicy.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-cluster-metrics
   namespace: observe
   labels:
-    helm.sh/chart: cluster-metrics-0.143.0
+    helm.sh/chart: cluster-metrics-0.159.0
     app.kubernetes.io/name: cluster-metrics
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector

--- a/charts/agent/examples/aws-eks-fargate/rendered/cluster-metrics/service.yaml
+++ b/charts/agent/examples/aws-eks-fargate/rendered/cluster-metrics/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-cluster-metrics
   namespace: observe
   labels:
-    helm.sh/chart: cluster-metrics-0.143.0
+    helm.sh/chart: cluster-metrics-0.159.0
     app.kubernetes.io/name: cluster-metrics
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector

--- a/charts/agent/examples/aws-eks-fargate/rendered/forwarder/deployment.yaml
+++ b/charts/agent/examples/aws-eks-fargate/rendered/forwarder/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-forwarder
   namespace: observe
   labels:
-    helm.sh/chart: forwarder-0.143.0
+    helm.sh/chart: forwarder-0.159.0
     app.kubernetes.io/name: forwarder
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector
@@ -86,12 +86,19 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
-            - name: GOMEMLIMIT
-              value: "409MiB"
-            - name: OTEL_K8S_POD_UID
+            - name: OTEL_K8S_NODE_NAME
               valueFrom:
                 fieldRef:
-                  fieldPath: metadata.uid
+                  fieldPath: spec.nodeName
+            - name: OTEL_K8S_NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: OTEL_K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
             - name: OTEL_K8S_POD_NAME
               valueFrom:
                 fieldRef:
@@ -102,6 +109,12 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
+            - name: GOMEMLIMIT
+              value: "409MiB"
+            - name: OTEL_K8S_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
             - name: OBSERVE_CLUSTER_NAME
               valueFrom:
                 configMapKeyRef:
@@ -160,6 +173,7 @@ spec:
           image: observeinc/kube-cluster-info:v0.11.6
           imagePullPolicy: Always
           name: kube-cluster-info
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: forwarder-configmap
           configMap:
@@ -186,3 +200,4 @@ spec:
                 values:
                 - windows
       hostNetwork: false
+      hostPID: false

--- a/charts/agent/examples/aws-eks-fargate/rendered/forwarder/networkpolicy.yaml
+++ b/charts/agent/examples/aws-eks-fargate/rendered/forwarder/networkpolicy.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-forwarder
   namespace: observe
   labels:
-    helm.sh/chart: forwarder-0.143.0
+    helm.sh/chart: forwarder-0.159.0
     app.kubernetes.io/name: forwarder
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector

--- a/charts/agent/examples/aws-eks-fargate/rendered/forwarder/service.yaml
+++ b/charts/agent/examples/aws-eks-fargate/rendered/forwarder/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-forwarder
   namespace: observe
   labels:
-    helm.sh/chart: forwarder-0.143.0
+    helm.sh/chart: forwarder-0.159.0
     app.kubernetes.io/name: forwarder
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector

--- a/charts/agent/examples/aws-eks-fargate/rendered/gateway/deployment.yaml
+++ b/charts/agent/examples/aws-eks-fargate/rendered/gateway/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-gateway
   namespace: observe
   labels:
-    helm.sh/chart: gateway-0.143.0
+    helm.sh/chart: gateway-0.159.0
     app.kubernetes.io/name: gateway
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector
@@ -86,12 +86,19 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
-            - name: GOMEMLIMIT
-              value: "614MiB"
-            - name: OTEL_K8S_POD_UID
+            - name: OTEL_K8S_NODE_NAME
               valueFrom:
                 fieldRef:
-                  fieldPath: metadata.uid
+                  fieldPath: spec.nodeName
+            - name: OTEL_K8S_NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: OTEL_K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
             - name: OTEL_K8S_POD_NAME
               valueFrom:
                 fieldRef:
@@ -102,6 +109,12 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
+            - name: GOMEMLIMIT
+              value: "614MiB"
+            - name: OTEL_K8S_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
             - name: OBSERVE_CLUSTER_NAME
               valueFrom:
                 configMapKeyRef:
@@ -154,6 +167,7 @@ spec:
           image: observeinc/kube-cluster-info:v0.11.6
           imagePullPolicy: Always
           name: kube-cluster-info
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: gateway-configmap
           configMap:
@@ -180,3 +194,4 @@ spec:
                 values:
                 - windows
       hostNetwork: false
+      hostPID: false

--- a/charts/agent/examples/aws-eks-fargate/rendered/gateway/networkpolicy.yaml
+++ b/charts/agent/examples/aws-eks-fargate/rendered/gateway/networkpolicy.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-gateway
   namespace: observe
   labels:
-    helm.sh/chart: gateway-0.143.0
+    helm.sh/chart: gateway-0.159.0
     app.kubernetes.io/name: gateway
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector

--- a/charts/agent/examples/aws-eks-fargate/rendered/gateway/service.yaml
+++ b/charts/agent/examples/aws-eks-fargate/rendered/gateway/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-gateway
   namespace: observe
   labels:
-    helm.sh/chart: gateway-0.143.0
+    helm.sh/chart: gateway-0.159.0
     app.kubernetes.io/name: gateway
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector

--- a/charts/agent/examples/aws-eks-fargate/rendered/monitor/deployment.yaml
+++ b/charts/agent/examples/aws-eks-fargate/rendered/monitor/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-monitor
   namespace: observe
   labels:
-    helm.sh/chart: monitor-0.143.0
+    helm.sh/chart: monitor-0.159.0
     app.kubernetes.io/name: monitor
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector
@@ -86,12 +86,19 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
-            - name: GOMEMLIMIT
-              value: "204MiB"
-            - name: OTEL_K8S_POD_UID
+            - name: OTEL_K8S_NODE_NAME
               valueFrom:
                 fieldRef:
-                  fieldPath: metadata.uid
+                  fieldPath: spec.nodeName
+            - name: OTEL_K8S_NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: OTEL_K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
             - name: OTEL_K8S_POD_NAME
               valueFrom:
                 fieldRef:
@@ -102,6 +109,12 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
+            - name: GOMEMLIMIT
+              value: "204MiB"
+            - name: OTEL_K8S_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
             - name: OBSERVE_CLUSTER_NAME
               valueFrom:
                 configMapKeyRef:
@@ -150,6 +163,7 @@ spec:
           image: observeinc/kube-cluster-info:v0.11.6
           imagePullPolicy: Always
           name: kube-cluster-info
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: monitor-configmap
           configMap:
@@ -176,3 +190,4 @@ spec:
                 values:
                 - windows
       hostNetwork: false
+      hostPID: false

--- a/charts/agent/examples/aws-eks-fargate/rendered/monitor/networkpolicy.yaml
+++ b/charts/agent/examples/aws-eks-fargate/rendered/monitor/networkpolicy.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-monitor
   namespace: observe
   labels:
-    helm.sh/chart: monitor-0.143.0
+    helm.sh/chart: monitor-0.159.0
     app.kubernetes.io/name: monitor
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector

--- a/charts/agent/examples/aws-eks-fargate/rendered/monitor/service.yaml
+++ b/charts/agent/examples/aws-eks-fargate/rendered/monitor/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-monitor
   namespace: observe
   labels:
-    helm.sh/chart: monitor-0.143.0
+    helm.sh/chart: monitor-0.159.0
     app.kubernetes.io/name: monitor
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector

--- a/charts/agent/examples/aws-eks-fargate/rendered/prometheus-scraper/deployment.yaml
+++ b/charts/agent/examples/aws-eks-fargate/rendered/prometheus-scraper/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-prometheus-scraper
   namespace: observe
   labels:
-    helm.sh/chart: prometheus-scraper-0.143.0
+    helm.sh/chart: prometheus-scraper-0.159.0
     app.kubernetes.io/name: prometheus-scraper
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector
@@ -86,12 +86,19 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
-            - name: GOMEMLIMIT
-              value: "409MiB"
-            - name: OTEL_K8S_POD_UID
+            - name: OTEL_K8S_NODE_NAME
               valueFrom:
                 fieldRef:
-                  fieldPath: metadata.uid
+                  fieldPath: spec.nodeName
+            - name: OTEL_K8S_NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: OTEL_K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
             - name: OTEL_K8S_POD_NAME
               valueFrom:
                 fieldRef:
@@ -102,6 +109,12 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
+            - name: GOMEMLIMIT
+              value: "409MiB"
+            - name: OTEL_K8S_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
             - name: OBSERVE_CLUSTER_NAME
               valueFrom:
                 configMapKeyRef:
@@ -150,6 +163,7 @@ spec:
           image: observeinc/kube-cluster-info:v0.11.6
           imagePullPolicy: Always
           name: kube-cluster-info
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: prometheus-scraper-configmap
           configMap:
@@ -176,3 +190,4 @@ spec:
                 values:
                 - windows
       hostNetwork: false
+      hostPID: false

--- a/charts/agent/examples/aws-eks-fargate/rendered/prometheus-scraper/networkpolicy.yaml
+++ b/charts/agent/examples/aws-eks-fargate/rendered/prometheus-scraper/networkpolicy.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-prometheus-scraper
   namespace: observe
   labels:
-    helm.sh/chart: prometheus-scraper-0.143.0
+    helm.sh/chart: prometheus-scraper-0.159.0
     app.kubernetes.io/name: prometheus-scraper
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector

--- a/charts/agent/examples/aws-eks-fargate/rendered/prometheus-scraper/service.yaml
+++ b/charts/agent/examples/aws-eks-fargate/rendered/prometheus-scraper/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-prometheus-scraper
   namespace: observe
   labels:
-    helm.sh/chart: prometheus-scraper-0.143.0
+    helm.sh/chart: prometheus-scraper-0.159.0
     app.kubernetes.io/name: prometheus-scraper
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector

--- a/charts/agent/examples/internal-red-metrics/rendered/cluster-events/deployment.yaml
+++ b/charts/agent/examples/internal-red-metrics/rendered/cluster-events/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-cluster-events
   namespace: observe
   labels:
-    helm.sh/chart: cluster-events-0.143.0
+    helm.sh/chart: cluster-events-0.159.0
     app.kubernetes.io/name: cluster-events
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector
@@ -85,12 +85,19 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
-            - name: GOMEMLIMIT
-              value: "204MiB"
-            - name: OTEL_K8S_POD_UID
+            - name: OTEL_K8S_NODE_NAME
               valueFrom:
                 fieldRef:
-                  fieldPath: metadata.uid
+                  fieldPath: spec.nodeName
+            - name: OTEL_K8S_NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: OTEL_K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
             - name: OTEL_K8S_POD_NAME
               valueFrom:
                 fieldRef:
@@ -101,6 +108,12 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
+            - name: GOMEMLIMIT
+              value: "204MiB"
+            - name: OTEL_K8S_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
             - name: OBSERVE_CLUSTER_NAME
               valueFrom:
                 configMapKeyRef:
@@ -149,6 +162,7 @@ spec:
           image: observeinc/kube-cluster-info:v0.11.6
           imagePullPolicy: Always
           name: kube-cluster-info
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: cluster-events-configmap
           configMap:
@@ -175,3 +189,4 @@ spec:
                 values:
                 - windows
       hostNetwork: false
+      hostPID: false

--- a/charts/agent/examples/internal-red-metrics/rendered/cluster-events/networkpolicy.yaml
+++ b/charts/agent/examples/internal-red-metrics/rendered/cluster-events/networkpolicy.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-cluster-events
   namespace: observe
   labels:
-    helm.sh/chart: cluster-events-0.143.0
+    helm.sh/chart: cluster-events-0.159.0
     app.kubernetes.io/name: cluster-events
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector

--- a/charts/agent/examples/internal-red-metrics/rendered/cluster-events/service.yaml
+++ b/charts/agent/examples/internal-red-metrics/rendered/cluster-events/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-cluster-events
   namespace: observe
   labels:
-    helm.sh/chart: cluster-events-0.143.0
+    helm.sh/chart: cluster-events-0.159.0
     app.kubernetes.io/name: cluster-events
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector

--- a/charts/agent/examples/internal-red-metrics/rendered/cluster-metrics/deployment.yaml
+++ b/charts/agent/examples/internal-red-metrics/rendered/cluster-metrics/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-cluster-metrics
   namespace: observe
   labels:
-    helm.sh/chart: cluster-metrics-0.143.0
+    helm.sh/chart: cluster-metrics-0.159.0
     app.kubernetes.io/name: cluster-metrics
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector
@@ -86,12 +86,19 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
-            - name: GOMEMLIMIT
-              value: "409MiB"
-            - name: OTEL_K8S_POD_UID
+            - name: OTEL_K8S_NODE_NAME
               valueFrom:
                 fieldRef:
-                  fieldPath: metadata.uid
+                  fieldPath: spec.nodeName
+            - name: OTEL_K8S_NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: OTEL_K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
             - name: OTEL_K8S_POD_NAME
               valueFrom:
                 fieldRef:
@@ -102,6 +109,12 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
+            - name: GOMEMLIMIT
+              value: "409MiB"
+            - name: OTEL_K8S_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
             - name: OBSERVE_CLUSTER_NAME
               valueFrom:
                 configMapKeyRef:
@@ -150,6 +163,7 @@ spec:
           image: observeinc/kube-cluster-info:v0.11.6
           imagePullPolicy: Always
           name: kube-cluster-info
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: cluster-metrics-configmap
           configMap:
@@ -176,3 +190,4 @@ spec:
                 values:
                 - windows
       hostNetwork: false
+      hostPID: false

--- a/charts/agent/examples/internal-red-metrics/rendered/cluster-metrics/networkpolicy.yaml
+++ b/charts/agent/examples/internal-red-metrics/rendered/cluster-metrics/networkpolicy.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-cluster-metrics
   namespace: observe
   labels:
-    helm.sh/chart: cluster-metrics-0.143.0
+    helm.sh/chart: cluster-metrics-0.159.0
     app.kubernetes.io/name: cluster-metrics
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector

--- a/charts/agent/examples/internal-red-metrics/rendered/cluster-metrics/service.yaml
+++ b/charts/agent/examples/internal-red-metrics/rendered/cluster-metrics/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-cluster-metrics
   namespace: observe
   labels:
-    helm.sh/chart: cluster-metrics-0.143.0
+    helm.sh/chart: cluster-metrics-0.159.0
     app.kubernetes.io/name: cluster-metrics
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector

--- a/charts/agent/examples/internal-red-metrics/rendered/forwarder/daemonset.yaml
+++ b/charts/agent/examples/internal-red-metrics/rendered/forwarder/daemonset.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-forwarder-agent
   namespace: observe
   labels:
-    helm.sh/chart: forwarder-0.143.0
+    helm.sh/chart: forwarder-0.159.0
     app.kubernetes.io/name: forwarder
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: agent-collector
@@ -91,12 +91,19 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
-            - name: GOMEMLIMIT
-              value: "409MiB"
-            - name: OTEL_K8S_POD_UID
+            - name: OTEL_K8S_NODE_NAME
               valueFrom:
                 fieldRef:
-                  fieldPath: metadata.uid
+                  fieldPath: spec.nodeName
+            - name: OTEL_K8S_NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: OTEL_K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
             - name: OTEL_K8S_POD_NAME
               valueFrom:
                 fieldRef:
@@ -107,6 +114,12 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
+            - name: GOMEMLIMIT
+              value: "409MiB"
+            - name: OTEL_K8S_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
             - name: OBSERVE_CLUSTER_NAME
               valueFrom:
                 configMapKeyRef:
@@ -165,6 +178,7 @@ spec:
           image: observeinc/kube-cluster-info:v0.11.6
           imagePullPolicy: Always
           name: kube-cluster-info
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: forwarder-configmap
           configMap:
@@ -191,3 +205,4 @@ spec:
                 values:
                 - windows
       hostNetwork: false
+      hostPID: false

--- a/charts/agent/examples/internal-red-metrics/rendered/forwarder/networkpolicy.yaml
+++ b/charts/agent/examples/internal-red-metrics/rendered/forwarder/networkpolicy.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-forwarder
   namespace: observe
   labels:
-    helm.sh/chart: forwarder-0.143.0
+    helm.sh/chart: forwarder-0.159.0
     app.kubernetes.io/name: forwarder
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: agent-collector

--- a/charts/agent/examples/internal-red-metrics/rendered/forwarder/service.yaml
+++ b/charts/agent/examples/internal-red-metrics/rendered/forwarder/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-forwarder
   namespace: observe
   labels:
-    helm.sh/chart: forwarder-0.143.0
+    helm.sh/chart: forwarder-0.159.0
     app.kubernetes.io/name: forwarder
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: agent-collector

--- a/charts/agent/examples/internal-red-metrics/rendered/gateway/deployment.yaml
+++ b/charts/agent/examples/internal-red-metrics/rendered/gateway/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-gateway
   namespace: observe
   labels:
-    helm.sh/chart: gateway-0.143.0
+    helm.sh/chart: gateway-0.159.0
     app.kubernetes.io/name: gateway
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector
@@ -86,12 +86,19 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
-            - name: GOMEMLIMIT
-              value: "614MiB"
-            - name: OTEL_K8S_POD_UID
+            - name: OTEL_K8S_NODE_NAME
               valueFrom:
                 fieldRef:
-                  fieldPath: metadata.uid
+                  fieldPath: spec.nodeName
+            - name: OTEL_K8S_NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: OTEL_K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
             - name: OTEL_K8S_POD_NAME
               valueFrom:
                 fieldRef:
@@ -102,6 +109,12 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
+            - name: GOMEMLIMIT
+              value: "614MiB"
+            - name: OTEL_K8S_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
             - name: OBSERVE_CLUSTER_NAME
               valueFrom:
                 configMapKeyRef:
@@ -154,6 +167,7 @@ spec:
           image: observeinc/kube-cluster-info:v0.11.6
           imagePullPolicy: Always
           name: kube-cluster-info
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: gateway-configmap
           configMap:
@@ -180,3 +194,4 @@ spec:
                 values:
                 - windows
       hostNetwork: false
+      hostPID: false

--- a/charts/agent/examples/internal-red-metrics/rendered/gateway/networkpolicy.yaml
+++ b/charts/agent/examples/internal-red-metrics/rendered/gateway/networkpolicy.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-gateway
   namespace: observe
   labels:
-    helm.sh/chart: gateway-0.143.0
+    helm.sh/chart: gateway-0.159.0
     app.kubernetes.io/name: gateway
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector

--- a/charts/agent/examples/internal-red-metrics/rendered/gateway/service.yaml
+++ b/charts/agent/examples/internal-red-metrics/rendered/gateway/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-gateway
   namespace: observe
   labels:
-    helm.sh/chart: gateway-0.143.0
+    helm.sh/chart: gateway-0.159.0
     app.kubernetes.io/name: gateway
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector

--- a/charts/agent/examples/internal-red-metrics/rendered/monitor/deployment.yaml
+++ b/charts/agent/examples/internal-red-metrics/rendered/monitor/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-monitor
   namespace: observe
   labels:
-    helm.sh/chart: monitor-0.143.0
+    helm.sh/chart: monitor-0.159.0
     app.kubernetes.io/name: monitor
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector
@@ -86,12 +86,19 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
-            - name: GOMEMLIMIT
-              value: "204MiB"
-            - name: OTEL_K8S_POD_UID
+            - name: OTEL_K8S_NODE_NAME
               valueFrom:
                 fieldRef:
-                  fieldPath: metadata.uid
+                  fieldPath: spec.nodeName
+            - name: OTEL_K8S_NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: OTEL_K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
             - name: OTEL_K8S_POD_NAME
               valueFrom:
                 fieldRef:
@@ -102,6 +109,12 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
+            - name: GOMEMLIMIT
+              value: "204MiB"
+            - name: OTEL_K8S_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
             - name: OBSERVE_CLUSTER_NAME
               valueFrom:
                 configMapKeyRef:
@@ -150,6 +163,7 @@ spec:
           image: observeinc/kube-cluster-info:v0.11.6
           imagePullPolicy: Always
           name: kube-cluster-info
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: monitor-configmap
           configMap:
@@ -176,3 +190,4 @@ spec:
                 values:
                 - windows
       hostNetwork: false
+      hostPID: false

--- a/charts/agent/examples/internal-red-metrics/rendered/monitor/networkpolicy.yaml
+++ b/charts/agent/examples/internal-red-metrics/rendered/monitor/networkpolicy.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-monitor
   namespace: observe
   labels:
-    helm.sh/chart: monitor-0.143.0
+    helm.sh/chart: monitor-0.159.0
     app.kubernetes.io/name: monitor
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector

--- a/charts/agent/examples/internal-red-metrics/rendered/monitor/service.yaml
+++ b/charts/agent/examples/internal-red-metrics/rendered/monitor/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-monitor
   namespace: observe
   labels:
-    helm.sh/chart: monitor-0.143.0
+    helm.sh/chart: monitor-0.159.0
     app.kubernetes.io/name: monitor
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector

--- a/charts/agent/examples/internal-red-metrics/rendered/node-logs-metrics/daemonset.yaml
+++ b/charts/agent/examples/internal-red-metrics/rendered/node-logs-metrics/daemonset.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-node-logs-metrics-agent
   namespace: observe
   labels:
-    helm.sh/chart: node-logs-metrics-0.143.0
+    helm.sh/chart: node-logs-metrics-0.159.0
     app.kubernetes.io/name: node-logs-metrics
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: agent-collector
@@ -68,12 +68,19 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
-            - name: GOMEMLIMIT
-              value: "409MiB"
-            - name: OTEL_K8S_POD_UID
+            - name: OTEL_K8S_NODE_NAME
               valueFrom:
                 fieldRef:
-                  fieldPath: metadata.uid
+                  fieldPath: spec.nodeName
+            - name: OTEL_K8S_NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: OTEL_K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
             - name: OTEL_K8S_POD_NAME
               valueFrom:
                 fieldRef:
@@ -84,6 +91,12 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
+            - name: GOMEMLIMIT
+              value: "409MiB"
+            - name: OTEL_K8S_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
             - name: OBSERVE_CLUSTER_NAME
               valueFrom:
                 configMapKeyRef:
@@ -158,6 +171,7 @@ spec:
           image: observeinc/kube-cluster-info:v0.11.6
           imagePullPolicy: Always
           name: kube-cluster-info
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: node-logs-metrics-configmap
           configMap:
@@ -197,3 +211,4 @@ spec:
                 values:
                 - windows
       hostNetwork: false
+      hostPID: false

--- a/charts/agent/examples/internal-red-metrics/rendered/prometheus-scraper/deployment.yaml
+++ b/charts/agent/examples/internal-red-metrics/rendered/prometheus-scraper/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-prometheus-scraper
   namespace: observe
   labels:
-    helm.sh/chart: prometheus-scraper-0.143.0
+    helm.sh/chart: prometheus-scraper-0.159.0
     app.kubernetes.io/name: prometheus-scraper
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector
@@ -86,12 +86,19 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
-            - name: GOMEMLIMIT
-              value: "409MiB"
-            - name: OTEL_K8S_POD_UID
+            - name: OTEL_K8S_NODE_NAME
               valueFrom:
                 fieldRef:
-                  fieldPath: metadata.uid
+                  fieldPath: spec.nodeName
+            - name: OTEL_K8S_NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: OTEL_K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
             - name: OTEL_K8S_POD_NAME
               valueFrom:
                 fieldRef:
@@ -102,6 +109,12 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
+            - name: GOMEMLIMIT
+              value: "409MiB"
+            - name: OTEL_K8S_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
             - name: OBSERVE_CLUSTER_NAME
               valueFrom:
                 configMapKeyRef:
@@ -150,6 +163,7 @@ spec:
           image: observeinc/kube-cluster-info:v0.11.6
           imagePullPolicy: Always
           name: kube-cluster-info
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: prometheus-scraper-configmap
           configMap:
@@ -176,3 +190,4 @@ spec:
                 values:
                 - windows
       hostNetwork: false
+      hostPID: false

--- a/charts/agent/examples/internal-red-metrics/rendered/prometheus-scraper/networkpolicy.yaml
+++ b/charts/agent/examples/internal-red-metrics/rendered/prometheus-scraper/networkpolicy.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-prometheus-scraper
   namespace: observe
   labels:
-    helm.sh/chart: prometheus-scraper-0.143.0
+    helm.sh/chart: prometheus-scraper-0.159.0
     app.kubernetes.io/name: prometheus-scraper
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector

--- a/charts/agent/examples/internal-red-metrics/rendered/prometheus-scraper/service.yaml
+++ b/charts/agent/examples/internal-red-metrics/rendered/prometheus-scraper/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-prometheus-scraper
   namespace: observe
   labels:
-    helm.sh/chart: prometheus-scraper-0.143.0
+    helm.sh/chart: prometheus-scraper-0.159.0
     app.kubernetes.io/name: prometheus-scraper
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector

--- a/charts/agent/examples/prometheus-ta-cr-discovery/rendered/cluster-events/deployment.yaml
+++ b/charts/agent/examples/prometheus-ta-cr-discovery/rendered/cluster-events/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-cluster-events
   namespace: observe
   labels:
-    helm.sh/chart: cluster-events-0.143.0
+    helm.sh/chart: cluster-events-0.159.0
     app.kubernetes.io/name: cluster-events
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector
@@ -85,12 +85,19 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
-            - name: GOMEMLIMIT
-              value: "204MiB"
-            - name: OTEL_K8S_POD_UID
+            - name: OTEL_K8S_NODE_NAME
               valueFrom:
                 fieldRef:
-                  fieldPath: metadata.uid
+                  fieldPath: spec.nodeName
+            - name: OTEL_K8S_NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: OTEL_K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
             - name: OTEL_K8S_POD_NAME
               valueFrom:
                 fieldRef:
@@ -101,6 +108,12 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
+            - name: GOMEMLIMIT
+              value: "204MiB"
+            - name: OTEL_K8S_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
             - name: OBSERVE_CLUSTER_NAME
               valueFrom:
                 configMapKeyRef:
@@ -149,6 +162,7 @@ spec:
           image: observeinc/kube-cluster-info:v0.11.6
           imagePullPolicy: Always
           name: kube-cluster-info
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: cluster-events-configmap
           configMap:
@@ -175,3 +189,4 @@ spec:
                 values:
                 - windows
       hostNetwork: false
+      hostPID: false

--- a/charts/agent/examples/prometheus-ta-cr-discovery/rendered/cluster-events/networkpolicy.yaml
+++ b/charts/agent/examples/prometheus-ta-cr-discovery/rendered/cluster-events/networkpolicy.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-cluster-events
   namespace: observe
   labels:
-    helm.sh/chart: cluster-events-0.143.0
+    helm.sh/chart: cluster-events-0.159.0
     app.kubernetes.io/name: cluster-events
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector

--- a/charts/agent/examples/prometheus-ta-cr-discovery/rendered/cluster-events/service.yaml
+++ b/charts/agent/examples/prometheus-ta-cr-discovery/rendered/cluster-events/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-cluster-events
   namespace: observe
   labels:
-    helm.sh/chart: cluster-events-0.143.0
+    helm.sh/chart: cluster-events-0.159.0
     app.kubernetes.io/name: cluster-events
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector

--- a/charts/agent/examples/prometheus-ta-cr-discovery/rendered/cluster-metrics/deployment.yaml
+++ b/charts/agent/examples/prometheus-ta-cr-discovery/rendered/cluster-metrics/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-cluster-metrics
   namespace: observe
   labels:
-    helm.sh/chart: cluster-metrics-0.143.0
+    helm.sh/chart: cluster-metrics-0.159.0
     app.kubernetes.io/name: cluster-metrics
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector
@@ -86,12 +86,19 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
-            - name: GOMEMLIMIT
-              value: "409MiB"
-            - name: OTEL_K8S_POD_UID
+            - name: OTEL_K8S_NODE_NAME
               valueFrom:
                 fieldRef:
-                  fieldPath: metadata.uid
+                  fieldPath: spec.nodeName
+            - name: OTEL_K8S_NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: OTEL_K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
             - name: OTEL_K8S_POD_NAME
               valueFrom:
                 fieldRef:
@@ -102,6 +109,12 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
+            - name: GOMEMLIMIT
+              value: "409MiB"
+            - name: OTEL_K8S_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
             - name: OBSERVE_CLUSTER_NAME
               valueFrom:
                 configMapKeyRef:
@@ -150,6 +163,7 @@ spec:
           image: observeinc/kube-cluster-info:v0.11.6
           imagePullPolicy: Always
           name: kube-cluster-info
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: cluster-metrics-configmap
           configMap:
@@ -176,3 +190,4 @@ spec:
                 values:
                 - windows
       hostNetwork: false
+      hostPID: false

--- a/charts/agent/examples/prometheus-ta-cr-discovery/rendered/cluster-metrics/networkpolicy.yaml
+++ b/charts/agent/examples/prometheus-ta-cr-discovery/rendered/cluster-metrics/networkpolicy.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-cluster-metrics
   namespace: observe
   labels:
-    helm.sh/chart: cluster-metrics-0.143.0
+    helm.sh/chart: cluster-metrics-0.159.0
     app.kubernetes.io/name: cluster-metrics
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector

--- a/charts/agent/examples/prometheus-ta-cr-discovery/rendered/cluster-metrics/service.yaml
+++ b/charts/agent/examples/prometheus-ta-cr-discovery/rendered/cluster-metrics/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-cluster-metrics
   namespace: observe
   labels:
-    helm.sh/chart: cluster-metrics-0.143.0
+    helm.sh/chart: cluster-metrics-0.159.0
     app.kubernetes.io/name: cluster-metrics
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector

--- a/charts/agent/examples/prometheus-ta-cr-discovery/rendered/forwarder/daemonset.yaml
+++ b/charts/agent/examples/prometheus-ta-cr-discovery/rendered/forwarder/daemonset.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-forwarder-agent
   namespace: observe
   labels:
-    helm.sh/chart: forwarder-0.143.0
+    helm.sh/chart: forwarder-0.159.0
     app.kubernetes.io/name: forwarder
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: agent-collector
@@ -91,12 +91,19 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
-            - name: GOMEMLIMIT
-              value: "409MiB"
-            - name: OTEL_K8S_POD_UID
+            - name: OTEL_K8S_NODE_NAME
               valueFrom:
                 fieldRef:
-                  fieldPath: metadata.uid
+                  fieldPath: spec.nodeName
+            - name: OTEL_K8S_NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: OTEL_K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
             - name: OTEL_K8S_POD_NAME
               valueFrom:
                 fieldRef:
@@ -107,6 +114,12 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
+            - name: GOMEMLIMIT
+              value: "409MiB"
+            - name: OTEL_K8S_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
             - name: OBSERVE_CLUSTER_NAME
               valueFrom:
                 configMapKeyRef:
@@ -165,6 +178,7 @@ spec:
           image: observeinc/kube-cluster-info:v0.11.6
           imagePullPolicy: Always
           name: kube-cluster-info
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: forwarder-configmap
           configMap:
@@ -191,3 +205,4 @@ spec:
                 values:
                 - windows
       hostNetwork: false
+      hostPID: false

--- a/charts/agent/examples/prometheus-ta-cr-discovery/rendered/forwarder/networkpolicy.yaml
+++ b/charts/agent/examples/prometheus-ta-cr-discovery/rendered/forwarder/networkpolicy.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-forwarder
   namespace: observe
   labels:
-    helm.sh/chart: forwarder-0.143.0
+    helm.sh/chart: forwarder-0.159.0
     app.kubernetes.io/name: forwarder
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: agent-collector

--- a/charts/agent/examples/prometheus-ta-cr-discovery/rendered/forwarder/service.yaml
+++ b/charts/agent/examples/prometheus-ta-cr-discovery/rendered/forwarder/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-forwarder
   namespace: observe
   labels:
-    helm.sh/chart: forwarder-0.143.0
+    helm.sh/chart: forwarder-0.159.0
     app.kubernetes.io/name: forwarder
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: agent-collector

--- a/charts/agent/examples/prometheus-ta-cr-discovery/rendered/monitor/deployment.yaml
+++ b/charts/agent/examples/prometheus-ta-cr-discovery/rendered/monitor/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-monitor
   namespace: observe
   labels:
-    helm.sh/chart: monitor-0.143.0
+    helm.sh/chart: monitor-0.159.0
     app.kubernetes.io/name: monitor
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector
@@ -86,12 +86,19 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
-            - name: GOMEMLIMIT
-              value: "204MiB"
-            - name: OTEL_K8S_POD_UID
+            - name: OTEL_K8S_NODE_NAME
               valueFrom:
                 fieldRef:
-                  fieldPath: metadata.uid
+                  fieldPath: spec.nodeName
+            - name: OTEL_K8S_NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: OTEL_K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
             - name: OTEL_K8S_POD_NAME
               valueFrom:
                 fieldRef:
@@ -102,6 +109,12 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
+            - name: GOMEMLIMIT
+              value: "204MiB"
+            - name: OTEL_K8S_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
             - name: OBSERVE_CLUSTER_NAME
               valueFrom:
                 configMapKeyRef:
@@ -150,6 +163,7 @@ spec:
           image: observeinc/kube-cluster-info:v0.11.6
           imagePullPolicy: Always
           name: kube-cluster-info
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: monitor-configmap
           configMap:
@@ -176,3 +190,4 @@ spec:
                 values:
                 - windows
       hostNetwork: false
+      hostPID: false

--- a/charts/agent/examples/prometheus-ta-cr-discovery/rendered/monitor/networkpolicy.yaml
+++ b/charts/agent/examples/prometheus-ta-cr-discovery/rendered/monitor/networkpolicy.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-monitor
   namespace: observe
   labels:
-    helm.sh/chart: monitor-0.143.0
+    helm.sh/chart: monitor-0.159.0
     app.kubernetes.io/name: monitor
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector

--- a/charts/agent/examples/prometheus-ta-cr-discovery/rendered/monitor/service.yaml
+++ b/charts/agent/examples/prometheus-ta-cr-discovery/rendered/monitor/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-monitor
   namespace: observe
   labels:
-    helm.sh/chart: monitor-0.143.0
+    helm.sh/chart: monitor-0.159.0
     app.kubernetes.io/name: monitor
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector

--- a/charts/agent/examples/prometheus-ta-cr-discovery/rendered/node-logs-metrics/daemonset.yaml
+++ b/charts/agent/examples/prometheus-ta-cr-discovery/rendered/node-logs-metrics/daemonset.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-node-logs-metrics-agent
   namespace: observe
   labels:
-    helm.sh/chart: node-logs-metrics-0.143.0
+    helm.sh/chart: node-logs-metrics-0.159.0
     app.kubernetes.io/name: node-logs-metrics
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: agent-collector
@@ -68,12 +68,19 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
-            - name: GOMEMLIMIT
-              value: "409MiB"
-            - name: OTEL_K8S_POD_UID
+            - name: OTEL_K8S_NODE_NAME
               valueFrom:
                 fieldRef:
-                  fieldPath: metadata.uid
+                  fieldPath: spec.nodeName
+            - name: OTEL_K8S_NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: OTEL_K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
             - name: OTEL_K8S_POD_NAME
               valueFrom:
                 fieldRef:
@@ -84,6 +91,12 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
+            - name: GOMEMLIMIT
+              value: "409MiB"
+            - name: OTEL_K8S_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
             - name: OBSERVE_CLUSTER_NAME
               valueFrom:
                 configMapKeyRef:
@@ -158,6 +171,7 @@ spec:
           image: observeinc/kube-cluster-info:v0.11.6
           imagePullPolicy: Always
           name: kube-cluster-info
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: node-logs-metrics-configmap
           configMap:
@@ -197,3 +211,4 @@ spec:
                 values:
                 - windows
       hostNetwork: false
+      hostPID: false

--- a/charts/agent/examples/prometheus-ta-cr-discovery/rendered/prometheus-scraper/deployment.yaml
+++ b/charts/agent/examples/prometheus-ta-cr-discovery/rendered/prometheus-scraper/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-prometheus-scraper
   namespace: observe
   labels:
-    helm.sh/chart: prometheus-scraper-0.143.0
+    helm.sh/chart: prometheus-scraper-0.159.0
     app.kubernetes.io/name: prometheus-scraper
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector
@@ -86,12 +86,19 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
-            - name: GOMEMLIMIT
-              value: "409MiB"
-            - name: OTEL_K8S_POD_UID
+            - name: OTEL_K8S_NODE_NAME
               valueFrom:
                 fieldRef:
-                  fieldPath: metadata.uid
+                  fieldPath: spec.nodeName
+            - name: OTEL_K8S_NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: OTEL_K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
             - name: OTEL_K8S_POD_NAME
               valueFrom:
                 fieldRef:
@@ -102,6 +109,12 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
+            - name: GOMEMLIMIT
+              value: "409MiB"
+            - name: OTEL_K8S_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
             - name: OBSERVE_CLUSTER_NAME
               valueFrom:
                 configMapKeyRef:
@@ -150,6 +163,7 @@ spec:
           image: observeinc/kube-cluster-info:v0.11.6
           imagePullPolicy: Always
           name: kube-cluster-info
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: prometheus-scraper-configmap
           configMap:
@@ -176,3 +190,4 @@ spec:
                 values:
                 - windows
       hostNetwork: false
+      hostPID: false

--- a/charts/agent/examples/prometheus-ta-cr-discovery/rendered/prometheus-scraper/networkpolicy.yaml
+++ b/charts/agent/examples/prometheus-ta-cr-discovery/rendered/prometheus-scraper/networkpolicy.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-prometheus-scraper
   namespace: observe
   labels:
-    helm.sh/chart: prometheus-scraper-0.143.0
+    helm.sh/chart: prometheus-scraper-0.159.0
     app.kubernetes.io/name: prometheus-scraper
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector

--- a/charts/agent/examples/prometheus-ta-cr-discovery/rendered/prometheus-scraper/service.yaml
+++ b/charts/agent/examples/prometheus-ta-cr-discovery/rendered/prometheus-scraper/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-prometheus-scraper
   namespace: observe
   labels:
-    helm.sh/chart: prometheus-scraper-0.143.0
+    helm.sh/chart: prometheus-scraper-0.159.0
     app.kubernetes.io/name: prometheus-scraper
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/cluster-events/deployment.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/cluster-events/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-cluster-events
   namespace: observe
   labels:
-    helm.sh/chart: cluster-events-0.143.0
+    helm.sh/chart: cluster-events-0.159.0
     app.kubernetes.io/name: cluster-events
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector
@@ -85,12 +85,19 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
-            - name: GOMEMLIMIT
-              value: "204MiB"
-            - name: OTEL_K8S_POD_UID
+            - name: OTEL_K8S_NODE_NAME
               valueFrom:
                 fieldRef:
-                  fieldPath: metadata.uid
+                  fieldPath: spec.nodeName
+            - name: OTEL_K8S_NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: OTEL_K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
             - name: OTEL_K8S_POD_NAME
               valueFrom:
                 fieldRef:
@@ -101,6 +108,12 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
+            - name: GOMEMLIMIT
+              value: "204MiB"
+            - name: OTEL_K8S_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
             - name: OBSERVE_CLUSTER_NAME
               valueFrom:
                 configMapKeyRef:
@@ -149,6 +162,7 @@ spec:
           image: observeinc/kube-cluster-info:v0.11.6
           imagePullPolicy: Always
           name: kube-cluster-info
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: cluster-events-configmap
           configMap:
@@ -175,3 +189,4 @@ spec:
                 values:
                 - windows
       hostNetwork: false
+      hostPID: false

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/cluster-events/networkpolicy.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/cluster-events/networkpolicy.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-cluster-events
   namespace: observe
   labels:
-    helm.sh/chart: cluster-events-0.143.0
+    helm.sh/chart: cluster-events-0.159.0
     app.kubernetes.io/name: cluster-events
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/cluster-events/service.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/cluster-events/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-cluster-events
   namespace: observe
   labels:
-    helm.sh/chart: cluster-events-0.143.0
+    helm.sh/chart: cluster-events-0.159.0
     app.kubernetes.io/name: cluster-events
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/cluster-metrics/deployment.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/cluster-metrics/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-cluster-metrics
   namespace: observe
   labels:
-    helm.sh/chart: cluster-metrics-0.143.0
+    helm.sh/chart: cluster-metrics-0.159.0
     app.kubernetes.io/name: cluster-metrics
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector
@@ -86,12 +86,19 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
-            - name: GOMEMLIMIT
-              value: "409MiB"
-            - name: OTEL_K8S_POD_UID
+            - name: OTEL_K8S_NODE_NAME
               valueFrom:
                 fieldRef:
-                  fieldPath: metadata.uid
+                  fieldPath: spec.nodeName
+            - name: OTEL_K8S_NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: OTEL_K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
             - name: OTEL_K8S_POD_NAME
               valueFrom:
                 fieldRef:
@@ -102,6 +109,12 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
+            - name: GOMEMLIMIT
+              value: "409MiB"
+            - name: OTEL_K8S_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
             - name: OBSERVE_CLUSTER_NAME
               valueFrom:
                 configMapKeyRef:
@@ -150,6 +163,7 @@ spec:
           image: observeinc/kube-cluster-info:v0.11.6
           imagePullPolicy: Always
           name: kube-cluster-info
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: cluster-metrics-configmap
           configMap:
@@ -176,3 +190,4 @@ spec:
                 values:
                 - windows
       hostNetwork: false
+      hostPID: false

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/cluster-metrics/networkpolicy.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/cluster-metrics/networkpolicy.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-cluster-metrics
   namespace: observe
   labels:
-    helm.sh/chart: cluster-metrics-0.143.0
+    helm.sh/chart: cluster-metrics-0.159.0
     app.kubernetes.io/name: cluster-metrics
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/cluster-metrics/service.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/cluster-metrics/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-cluster-metrics
   namespace: observe
   labels:
-    helm.sh/chart: cluster-metrics-0.143.0
+    helm.sh/chart: cluster-metrics-0.159.0
     app.kubernetes.io/name: cluster-metrics
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/forwarder/daemonset.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/forwarder/daemonset.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-forwarder-agent
   namespace: observe
   labels:
-    helm.sh/chart: forwarder-0.143.0
+    helm.sh/chart: forwarder-0.159.0
     app.kubernetes.io/name: forwarder
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: agent-collector
@@ -91,12 +91,19 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
-            - name: GOMEMLIMIT
-              value: "409MiB"
-            - name: OTEL_K8S_POD_UID
+            - name: OTEL_K8S_NODE_NAME
               valueFrom:
                 fieldRef:
-                  fieldPath: metadata.uid
+                  fieldPath: spec.nodeName
+            - name: OTEL_K8S_NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: OTEL_K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
             - name: OTEL_K8S_POD_NAME
               valueFrom:
                 fieldRef:
@@ -107,6 +114,12 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
+            - name: GOMEMLIMIT
+              value: "409MiB"
+            - name: OTEL_K8S_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
             - name: OBSERVE_CLUSTER_NAME
               valueFrom:
                 configMapKeyRef:
@@ -165,6 +178,7 @@ spec:
           image: observeinc/kube-cluster-info:v0.11.6
           imagePullPolicy: Always
           name: kube-cluster-info
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: forwarder-configmap
           configMap:
@@ -191,3 +205,4 @@ spec:
                 values:
                 - windows
       hostNetwork: false
+      hostPID: false

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/forwarder/networkpolicy.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/forwarder/networkpolicy.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-forwarder
   namespace: observe
   labels:
-    helm.sh/chart: forwarder-0.143.0
+    helm.sh/chart: forwarder-0.159.0
     app.kubernetes.io/name: forwarder
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: agent-collector

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/forwarder/service.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/forwarder/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-forwarder
   namespace: observe
   labels:
-    helm.sh/chart: forwarder-0.143.0
+    helm.sh/chart: forwarder-0.159.0
     app.kubernetes.io/name: forwarder
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: agent-collector

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/monitor/deployment.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/monitor/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-monitor
   namespace: observe
   labels:
-    helm.sh/chart: monitor-0.143.0
+    helm.sh/chart: monitor-0.159.0
     app.kubernetes.io/name: monitor
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector
@@ -86,12 +86,19 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
-            - name: GOMEMLIMIT
-              value: "204MiB"
-            - name: OTEL_K8S_POD_UID
+            - name: OTEL_K8S_NODE_NAME
               valueFrom:
                 fieldRef:
-                  fieldPath: metadata.uid
+                  fieldPath: spec.nodeName
+            - name: OTEL_K8S_NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: OTEL_K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
             - name: OTEL_K8S_POD_NAME
               valueFrom:
                 fieldRef:
@@ -102,6 +109,12 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
+            - name: GOMEMLIMIT
+              value: "204MiB"
+            - name: OTEL_K8S_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
             - name: OBSERVE_CLUSTER_NAME
               valueFrom:
                 configMapKeyRef:
@@ -150,6 +163,7 @@ spec:
           image: observeinc/kube-cluster-info:v0.11.6
           imagePullPolicy: Always
           name: kube-cluster-info
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: monitor-configmap
           configMap:
@@ -176,3 +190,4 @@ spec:
                 values:
                 - windows
       hostNetwork: false
+      hostPID: false

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/monitor/networkpolicy.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/monitor/networkpolicy.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-monitor
   namespace: observe
   labels:
-    helm.sh/chart: monitor-0.143.0
+    helm.sh/chart: monitor-0.159.0
     app.kubernetes.io/name: monitor
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/monitor/service.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/monitor/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-monitor
   namespace: observe
   labels:
-    helm.sh/chart: monitor-0.143.0
+    helm.sh/chart: monitor-0.159.0
     app.kubernetes.io/name: monitor
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/node-logs-metrics/daemonset.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/node-logs-metrics/daemonset.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-node-logs-metrics-agent
   namespace: observe
   labels:
-    helm.sh/chart: node-logs-metrics-0.143.0
+    helm.sh/chart: node-logs-metrics-0.159.0
     app.kubernetes.io/name: node-logs-metrics
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: agent-collector
@@ -68,12 +68,19 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
-            - name: GOMEMLIMIT
-              value: "409MiB"
-            - name: OTEL_K8S_POD_UID
+            - name: OTEL_K8S_NODE_NAME
               valueFrom:
                 fieldRef:
-                  fieldPath: metadata.uid
+                  fieldPath: spec.nodeName
+            - name: OTEL_K8S_NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: OTEL_K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
             - name: OTEL_K8S_POD_NAME
               valueFrom:
                 fieldRef:
@@ -84,6 +91,12 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
+            - name: GOMEMLIMIT
+              value: "409MiB"
+            - name: OTEL_K8S_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
             - name: OBSERVE_CLUSTER_NAME
               valueFrom:
                 configMapKeyRef:
@@ -158,6 +171,7 @@ spec:
           image: observeinc/kube-cluster-info:v0.11.6
           imagePullPolicy: Always
           name: kube-cluster-info
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: node-logs-metrics-configmap
           configMap:
@@ -197,3 +211,4 @@ spec:
                 values:
                 - windows
       hostNetwork: false
+      hostPID: false

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/prometheus-scraper/deployment.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/prometheus-scraper/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-prometheus-scraper
   namespace: observe
   labels:
-    helm.sh/chart: prometheus-scraper-0.143.0
+    helm.sh/chart: prometheus-scraper-0.159.0
     app.kubernetes.io/name: prometheus-scraper
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector
@@ -86,12 +86,19 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
-            - name: GOMEMLIMIT
-              value: "409MiB"
-            - name: OTEL_K8S_POD_UID
+            - name: OTEL_K8S_NODE_NAME
               valueFrom:
                 fieldRef:
-                  fieldPath: metadata.uid
+                  fieldPath: spec.nodeName
+            - name: OTEL_K8S_NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: OTEL_K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
             - name: OTEL_K8S_POD_NAME
               valueFrom:
                 fieldRef:
@@ -102,6 +109,12 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
+            - name: GOMEMLIMIT
+              value: "409MiB"
+            - name: OTEL_K8S_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
             - name: OBSERVE_CLUSTER_NAME
               valueFrom:
                 configMapKeyRef:
@@ -150,6 +163,7 @@ spec:
           image: observeinc/kube-cluster-info:v0.11.6
           imagePullPolicy: Always
           name: kube-cluster-info
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: prometheus-scraper-configmap
           configMap:
@@ -176,3 +190,4 @@ spec:
                 values:
                 - windows
       hostNetwork: false
+      hostPID: false

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/prometheus-scraper/networkpolicy.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/prometheus-scraper/networkpolicy.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-prometheus-scraper
   namespace: observe
   labels:
-    helm.sh/chart: prometheus-scraper-0.143.0
+    helm.sh/chart: prometheus-scraper-0.159.0
     app.kubernetes.io/name: prometheus-scraper
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/prometheus-scraper/service.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/prometheus-scraper/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-prometheus-scraper
   namespace: observe
   labels:
-    helm.sh/chart: prometheus-scraper-0.143.0
+    helm.sh/chart: prometheus-scraper-0.159.0
     app.kubernetes.io/name: prometheus-scraper
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector

--- a/charts/agent/examples/recommended-config/rendered/cluster-events/deployment.yaml
+++ b/charts/agent/examples/recommended-config/rendered/cluster-events/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-cluster-events
   namespace: observe
   labels:
-    helm.sh/chart: cluster-events-0.143.0
+    helm.sh/chart: cluster-events-0.159.0
     app.kubernetes.io/name: cluster-events
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector
@@ -85,12 +85,19 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
-            - name: GOMEMLIMIT
-              value: "204MiB"
-            - name: OTEL_K8S_POD_UID
+            - name: OTEL_K8S_NODE_NAME
               valueFrom:
                 fieldRef:
-                  fieldPath: metadata.uid
+                  fieldPath: spec.nodeName
+            - name: OTEL_K8S_NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: OTEL_K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
             - name: OTEL_K8S_POD_NAME
               valueFrom:
                 fieldRef:
@@ -101,6 +108,12 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
+            - name: GOMEMLIMIT
+              value: "204MiB"
+            - name: OTEL_K8S_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
             - name: OBSERVE_CLUSTER_NAME
               valueFrom:
                 configMapKeyRef:
@@ -149,6 +162,7 @@ spec:
           image: observeinc/kube-cluster-info:v0.11.6
           imagePullPolicy: Always
           name: kube-cluster-info
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: cluster-events-configmap
           configMap:
@@ -175,3 +189,4 @@ spec:
                 values:
                 - windows
       hostNetwork: false
+      hostPID: false

--- a/charts/agent/examples/recommended-config/rendered/cluster-events/networkpolicy.yaml
+++ b/charts/agent/examples/recommended-config/rendered/cluster-events/networkpolicy.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-cluster-events
   namespace: observe
   labels:
-    helm.sh/chart: cluster-events-0.143.0
+    helm.sh/chart: cluster-events-0.159.0
     app.kubernetes.io/name: cluster-events
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector

--- a/charts/agent/examples/recommended-config/rendered/cluster-events/service.yaml
+++ b/charts/agent/examples/recommended-config/rendered/cluster-events/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-cluster-events
   namespace: observe
   labels:
-    helm.sh/chart: cluster-events-0.143.0
+    helm.sh/chart: cluster-events-0.159.0
     app.kubernetes.io/name: cluster-events
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector

--- a/charts/agent/examples/recommended-config/rendered/cluster-metrics/deployment.yaml
+++ b/charts/agent/examples/recommended-config/rendered/cluster-metrics/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-cluster-metrics
   namespace: observe
   labels:
-    helm.sh/chart: cluster-metrics-0.143.0
+    helm.sh/chart: cluster-metrics-0.159.0
     app.kubernetes.io/name: cluster-metrics
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector
@@ -86,12 +86,19 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
-            - name: GOMEMLIMIT
-              value: "409MiB"
-            - name: OTEL_K8S_POD_UID
+            - name: OTEL_K8S_NODE_NAME
               valueFrom:
                 fieldRef:
-                  fieldPath: metadata.uid
+                  fieldPath: spec.nodeName
+            - name: OTEL_K8S_NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: OTEL_K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
             - name: OTEL_K8S_POD_NAME
               valueFrom:
                 fieldRef:
@@ -102,6 +109,12 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
+            - name: GOMEMLIMIT
+              value: "409MiB"
+            - name: OTEL_K8S_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
             - name: OBSERVE_CLUSTER_NAME
               valueFrom:
                 configMapKeyRef:
@@ -150,6 +163,7 @@ spec:
           image: observeinc/kube-cluster-info:v0.11.6
           imagePullPolicy: Always
           name: kube-cluster-info
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: cluster-metrics-configmap
           configMap:
@@ -176,3 +190,4 @@ spec:
                 values:
                 - windows
       hostNetwork: false
+      hostPID: false

--- a/charts/agent/examples/recommended-config/rendered/cluster-metrics/networkpolicy.yaml
+++ b/charts/agent/examples/recommended-config/rendered/cluster-metrics/networkpolicy.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-cluster-metrics
   namespace: observe
   labels:
-    helm.sh/chart: cluster-metrics-0.143.0
+    helm.sh/chart: cluster-metrics-0.159.0
     app.kubernetes.io/name: cluster-metrics
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector

--- a/charts/agent/examples/recommended-config/rendered/cluster-metrics/service.yaml
+++ b/charts/agent/examples/recommended-config/rendered/cluster-metrics/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-cluster-metrics
   namespace: observe
   labels:
-    helm.sh/chart: cluster-metrics-0.143.0
+    helm.sh/chart: cluster-metrics-0.159.0
     app.kubernetes.io/name: cluster-metrics
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector

--- a/charts/agent/examples/recommended-config/rendered/forwarder/daemonset.yaml
+++ b/charts/agent/examples/recommended-config/rendered/forwarder/daemonset.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-forwarder-agent
   namespace: observe
   labels:
-    helm.sh/chart: forwarder-0.143.0
+    helm.sh/chart: forwarder-0.159.0
     app.kubernetes.io/name: forwarder
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: agent-collector
@@ -91,12 +91,19 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
-            - name: GOMEMLIMIT
-              value: "409MiB"
-            - name: OTEL_K8S_POD_UID
+            - name: OTEL_K8S_NODE_NAME
               valueFrom:
                 fieldRef:
-                  fieldPath: metadata.uid
+                  fieldPath: spec.nodeName
+            - name: OTEL_K8S_NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: OTEL_K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
             - name: OTEL_K8S_POD_NAME
               valueFrom:
                 fieldRef:
@@ -107,6 +114,12 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
+            - name: GOMEMLIMIT
+              value: "409MiB"
+            - name: OTEL_K8S_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
             - name: OBSERVE_CLUSTER_NAME
               valueFrom:
                 configMapKeyRef:
@@ -165,6 +178,7 @@ spec:
           image: observeinc/kube-cluster-info:v0.11.6
           imagePullPolicy: Always
           name: kube-cluster-info
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: forwarder-configmap
           configMap:
@@ -191,3 +205,4 @@ spec:
                 values:
                 - windows
       hostNetwork: false
+      hostPID: false

--- a/charts/agent/examples/recommended-config/rendered/forwarder/networkpolicy.yaml
+++ b/charts/agent/examples/recommended-config/rendered/forwarder/networkpolicy.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-forwarder
   namespace: observe
   labels:
-    helm.sh/chart: forwarder-0.143.0
+    helm.sh/chart: forwarder-0.159.0
     app.kubernetes.io/name: forwarder
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: agent-collector

--- a/charts/agent/examples/recommended-config/rendered/forwarder/service.yaml
+++ b/charts/agent/examples/recommended-config/rendered/forwarder/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-forwarder
   namespace: observe
   labels:
-    helm.sh/chart: forwarder-0.143.0
+    helm.sh/chart: forwarder-0.159.0
     app.kubernetes.io/name: forwarder
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: agent-collector

--- a/charts/agent/examples/recommended-config/rendered/gateway/deployment.yaml
+++ b/charts/agent/examples/recommended-config/rendered/gateway/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-gateway
   namespace: observe
   labels:
-    helm.sh/chart: gateway-0.143.0
+    helm.sh/chart: gateway-0.159.0
     app.kubernetes.io/name: gateway
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector
@@ -86,12 +86,19 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
-            - name: GOMEMLIMIT
-              value: "614MiB"
-            - name: OTEL_K8S_POD_UID
+            - name: OTEL_K8S_NODE_NAME
               valueFrom:
                 fieldRef:
-                  fieldPath: metadata.uid
+                  fieldPath: spec.nodeName
+            - name: OTEL_K8S_NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: OTEL_K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
             - name: OTEL_K8S_POD_NAME
               valueFrom:
                 fieldRef:
@@ -102,6 +109,12 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
+            - name: GOMEMLIMIT
+              value: "614MiB"
+            - name: OTEL_K8S_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
             - name: OBSERVE_CLUSTER_NAME
               valueFrom:
                 configMapKeyRef:
@@ -154,6 +167,7 @@ spec:
           image: observeinc/kube-cluster-info:v0.11.6
           imagePullPolicy: Always
           name: kube-cluster-info
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: gateway-configmap
           configMap:
@@ -180,3 +194,4 @@ spec:
                 values:
                 - windows
       hostNetwork: false
+      hostPID: false

--- a/charts/agent/examples/recommended-config/rendered/gateway/networkpolicy.yaml
+++ b/charts/agent/examples/recommended-config/rendered/gateway/networkpolicy.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-gateway
   namespace: observe
   labels:
-    helm.sh/chart: gateway-0.143.0
+    helm.sh/chart: gateway-0.159.0
     app.kubernetes.io/name: gateway
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector

--- a/charts/agent/examples/recommended-config/rendered/gateway/service.yaml
+++ b/charts/agent/examples/recommended-config/rendered/gateway/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-gateway
   namespace: observe
   labels:
-    helm.sh/chart: gateway-0.143.0
+    helm.sh/chart: gateway-0.159.0
     app.kubernetes.io/name: gateway
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector

--- a/charts/agent/examples/recommended-config/rendered/monitor/deployment.yaml
+++ b/charts/agent/examples/recommended-config/rendered/monitor/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-monitor
   namespace: observe
   labels:
-    helm.sh/chart: monitor-0.143.0
+    helm.sh/chart: monitor-0.159.0
     app.kubernetes.io/name: monitor
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector
@@ -86,12 +86,19 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
-            - name: GOMEMLIMIT
-              value: "204MiB"
-            - name: OTEL_K8S_POD_UID
+            - name: OTEL_K8S_NODE_NAME
               valueFrom:
                 fieldRef:
-                  fieldPath: metadata.uid
+                  fieldPath: spec.nodeName
+            - name: OTEL_K8S_NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: OTEL_K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
             - name: OTEL_K8S_POD_NAME
               valueFrom:
                 fieldRef:
@@ -102,6 +109,12 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
+            - name: GOMEMLIMIT
+              value: "204MiB"
+            - name: OTEL_K8S_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
             - name: OBSERVE_CLUSTER_NAME
               valueFrom:
                 configMapKeyRef:
@@ -150,6 +163,7 @@ spec:
           image: observeinc/kube-cluster-info:v0.11.6
           imagePullPolicy: Always
           name: kube-cluster-info
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: monitor-configmap
           configMap:
@@ -176,3 +190,4 @@ spec:
                 values:
                 - windows
       hostNetwork: false
+      hostPID: false

--- a/charts/agent/examples/recommended-config/rendered/monitor/networkpolicy.yaml
+++ b/charts/agent/examples/recommended-config/rendered/monitor/networkpolicy.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-monitor
   namespace: observe
   labels:
-    helm.sh/chart: monitor-0.143.0
+    helm.sh/chart: monitor-0.159.0
     app.kubernetes.io/name: monitor
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector

--- a/charts/agent/examples/recommended-config/rendered/monitor/service.yaml
+++ b/charts/agent/examples/recommended-config/rendered/monitor/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-monitor
   namespace: observe
   labels:
-    helm.sh/chart: monitor-0.143.0
+    helm.sh/chart: monitor-0.159.0
     app.kubernetes.io/name: monitor
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector

--- a/charts/agent/examples/recommended-config/rendered/node-logs-metrics/daemonset.yaml
+++ b/charts/agent/examples/recommended-config/rendered/node-logs-metrics/daemonset.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-node-logs-metrics-agent
   namespace: observe
   labels:
-    helm.sh/chart: node-logs-metrics-0.143.0
+    helm.sh/chart: node-logs-metrics-0.159.0
     app.kubernetes.io/name: node-logs-metrics
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: agent-collector
@@ -68,12 +68,19 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
-            - name: GOMEMLIMIT
-              value: "409MiB"
-            - name: OTEL_K8S_POD_UID
+            - name: OTEL_K8S_NODE_NAME
               valueFrom:
                 fieldRef:
-                  fieldPath: metadata.uid
+                  fieldPath: spec.nodeName
+            - name: OTEL_K8S_NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: OTEL_K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
             - name: OTEL_K8S_POD_NAME
               valueFrom:
                 fieldRef:
@@ -84,6 +91,12 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
+            - name: GOMEMLIMIT
+              value: "409MiB"
+            - name: OTEL_K8S_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
             - name: OBSERVE_CLUSTER_NAME
               valueFrom:
                 configMapKeyRef:
@@ -158,6 +171,7 @@ spec:
           image: observeinc/kube-cluster-info:v0.11.6
           imagePullPolicy: Always
           name: kube-cluster-info
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: node-logs-metrics-configmap
           configMap:
@@ -197,3 +211,4 @@ spec:
                 values:
                 - windows
       hostNetwork: false
+      hostPID: false

--- a/charts/agent/examples/recommended-config/rendered/prometheus-scraper/deployment.yaml
+++ b/charts/agent/examples/recommended-config/rendered/prometheus-scraper/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-prometheus-scraper
   namespace: observe
   labels:
-    helm.sh/chart: prometheus-scraper-0.143.0
+    helm.sh/chart: prometheus-scraper-0.159.0
     app.kubernetes.io/name: prometheus-scraper
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector
@@ -86,12 +86,19 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
-            - name: GOMEMLIMIT
-              value: "409MiB"
-            - name: OTEL_K8S_POD_UID
+            - name: OTEL_K8S_NODE_NAME
               valueFrom:
                 fieldRef:
-                  fieldPath: metadata.uid
+                  fieldPath: spec.nodeName
+            - name: OTEL_K8S_NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: OTEL_K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
             - name: OTEL_K8S_POD_NAME
               valueFrom:
                 fieldRef:
@@ -102,6 +109,12 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
+            - name: GOMEMLIMIT
+              value: "409MiB"
+            - name: OTEL_K8S_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
             - name: OBSERVE_CLUSTER_NAME
               valueFrom:
                 configMapKeyRef:
@@ -150,6 +163,7 @@ spec:
           image: observeinc/kube-cluster-info:v0.11.6
           imagePullPolicy: Always
           name: kube-cluster-info
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: prometheus-scraper-configmap
           configMap:
@@ -176,3 +190,4 @@ spec:
                 values:
                 - windows
       hostNetwork: false
+      hostPID: false

--- a/charts/agent/examples/recommended-config/rendered/prometheus-scraper/networkpolicy.yaml
+++ b/charts/agent/examples/recommended-config/rendered/prometheus-scraper/networkpolicy.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-prometheus-scraper
   namespace: observe
   labels:
-    helm.sh/chart: prometheus-scraper-0.143.0
+    helm.sh/chart: prometheus-scraper-0.159.0
     app.kubernetes.io/name: prometheus-scraper
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector

--- a/charts/agent/examples/recommended-config/rendered/prometheus-scraper/service.yaml
+++ b/charts/agent/examples/recommended-config/rendered/prometheus-scraper/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-prometheus-scraper
   namespace: observe
   labels:
-    helm.sh/chart: prometheus-scraper-0.143.0
+    helm.sh/chart: prometheus-scraper-0.159.0
     app.kubernetes.io/name: prometheus-scraper
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.143.0"
+    app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-collector
     app.kubernetes.io/component: standalone-collector

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -488,16 +488,6 @@ cluster-events:
       valueFrom:
         fieldRef:
           fieldPath: metadata.uid
-    - name: OTEL_K8S_POD_NAME
-      valueFrom:
-        fieldRef:
-          apiVersion: v1
-          fieldPath: metadata.name
-    - name: OTEL_K8S_POD_IP
-      valueFrom:
-        fieldRef:
-          apiVersion: v1
-          fieldPath: status.podIP
     - name: OBSERVE_CLUSTER_NAME
       valueFrom:
         configMapKeyRef:
@@ -634,16 +624,6 @@ cluster-metrics:
       valueFrom:
         fieldRef:
           fieldPath: metadata.uid
-    - name: OTEL_K8S_POD_NAME
-      valueFrom:
-        fieldRef:
-          apiVersion: v1
-          fieldPath: metadata.name
-    - name: OTEL_K8S_POD_IP
-      valueFrom:
-        fieldRef:
-          apiVersion: v1
-          fieldPath: status.podIP
     - name: OBSERVE_CLUSTER_NAME
       valueFrom:
         configMapKeyRef:
@@ -813,16 +793,6 @@ prometheus-scraper:
       valueFrom:
         fieldRef:
           fieldPath: metadata.uid
-    - name: OTEL_K8S_POD_NAME
-      valueFrom:
-        fieldRef:
-          apiVersion: v1
-          fieldPath: metadata.name
-    - name: OTEL_K8S_POD_IP
-      valueFrom:
-        fieldRef:
-          apiVersion: v1
-          fieldPath: status.podIP
     - name: OBSERVE_CLUSTER_NAME
       valueFrom:
         configMapKeyRef:
@@ -966,16 +936,6 @@ node-logs-metrics:
       valueFrom:
         fieldRef:
           fieldPath: metadata.uid
-    - name: OTEL_K8S_POD_NAME
-      valueFrom:
-        fieldRef:
-          apiVersion: v1
-          fieldPath: metadata.name
-    - name: OTEL_K8S_POD_IP
-      valueFrom:
-        fieldRef:
-          apiVersion: v1
-          fieldPath: status.podIP
     - name: OBSERVE_CLUSTER_NAME
       valueFrom:
         configMapKeyRef:
@@ -1154,16 +1114,6 @@ monitor:
       valueFrom:
         fieldRef:
           fieldPath: metadata.uid
-    - name: OTEL_K8S_POD_NAME
-      valueFrom:
-        fieldRef:
-          apiVersion: v1
-          fieldPath: metadata.name
-    - name: OTEL_K8S_POD_IP
-      valueFrom:
-        fieldRef:
-          apiVersion: v1
-          fieldPath: status.podIP
     - name: OBSERVE_CLUSTER_NAME
       valueFrom:
         configMapKeyRef:
@@ -1311,16 +1261,6 @@ forwarder:
       valueFrom:
         fieldRef:
           fieldPath: metadata.uid
-    - name: OTEL_K8S_POD_NAME
-      valueFrom:
-        fieldRef:
-          apiVersion: v1
-          fieldPath: metadata.name
-    - name: OTEL_K8S_POD_IP
-      valueFrom:
-        fieldRef:
-          apiVersion: v1
-          fieldPath: status.podIP
     - name: OBSERVE_CLUSTER_NAME
       valueFrom:
         configMapKeyRef:
@@ -1480,16 +1420,6 @@ gateway:
       valueFrom:
         fieldRef:
           fieldPath: metadata.uid
-    - name: OTEL_K8S_POD_NAME
-      valueFrom:
-        fieldRef:
-          apiVersion: v1
-          fieldPath: metadata.name
-    - name: OTEL_K8S_POD_IP
-      valueFrom:
-        fieldRef:
-          apiVersion: v1
-          fieldPath: status.podIP
     - name: OBSERVE_CLUSTER_NAME
       valueFrom:
         configMapKeyRef:


### PR DESCRIPTION
Rolls forward from #509 back to upstream `opentelemetry-collector` `0.159.0` (current latest) and removes the local `OTEL_K8S_POD_NAME` / `OTEL_K8S_POD_IP` extraEnvs, which the upstream chart now injects in `_pod.tpl` and Helm v4 rejects as duplicates. #514 was actually what was needed to fix Fargate. The reason I got the  error: `Error: host IP unknown; known addresses: [{Hostname fargate-ip-xxx-xxx-xxx-xx.us-east-2.compute.internal}]` was probably because the cluster I was testing on was stale/old.

Verified on EKS Fargate: all standalone collectors and the sidecar pathway come up clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)