### PR TITLE
chore(ci): update CI GitHub Actions versions

### DIFF
--- a/.github/workflows/check-examples.yml
+++ b/.github/workflows/check-examples.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
         with:
           version: v3.12.1
 

--- a/.github/workflows/orca.yaml
+++ b/.github/workflows/orca.yaml
@@ -18,7 +18,7 @@ jobs:
     steps:
       # Checkout your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           # Important for pull request diff-awareness report
           fetch-depth: 0

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -9,7 +9,7 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: gabe565/setup-helm-docs-action@v1
       - uses: pre-commit/action@v3.0.1
         env:
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     if: "!startsWith(github.event.head_commit.message, 'chore')"
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,14 +7,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Install Helm
         uses: azure/setup-helm@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.9'
           check-latest: true
@@ -36,7 +36,7 @@ jobs:
     name: test-charts (helm v${{ matrix.helm-major }})
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/tests-integration.yaml
+++ b/.github/workflows/tests-integration.yaml
@@ -51,7 +51,7 @@ jobs:
             working-directory: integration #Terraform commands and tests are ran from integration directory
     steps:
         - name: Checkout code
-          uses: actions/checkout@v6
+          uses: actions/checkout@v7
           with:
             fetch-depth: 0
             ref: ${{ github.event.inputs.branch }}
@@ -66,7 +66,7 @@ jobs:
             version: latest
 
         - name: Setup Python
-          uses: actions/setup-python@v5
+          uses: actions/setup-python@v7
           with:
             python-version: '3.10'
 
@@ -91,7 +91,7 @@ jobs:
             terraform test -verbose -junit-xml=results-ns-${{ matrix.namespace }}+values-${{ matrix.values }}.xml
 
         - name: Upload Test Results
-          uses: actions/upload-artifact@v4
+          uses: actions/upload-artifact@v7
           if: success() || failure()
           with:
             name: results-ns-${{ matrix.namespace }}+values-${{ matrix.values }}

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       # Checkout the repository
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -25,7 +25,7 @@ jobs:
           UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run helm-docs
-        uses: losisin/helm-docs-github-action@v1
+        uses: losisin/helm-docs-github-action@v2
         with:
           git-push: false
 


### PR DESCRIPTION
## Summary

Consolidates all open Dependabot GitHub Actions bump PRs into a single change. Once merged, the individual Dependabot PRs (#495, #496, #497, #512, #517) can be closed.

### Changes

| Action | From | To | Files |
|---|---|---|---|
| `actions/checkout` | v6 | v7 | check-examples.yml, orca.yaml, pre-commit.yml, release.yml, test.yml, tests-integration.yaml, update-deps.yml |
| `actions/setup-python` | v5 | v7 | test.yml, tests-integration.yaml |
| `actions/upload-artifact` | v4 | v7 | tests-integration.yaml |
| `azure/setup-helm` | v4 | v5 | check-examples.yml |
| `losisin/helm-docs-github-action` | v1 | v2 | update-deps.yml |

### Replaces Dependabot PRs
- #495 — bump azure/setup-helm from 4 to 5
- #496 — bump losisin/helm-docs-github-action from 1 to 2
- #497 — bump actions/upload-artifact from 4 to 7
- #512 — bump actions/checkout from 6 to 7
- #517 — bump actions/setup-python from 5 to 7