### PR TITLE
fix: add resource processor to put k8s.node.name on hostmetrics

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent
 description: Chart to install K8s collection stack based on Observe Agent
 type: application
-version: 0.93.1
+version: 0.93.2
 appVersion: "2.16.0"
 dependencies:
   - name: opentelemetry-collector

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -1,6 +1,6 @@
 # agent
 
-![Version: 0.93.1](https://img.shields.io/badge/Version-0.93.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.16.0](https://img.shields.io/badge/AppVersion-2.16.0-informational?style=flat-square)
+![Version: 0.93.2](https://img.shields.io/badge/Version-0.93.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.16.0](https://img.shields.io/badge/AppVersion-2.16.0-informational?style=flat-square)
 
 Chart to install K8s collection stack based on Observe Agent
 

--- a/charts/agent/examples/internal-red-metrics/rendered/node-logs-metrics-configmap.yaml
+++ b/charts/agent/examples/internal-red-metrics/rendered/node-logs-metrics-configmap.yaml
@@ -156,6 +156,11 @@ data:
           - action: upsert
             key: k8s.pod.name
             value: ${env:OTEL_K8S_POD_NAME}
+        resource/node_name:
+          attributes:
+          - action: upsert
+            key: k8s.node.name
+            value: ${env:K8S_NODE_NAME}
         resource/observe_common:
           attributes:
           - action: upsert
@@ -356,6 +361,7 @@ data:
             - memory_limiter
             - k8sattributes
             - resourcedetection/cloud
+            - resource/node_name
             - resource/observe_common
             - attributes/debug_source_hostmetrics
             receivers:

--- a/charts/agent/examples/prometheus-ta-cr-discovery/rendered/node-logs-metrics-configmap.yaml
+++ b/charts/agent/examples/prometheus-ta-cr-discovery/rendered/node-logs-metrics-configmap.yaml
@@ -121,6 +121,11 @@ data:
           - action: insert
             include: k8s.node.cpu.usage
             new_name: k8s.node.cpu.utilization
+        resource/node_name:
+          attributes:
+          - action: upsert
+            key: k8s.node.name
+            value: ${env:K8S_NODE_NAME}
         resource/observe_common:
           attributes:
           - action: upsert
@@ -280,6 +285,7 @@ data:
             - k8sattributes
             - batch
             - resourcedetection/cloud
+            - resource/node_name
             - resource/observe_common
             - attributes/debug_source_hostmetrics
             receivers:

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/node-logs-metrics-configmap.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/node-logs-metrics-configmap.yaml
@@ -121,6 +121,11 @@ data:
           - action: insert
             include: k8s.node.cpu.usage
             new_name: k8s.node.cpu.utilization
+        resource/node_name:
+          attributes:
+          - action: upsert
+            key: k8s.node.name
+            value: ${env:K8S_NODE_NAME}
         resource/observe_common:
           attributes:
           - action: upsert
@@ -280,6 +285,7 @@ data:
             - k8sattributes
             - batch
             - resourcedetection/cloud
+            - resource/node_name
             - resource/observe_common
             - attributes/debug_source_hostmetrics
             receivers:

--- a/charts/agent/examples/recommended-config/rendered/node-logs-metrics-configmap.yaml
+++ b/charts/agent/examples/recommended-config/rendered/node-logs-metrics-configmap.yaml
@@ -156,6 +156,11 @@ data:
           - action: upsert
             key: k8s.pod.name
             value: ${env:OTEL_K8S_POD_NAME}
+        resource/node_name:
+          attributes:
+          - action: upsert
+            key: k8s.node.name
+            value: ${env:K8S_NODE_NAME}
         resource/observe_common:
           attributes:
           - action: upsert
@@ -356,6 +361,7 @@ data:
             - memory_limiter
             - k8sattributes
             - resourcedetection/cloud
+            - resource/node_name
             - resource/observe_common
             - attributes/debug_source_hostmetrics
             receivers:

--- a/charts/agent/templates/_config-processors.tpl
+++ b/charts/agent/templates/_config-processors.tpl
@@ -108,6 +108,14 @@ resource/observe_common:
     {{ end }}
 {{- end -}}
 
+{{- define "config.processors.resource.node_name" -}}
+resource/node_name:
+  attributes:
+    - key: k8s.node.name
+      action: upsert
+      value: ${env:K8S_NODE_NAME}
+{{- end -}}
+
 {{- define "config.processors.resource.fargate_resource_attributes" -}}
 resource/fargate_resource_attributes:
   attributes:

--- a/charts/agent/templates/_node-logs-metrics-config.tpl
+++ b/charts/agent/templates/_node-logs-metrics-config.tpl
@@ -120,6 +120,7 @@ processors:
 {{- include "config.processors.batch" . | nindent 2 }}
 {{- include "config.processors.attributes.k8sattributes" (merge . (dict "filterToNode" true)) | nindent 2 }}
 {{- include "config.processors.resource.observe_common" . | nindent 2 }}
+{{- include "config.processors.resource.node_name" . | nindent 2 }}
 {{- include "config.processors.metricstransform.duplicate_k8s_cpu_metrics" . | nindent 2 }}
 
 {{- if .Values.agent.config.global.fleet.enabled }}
@@ -183,6 +184,7 @@ service:
           - batch
           {{- end }}
           - resourcedetection/cloud
+          - resource/node_name
           - resource/observe_common
           - attributes/debug_source_hostmetrics
         exporters: [{{ join ", " $hostmetricsExporters }}]


### PR DESCRIPTION
OB-61993

The k8sattributes processor is insufficient because the hostmetrics receiver metrics cannot be associated with a pod.