### PR TITLE
feat(agent): bump observe-agent to 2.18.0

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agent
 description: Chart to install K8s collection stack based on Observe Agent
 type: application
-version: 0.93.2
-appVersion: "2.16.0"
+version: 0.94.0
+appVersion: "2.18.0"
 dependencies:
   - name: opentelemetry-collector
     version: 0.159.0

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -1,6 +1,6 @@
 # agent
 
-![Version: 0.93.2](https://img.shields.io/badge/Version-0.93.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.16.0](https://img.shields.io/badge/AppVersion-2.16.0-informational?style=flat-square)
+![Version: 0.94.0](https://img.shields.io/badge/Version-0.94.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.18.0](https://img.shields.io/badge/AppVersion-2.18.0-informational?style=flat-square)
 
 Chart to install K8s collection stack based on Observe Agent
 
@@ -148,7 +148,7 @@ This service is an *OpenTelemetryCollector*, a custom resource that is managed b
 | cluster-events.extraVolumes[0].configMap.items[0].path | string | `"observe-agent.yaml"` |  |
 | cluster-events.extraVolumes[0].configMap.name | string | `"observe-agent"` |  |
 | cluster-events.extraVolumes[0].name | string | `"observe-agent-deployment-config"` |  |
-| cluster-events.image | object | `{"pullPolicy":"IfNotPresent","repository":"observeinc/observe-agent","tag":"2.16.0"}` | --------------------------------------- # Same for each deployment/daemonset      # |
+| cluster-events.image | object | `{"pullPolicy":"IfNotPresent","repository":"observeinc/observe-agent","tag":"2.18.0"}` | --------------------------------------- # Same for each deployment/daemonset      # |
 | cluster-events.initContainers[0].env[0].name | string | `"NAMESPACE"` |  |
 | cluster-events.initContainers[0].env[0].valueFrom.fieldRef.fieldPath | string | `"metadata.namespace"` |  |
 | cluster-events.initContainers[0].image | string | `"observeinc/kube-cluster-info:v0.11.6"` |  |
@@ -216,7 +216,7 @@ This service is an *OpenTelemetryCollector*, a custom resource that is managed b
 | cluster-metrics.extraVolumes[0].configMap.items[0].path | string | `"observe-agent.yaml"` |  |
 | cluster-metrics.extraVolumes[0].configMap.name | string | `"observe-agent"` |  |
 | cluster-metrics.extraVolumes[0].name | string | `"observe-agent-deployment-config"` |  |
-| cluster-metrics.image | object | `{"pullPolicy":"IfNotPresent","repository":"observeinc/observe-agent","tag":"2.16.0"}` | --------------------------------------- # Same for each deployment/daemonset      # |
+| cluster-metrics.image | object | `{"pullPolicy":"IfNotPresent","repository":"observeinc/observe-agent","tag":"2.18.0"}` | --------------------------------------- # Same for each deployment/daemonset      # |
 | cluster-metrics.initContainers[0].env[0].name | string | `"NAMESPACE"` |  |
 | cluster-metrics.initContainers[0].env[0].valueFrom.fieldRef.fieldPath | string | `"metadata.namespace"` |  |
 | cluster-metrics.initContainers[0].image | string | `"observeinc/kube-cluster-info:v0.11.6"` |  |
@@ -301,7 +301,7 @@ This service is an *OpenTelemetryCollector*, a custom resource that is managed b
 | forwarder.extraVolumes[0].configMap.items[0].path | string | `"observe-agent.yaml"` |  |
 | forwarder.extraVolumes[0].configMap.name | string | `"observe-agent"` |  |
 | forwarder.extraVolumes[0].name | string | `"observe-agent-deployment-config"` |  |
-| forwarder.image | object | `{"pullPolicy":"IfNotPresent","repository":"observeinc/observe-agent","tag":"2.16.0"}` | --------------------------------------- # Same for each deployment/daemonset      # |
+| forwarder.image | object | `{"pullPolicy":"IfNotPresent","repository":"observeinc/observe-agent","tag":"2.18.0"}` | --------------------------------------- # Same for each deployment/daemonset      # |
 | forwarder.initContainers[0].env[0].name | string | `"NAMESPACE"` |  |
 | forwarder.initContainers[0].env[0].valueFrom.fieldRef.fieldPath | string | `"metadata.namespace"` |  |
 | forwarder.initContainers[0].image | string | `"observeinc/kube-cluster-info:v0.11.6"` |  |
@@ -374,7 +374,7 @@ This service is an *OpenTelemetryCollector*, a custom resource that is managed b
 | gateway.extraVolumes[0].configMap.items[0].path | string | `"observe-agent.yaml"` |  |
 | gateway.extraVolumes[0].configMap.name | string | `"observe-agent"` |  |
 | gateway.extraVolumes[0].name | string | `"observe-agent-deployment-config"` |  |
-| gateway.image | object | `{"pullPolicy":"IfNotPresent","repository":"observeinc/observe-agent","tag":"2.16.0"}` | --------------------------------------- # Same for each deployment/daemonset      # |
+| gateway.image | object | `{"pullPolicy":"IfNotPresent","repository":"observeinc/observe-agent","tag":"2.18.0"}` | --------------------------------------- # Same for each deployment/daemonset      # |
 | gateway.initContainers[0].env[0].name | string | `"NAMESPACE"` |  |
 | gateway.initContainers[0].env[0].valueFrom.fieldRef.fieldPath | string | `"metadata.namespace"` |  |
 | gateway.initContainers[0].image | string | `"observeinc/kube-cluster-info:v0.11.6"` |  |
@@ -451,7 +451,7 @@ This service is an *OpenTelemetryCollector*, a custom resource that is managed b
 | monitor.extraVolumes[0].configMap.items[0].path | string | `"observe-agent.yaml"` |  |
 | monitor.extraVolumes[0].configMap.name | string | `"observe-agent"` |  |
 | monitor.extraVolumes[0].name | string | `"observe-agent-deployment-config"` |  |
-| monitor.image | object | `{"pullPolicy":"IfNotPresent","repository":"observeinc/observe-agent","tag":"2.16.0"}` | --------------------------------------- # Same for each deployment/daemonset      # |
+| monitor.image | object | `{"pullPolicy":"IfNotPresent","repository":"observeinc/observe-agent","tag":"2.18.0"}` | --------------------------------------- # Same for each deployment/daemonset      # |
 | monitor.initContainers[0].env[0].name | string | `"NAMESPACE"` |  |
 | monitor.initContainers[0].env[0].valueFrom.fieldRef.fieldPath | string | `"metadata.namespace"` |  |
 | monitor.initContainers[0].image | string | `"observeinc/kube-cluster-info:v0.11.6"` |  |
@@ -548,7 +548,7 @@ This service is an *OpenTelemetryCollector*, a custom resource that is managed b
 | node-logs-metrics.extraVolumes[3].name | string | `"varlibotelcol"` |  |
 | node-logs-metrics.extraVolumes[4].hostPath.path | string | `"/"` |  |
 | node-logs-metrics.extraVolumes[4].name | string | `"hostfs"` |  |
-| node-logs-metrics.image | object | `{"pullPolicy":"IfNotPresent","repository":"observeinc/observe-agent","tag":"2.16.0"}` | --------------------------------------- # Same for each deployment/daemonset      # |
+| node-logs-metrics.image | object | `{"pullPolicy":"IfNotPresent","repository":"observeinc/observe-agent","tag":"2.18.0"}` | --------------------------------------- # Same for each deployment/daemonset      # |
 | node-logs-metrics.initContainers[0].env[0].name | string | `"NAMESPACE"` |  |
 | node-logs-metrics.initContainers[0].env[0].valueFrom.fieldRef.fieldPath | string | `"metadata.namespace"` |  |
 | node-logs-metrics.initContainers[0].image | string | `"observeinc/kube-cluster-info:v0.11.6"` |  |
@@ -675,7 +675,7 @@ This service is an *OpenTelemetryCollector*, a custom resource that is managed b
 | prometheus-scraper.extraVolumes[0].configMap.items[0].path | string | `"observe-agent.yaml"` |  |
 | prometheus-scraper.extraVolumes[0].configMap.name | string | `"observe-agent"` |  |
 | prometheus-scraper.extraVolumes[0].name | string | `"observe-agent-deployment-config"` |  |
-| prometheus-scraper.image | object | `{"pullPolicy":"IfNotPresent","repository":"observeinc/observe-agent","tag":"2.16.0"}` | --------------------------------------- # Same for each deployment/daemonset      # |
+| prometheus-scraper.image | object | `{"pullPolicy":"IfNotPresent","repository":"observeinc/observe-agent","tag":"2.18.0"}` | --------------------------------------- # Same for each deployment/daemonset      # |
 | prometheus-scraper.initContainers[0].env[0].name | string | `"NAMESPACE"` |  |
 | prometheus-scraper.initContainers[0].env[0].valueFrom.fieldRef.fieldPath | string | `"metadata.namespace"` |  |
 | prometheus-scraper.initContainers[0].image | string | `"observeinc/kube-cluster-info:v0.11.6"` |  |

--- a/charts/agent/examples/aws-eks-fargate/rendered/cluster-events-configmap.yaml
+++ b/charts/agent/examples/aws-eks-fargate/rendered/cluster-events-configmap.yaml
@@ -188,7 +188,7 @@ data:
             - set(attributes["observe_transform"]["control"]["isDelete"], false) where attributes["observe_transform"]["control"]["isDelete"]
               == nil
             - set(attributes["observe_transform"]["control"]["version"], body["metadata"]["resourceVersion"])
-            - set(attributes["observe_transform"]["control"]["agentVersion"], "2.16.0")
+            - set(attributes["observe_transform"]["control"]["agentVersion"], "2.18.0")
             - set(attributes["observe_transform"]["identifiers"]["clusterName"], resource.attributes["k8s.cluster.name"])
             - set(attributes["observe_transform"]["identifiers"]["clusterUid"], resource.attributes["k8s.cluster.uid"])
             - set(attributes["observe_transform"]["identifiers"]["kind"], body["kind"])

--- a/charts/agent/examples/aws-eks-fargate/rendered/cluster-events/deployment.yaml
+++ b/charts/agent/examples/aws-eks-fargate/rendered/cluster-events/deployment.yaml
@@ -54,7 +54,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "observeinc/observe-agent:2.16.0"
+          image: "observeinc/observe-agent:2.18.0"
           imagePullPolicy: IfNotPresent
           ports:
 

--- a/charts/agent/examples/aws-eks-fargate/rendered/cluster-metrics/deployment.yaml
+++ b/charts/agent/examples/aws-eks-fargate/rendered/cluster-metrics/deployment.yaml
@@ -55,7 +55,7 @@ spec:
             - --feature-gates=+exporter.prometheusremotewritexporter.EnableMultipleWorkers
           securityContext:
             {}
-          image: "observeinc/observe-agent:2.16.0"
+          image: "observeinc/observe-agent:2.18.0"
           imagePullPolicy: IfNotPresent
           ports:
 

--- a/charts/agent/examples/aws-eks-fargate/rendered/forwarder/deployment.yaml
+++ b/charts/agent/examples/aws-eks-fargate/rendered/forwarder/deployment.yaml
@@ -55,7 +55,7 @@ spec:
             - --feature-gates=+connector.spanmetrics.includeCollectorInstanceID
           securityContext:
             {}
-          image: "observeinc/observe-agent:2.16.0"
+          image: "observeinc/observe-agent:2.18.0"
           imagePullPolicy: IfNotPresent
           ports:
 

--- a/charts/agent/examples/aws-eks-fargate/rendered/gateway/deployment.yaml
+++ b/charts/agent/examples/aws-eks-fargate/rendered/gateway/deployment.yaml
@@ -55,7 +55,7 @@ spec:
             - --feature-gates=+connector.spanmetrics.includeCollectorInstanceID
           securityContext:
             {}
-          image: "observeinc/observe-agent:2.16.0"
+          image: "observeinc/observe-agent:2.18.0"
           imagePullPolicy: IfNotPresent
           ports:
 

--- a/charts/agent/examples/aws-eks-fargate/rendered/monitor/deployment.yaml
+++ b/charts/agent/examples/aws-eks-fargate/rendered/monitor/deployment.yaml
@@ -55,7 +55,7 @@ spec:
             - --feature-gates=+exporter.prometheusremotewritexporter.EnableMultipleWorkers
           securityContext:
             {}
-          image: "observeinc/observe-agent:2.16.0"
+          image: "observeinc/observe-agent:2.18.0"
           imagePullPolicy: IfNotPresent
           ports:
 

--- a/charts/agent/examples/aws-eks-fargate/rendered/prometheus-scraper/deployment.yaml
+++ b/charts/agent/examples/aws-eks-fargate/rendered/prometheus-scraper/deployment.yaml
@@ -55,7 +55,7 @@ spec:
             - --feature-gates=+exporter.prometheusremotewritexporter.EnableMultipleWorkers
           securityContext:
             {}
-          image: "observeinc/observe-agent:2.16.0"
+          image: "observeinc/observe-agent:2.18.0"
           imagePullPolicy: IfNotPresent
           ports:
 

--- a/charts/agent/examples/internal-red-metrics/rendered/cluster-events-configmap.yaml
+++ b/charts/agent/examples/internal-red-metrics/rendered/cluster-events-configmap.yaml
@@ -188,7 +188,7 @@ data:
             - set(attributes["observe_transform"]["control"]["isDelete"], false) where attributes["observe_transform"]["control"]["isDelete"]
               == nil
             - set(attributes["observe_transform"]["control"]["version"], body["metadata"]["resourceVersion"])
-            - set(attributes["observe_transform"]["control"]["agentVersion"], "2.16.0")
+            - set(attributes["observe_transform"]["control"]["agentVersion"], "2.18.0")
             - set(attributes["observe_transform"]["identifiers"]["clusterName"], resource.attributes["k8s.cluster.name"])
             - set(attributes["observe_transform"]["identifiers"]["clusterUid"], resource.attributes["k8s.cluster.uid"])
             - set(attributes["observe_transform"]["identifiers"]["kind"], body["kind"])

--- a/charts/agent/examples/internal-red-metrics/rendered/cluster-events/deployment.yaml
+++ b/charts/agent/examples/internal-red-metrics/rendered/cluster-events/deployment.yaml
@@ -54,7 +54,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "observeinc/observe-agent:2.16.0"
+          image: "observeinc/observe-agent:2.18.0"
           imagePullPolicy: IfNotPresent
           ports:
 

--- a/charts/agent/examples/internal-red-metrics/rendered/cluster-metrics/deployment.yaml
+++ b/charts/agent/examples/internal-red-metrics/rendered/cluster-metrics/deployment.yaml
@@ -55,7 +55,7 @@ spec:
             - --feature-gates=+exporter.prometheusremotewritexporter.EnableMultipleWorkers
           securityContext:
             {}
-          image: "observeinc/observe-agent:2.16.0"
+          image: "observeinc/observe-agent:2.18.0"
           imagePullPolicy: IfNotPresent
           ports:
 

--- a/charts/agent/examples/internal-red-metrics/rendered/forwarder/daemonset.yaml
+++ b/charts/agent/examples/internal-red-metrics/rendered/forwarder/daemonset.yaml
@@ -54,7 +54,7 @@ spec:
             - --feature-gates=+connector.spanmetrics.includeCollectorInstanceID
           securityContext:
             {}
-          image: "observeinc/observe-agent:2.16.0"
+          image: "observeinc/observe-agent:2.18.0"
           imagePullPolicy: IfNotPresent
           ports:
 

--- a/charts/agent/examples/internal-red-metrics/rendered/gateway/deployment.yaml
+++ b/charts/agent/examples/internal-red-metrics/rendered/gateway/deployment.yaml
@@ -55,7 +55,7 @@ spec:
             - --feature-gates=+connector.spanmetrics.includeCollectorInstanceID
           securityContext:
             {}
-          image: "observeinc/observe-agent:2.16.0"
+          image: "observeinc/observe-agent:2.18.0"
           imagePullPolicy: IfNotPresent
           ports:
 

--- a/charts/agent/examples/internal-red-metrics/rendered/monitor/deployment.yaml
+++ b/charts/agent/examples/internal-red-metrics/rendered/monitor/deployment.yaml
@@ -55,7 +55,7 @@ spec:
             - --feature-gates=+exporter.prometheusremotewritexporter.EnableMultipleWorkers
           securityContext:
             {}
-          image: "observeinc/observe-agent:2.16.0"
+          image: "observeinc/observe-agent:2.18.0"
           imagePullPolicy: IfNotPresent
           ports:
 

--- a/charts/agent/examples/internal-red-metrics/rendered/node-logs-metrics/daemonset.yaml
+++ b/charts/agent/examples/internal-red-metrics/rendered/node-logs-metrics/daemonset.yaml
@@ -55,7 +55,7 @@ spec:
           securityContext:
             runAsGroup: 0
             runAsUser: 0
-          image: "observeinc/observe-agent:2.16.0"
+          image: "observeinc/observe-agent:2.18.0"
           imagePullPolicy: IfNotPresent
           ports:
 

--- a/charts/agent/examples/internal-red-metrics/rendered/prometheus-scraper/deployment.yaml
+++ b/charts/agent/examples/internal-red-metrics/rendered/prometheus-scraper/deployment.yaml
@@ -55,7 +55,7 @@ spec:
             - --feature-gates=+exporter.prometheusremotewritexporter.EnableMultipleWorkers
           securityContext:
             {}
-          image: "observeinc/observe-agent:2.16.0"
+          image: "observeinc/observe-agent:2.18.0"
           imagePullPolicy: IfNotPresent
           ports:
 

--- a/charts/agent/examples/prometheus-ta-cr-discovery/rendered/cluster-events-configmap.yaml
+++ b/charts/agent/examples/prometheus-ta-cr-discovery/rendered/cluster-events-configmap.yaml
@@ -93,7 +93,7 @@ data:
             - set(attributes["observe_transform"]["control"]["isDelete"], false) where attributes["observe_transform"]["control"]["isDelete"]
               == nil
             - set(attributes["observe_transform"]["control"]["version"], body["metadata"]["resourceVersion"])
-            - set(attributes["observe_transform"]["control"]["agentVersion"], "2.16.0")
+            - set(attributes["observe_transform"]["control"]["agentVersion"], "2.18.0")
             - set(attributes["observe_transform"]["identifiers"]["clusterName"], resource.attributes["k8s.cluster.name"])
             - set(attributes["observe_transform"]["identifiers"]["clusterUid"], resource.attributes["k8s.cluster.uid"])
             - set(attributes["observe_transform"]["identifiers"]["kind"], body["kind"])

--- a/charts/agent/examples/prometheus-ta-cr-discovery/rendered/cluster-events/deployment.yaml
+++ b/charts/agent/examples/prometheus-ta-cr-discovery/rendered/cluster-events/deployment.yaml
@@ -54,7 +54,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "observeinc/observe-agent:2.16.0"
+          image: "observeinc/observe-agent:2.18.0"
           imagePullPolicy: IfNotPresent
           ports:
 

--- a/charts/agent/examples/prometheus-ta-cr-discovery/rendered/cluster-metrics/deployment.yaml
+++ b/charts/agent/examples/prometheus-ta-cr-discovery/rendered/cluster-metrics/deployment.yaml
@@ -55,7 +55,7 @@ spec:
             - --feature-gates=+exporter.prometheusremotewritexporter.EnableMultipleWorkers
           securityContext:
             {}
-          image: "observeinc/observe-agent:2.16.0"
+          image: "observeinc/observe-agent:2.18.0"
           imagePullPolicy: IfNotPresent
           ports:
 

--- a/charts/agent/examples/prometheus-ta-cr-discovery/rendered/forwarder/daemonset.yaml
+++ b/charts/agent/examples/prometheus-ta-cr-discovery/rendered/forwarder/daemonset.yaml
@@ -54,7 +54,7 @@ spec:
             - --feature-gates=+connector.spanmetrics.includeCollectorInstanceID
           securityContext:
             {}
-          image: "observeinc/observe-agent:2.16.0"
+          image: "observeinc/observe-agent:2.18.0"
           imagePullPolicy: IfNotPresent
           ports:
 

--- a/charts/agent/examples/prometheus-ta-cr-discovery/rendered/monitor/deployment.yaml
+++ b/charts/agent/examples/prometheus-ta-cr-discovery/rendered/monitor/deployment.yaml
@@ -55,7 +55,7 @@ spec:
             - --feature-gates=+exporter.prometheusremotewritexporter.EnableMultipleWorkers
           securityContext:
             {}
-          image: "observeinc/observe-agent:2.16.0"
+          image: "observeinc/observe-agent:2.18.0"
           imagePullPolicy: IfNotPresent
           ports:
 

--- a/charts/agent/examples/prometheus-ta-cr-discovery/rendered/node-logs-metrics/daemonset.yaml
+++ b/charts/agent/examples/prometheus-ta-cr-discovery/rendered/node-logs-metrics/daemonset.yaml
@@ -55,7 +55,7 @@ spec:
           securityContext:
             runAsGroup: 0
             runAsUser: 0
-          image: "observeinc/observe-agent:2.16.0"
+          image: "observeinc/observe-agent:2.18.0"
           imagePullPolicy: IfNotPresent
           ports:
 

--- a/charts/agent/examples/prometheus-ta-cr-discovery/rendered/prometheus-scraper/deployment.yaml
+++ b/charts/agent/examples/prometheus-ta-cr-discovery/rendered/prometheus-scraper/deployment.yaml
@@ -55,7 +55,7 @@ spec:
             - --feature-gates=+exporter.prometheusremotewritexporter.EnableMultipleWorkers
           securityContext:
             {}
-          image: "observeinc/observe-agent:2.16.0"
+          image: "observeinc/observe-agent:2.18.0"
           imagePullPolicy: IfNotPresent
           ports:
 

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/cluster-events-configmap.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/cluster-events-configmap.yaml
@@ -93,7 +93,7 @@ data:
             - set(attributes["observe_transform"]["control"]["isDelete"], false) where attributes["observe_transform"]["control"]["isDelete"]
               == nil
             - set(attributes["observe_transform"]["control"]["version"], body["metadata"]["resourceVersion"])
-            - set(attributes["observe_transform"]["control"]["agentVersion"], "2.16.0")
+            - set(attributes["observe_transform"]["control"]["agentVersion"], "2.18.0")
             - set(attributes["observe_transform"]["identifiers"]["clusterName"], resource.attributes["k8s.cluster.name"])
             - set(attributes["observe_transform"]["identifiers"]["clusterUid"], resource.attributes["k8s.cluster.uid"])
             - set(attributes["observe_transform"]["identifiers"]["kind"], body["kind"])

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/cluster-events/deployment.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/cluster-events/deployment.yaml
@@ -54,7 +54,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "observeinc/observe-agent:2.16.0"
+          image: "observeinc/observe-agent:2.18.0"
           imagePullPolicy: IfNotPresent
           ports:
 

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/cluster-metrics/deployment.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/cluster-metrics/deployment.yaml
@@ -55,7 +55,7 @@ spec:
             - --feature-gates=+exporter.prometheusremotewritexporter.EnableMultipleWorkers
           securityContext:
             {}
-          image: "observeinc/observe-agent:2.16.0"
+          image: "observeinc/observe-agent:2.18.0"
           imagePullPolicy: IfNotPresent
           ports:
 

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/forwarder/daemonset.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/forwarder/daemonset.yaml
@@ -54,7 +54,7 @@ spec:
             - --feature-gates=+connector.spanmetrics.includeCollectorInstanceID
           securityContext:
             {}
-          image: "observeinc/observe-agent:2.16.0"
+          image: "observeinc/observe-agent:2.18.0"
           imagePullPolicy: IfNotPresent
           ports:
 

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/monitor/deployment.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/monitor/deployment.yaml
@@ -55,7 +55,7 @@ spec:
             - --feature-gates=+exporter.prometheusremotewritexporter.EnableMultipleWorkers
           securityContext:
             {}
-          image: "observeinc/observe-agent:2.16.0"
+          image: "observeinc/observe-agent:2.18.0"
           imagePullPolicy: IfNotPresent
           ports:
 

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/node-logs-metrics/daemonset.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/node-logs-metrics/daemonset.yaml
@@ -55,7 +55,7 @@ spec:
           securityContext:
             runAsGroup: 0
             runAsUser: 0
-          image: "observeinc/observe-agent:2.16.0"
+          image: "observeinc/observe-agent:2.18.0"
           imagePullPolicy: IfNotPresent
           ports:
 

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/prometheus-scraper/deployment.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/prometheus-scraper/deployment.yaml
@@ -55,7 +55,7 @@ spec:
             - --feature-gates=+exporter.prometheusremotewritexporter.EnableMultipleWorkers
           securityContext:
             {}
-          image: "observeinc/observe-agent:2.16.0"
+          image: "observeinc/observe-agent:2.18.0"
           imagePullPolicy: IfNotPresent
           ports:
 

--- a/charts/agent/examples/recommended-config/rendered/cluster-events-configmap.yaml
+++ b/charts/agent/examples/recommended-config/rendered/cluster-events-configmap.yaml
@@ -188,7 +188,7 @@ data:
             - set(attributes["observe_transform"]["control"]["isDelete"], false) where attributes["observe_transform"]["control"]["isDelete"]
               == nil
             - set(attributes["observe_transform"]["control"]["version"], body["metadata"]["resourceVersion"])
-            - set(attributes["observe_transform"]["control"]["agentVersion"], "2.16.0")
+            - set(attributes["observe_transform"]["control"]["agentVersion"], "2.18.0")
             - set(attributes["observe_transform"]["identifiers"]["clusterName"], resource.attributes["k8s.cluster.name"])
             - set(attributes["observe_transform"]["identifiers"]["clusterUid"], resource.attributes["k8s.cluster.uid"])
             - set(attributes["observe_transform"]["identifiers"]["kind"], body["kind"])

--- a/charts/agent/examples/recommended-config/rendered/cluster-events/deployment.yaml
+++ b/charts/agent/examples/recommended-config/rendered/cluster-events/deployment.yaml
@@ -54,7 +54,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "observeinc/observe-agent:2.16.0"
+          image: "observeinc/observe-agent:2.18.0"
           imagePullPolicy: IfNotPresent
           ports:
 

--- a/charts/agent/examples/recommended-config/rendered/cluster-metrics/deployment.yaml
+++ b/charts/agent/examples/recommended-config/rendered/cluster-metrics/deployment.yaml
@@ -55,7 +55,7 @@ spec:
             - --feature-gates=+exporter.prometheusremotewritexporter.EnableMultipleWorkers
           securityContext:
             {}
-          image: "observeinc/observe-agent:2.16.0"
+          image: "observeinc/observe-agent:2.18.0"
           imagePullPolicy: IfNotPresent
           ports:
 

--- a/charts/agent/examples/recommended-config/rendered/forwarder/daemonset.yaml
+++ b/charts/agent/examples/recommended-config/rendered/forwarder/daemonset.yaml
@@ -54,7 +54,7 @@ spec:
             - --feature-gates=+connector.spanmetrics.includeCollectorInstanceID
           securityContext:
             {}
-          image: "observeinc/observe-agent:2.16.0"
+          image: "observeinc/observe-agent:2.18.0"
           imagePullPolicy: IfNotPresent
           ports:
 

--- a/charts/agent/examples/recommended-config/rendered/gateway/deployment.yaml
+++ b/charts/agent/examples/recommended-config/rendered/gateway/deployment.yaml
@@ -55,7 +55,7 @@ spec:
             - --feature-gates=+connector.spanmetrics.includeCollectorInstanceID
           securityContext:
             {}
-          image: "observeinc/observe-agent:2.16.0"
+          image: "observeinc/observe-agent:2.18.0"
           imagePullPolicy: IfNotPresent
           ports:
 

--- a/charts/agent/examples/recommended-config/rendered/monitor/deployment.yaml
+++ b/charts/agent/examples/recommended-config/rendered/monitor/deployment.yaml
@@ -55,7 +55,7 @@ spec:
             - --feature-gates=+exporter.prometheusremotewritexporter.EnableMultipleWorkers
           securityContext:
             {}
-          image: "observeinc/observe-agent:2.16.0"
+          image: "observeinc/observe-agent:2.18.0"
           imagePullPolicy: IfNotPresent
           ports:
 

--- a/charts/agent/examples/recommended-config/rendered/node-logs-metrics/daemonset.yaml
+++ b/charts/agent/examples/recommended-config/rendered/node-logs-metrics/daemonset.yaml
@@ -55,7 +55,7 @@ spec:
           securityContext:
             runAsGroup: 0
             runAsUser: 0
-          image: "observeinc/observe-agent:2.16.0"
+          image: "observeinc/observe-agent:2.18.0"
           imagePullPolicy: IfNotPresent
           ports:
 

--- a/charts/agent/examples/recommended-config/rendered/prometheus-scraper/deployment.yaml
+++ b/charts/agent/examples/recommended-config/rendered/prometheus-scraper/deployment.yaml
@@ -55,7 +55,7 @@ spec:
             - --feature-gates=+exporter.prometheusremotewritexporter.EnableMultipleWorkers
           securityContext:
             {}
-          image: "observeinc/observe-agent:2.16.0"
+          image: "observeinc/observe-agent:2.18.0"
           imagePullPolicy: IfNotPresent
           ports:
 

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -426,7 +426,7 @@ cluster-events:
   # Same for each deployment/daemonset      #
   image:
     repository: observeinc/observe-agent
-    tag: 2.16.0
+    tag: 2.18.0
     pullPolicy: IfNotPresent
 
   command:
@@ -562,7 +562,7 @@ cluster-metrics:
   # Same for each deployment/daemonset      #
   image:
     repository: observeinc/observe-agent
-    tag: 2.16.0
+    tag: 2.18.0
     pullPolicy: IfNotPresent
 
   command:
@@ -731,7 +731,7 @@ prometheus-scraper:
   # Same for each deployment/daemonset      #
   image:
     repository: observeinc/observe-agent
-    tag: 2.16.0
+    tag: 2.18.0
     pullPolicy: IfNotPresent
 
   command:
@@ -866,7 +866,7 @@ node-logs-metrics:
   # Same for each deployment/daemonset      #
   image:
     repository: observeinc/observe-agent
-    tag: 2.16.0
+    tag: 2.18.0
     pullPolicy: IfNotPresent
 
   command:
@@ -1052,7 +1052,7 @@ monitor:
   # Same for each deployment/daemonset      #
   image:
     repository: observeinc/observe-agent
-    tag: 2.16.0
+    tag: 2.18.0
     pullPolicy: IfNotPresent
 
   command:
@@ -1193,7 +1193,7 @@ forwarder:
   # Same for each deployment/daemonset      #
   image:
     repository: observeinc/observe-agent
-    tag: 2.16.0
+    tag: 2.18.0
     pullPolicy: IfNotPresent
 
   command:
@@ -1347,7 +1347,7 @@ gateway:
   # Same for each deployment/daemonset      #
   image:
     repository: observeinc/observe-agent
-    tag: 2.16.0
+    tag: 2.18.0
     pullPolicy: IfNotPresent
 
   command:


### PR DESCRIPTION
## Summary

- Bump `appVersion` in `Chart.yaml` from `2.16.0` to `2.18.0`
- Update all 7 image `tag` references in `values.yaml` from `2.16.0` to `2.18.0`
- Bump chart `version` from `0.93.2` to `0.94.0`

## Test plan

- [x] Deployed locally in minikube using the local chart
- [x] All 7 pods reached `1/1 Running` with `service.version: 2.18.0` confirmed via `exec_version.sh`
- [x] Logs flowing into `198826828955.observe-eng.com` — confirmed in `Host Explorer/OpenTelemetry Logs` dataset with data from `kube-system` and `observe` namespaces
- [x] Zero export failures across all pods

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)