### PR TITLE
fix(agent): remove hardcoded release name from gateway NetworkPolicy selector

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent
 description: Chart to install K8s collection stack based on Observe Agent
 type: application
-version: 0.94.0
+version: 0.94.1
 appVersion: "2.18.0"
 dependencies:
   - name: opentelemetry-collector

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -1,6 +1,6 @@
 # agent
 
-![Version: 0.94.0](https://img.shields.io/badge/Version-0.94.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.18.0](https://img.shields.io/badge/AppVersion-2.18.0-informational?style=flat-square)
+![Version: 0.94.1](https://img.shields.io/badge/Version-0.94.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.18.0](https://img.shields.io/badge/AppVersion-2.18.0-informational?style=flat-square)
 
 Chart to install K8s collection stack based on Observe Agent
 
@@ -387,7 +387,6 @@ This service is an *OpenTelemetryCollector*, a custom resource that is managed b
 | gateway.mode | string | `"deployment"` |  |
 | gateway.nameOverride | string | `"gateway"` | --------------------------------------- # Different for each deployment/daemonset # |
 | gateway.namespaceOverride | string | `"observe"` |  |
-| gateway.networkPolicy.allowIngressFrom[0].podSelector.matchLabels."app.kubernetes.io/instance" | string | `"observe-agent"` |  |
 | gateway.networkPolicy.allowIngressFrom[0].podSelector.matchLabels."app.kubernetes.io/name" | string | `"forwarder"` |  |
 | gateway.networkPolicy.egressRules[0] | object | `{}` |  |
 | gateway.networkPolicy.enabled | bool | `true` |  |

--- a/charts/agent/examples/aws-eks-fargate/rendered/gateway/networkpolicy.yaml
+++ b/charts/agent/examples/aws-eks-fargate/rendered/gateway/networkpolicy.yaml
@@ -38,7 +38,6 @@ spec:
       from:
         - podSelector:
             matchLabels:
-              app.kubernetes.io/instance: observe-agent
               app.kubernetes.io/name: forwarder
   egress:
     - {}

--- a/charts/agent/examples/internal-red-metrics/rendered/gateway/networkpolicy.yaml
+++ b/charts/agent/examples/internal-red-metrics/rendered/gateway/networkpolicy.yaml
@@ -38,7 +38,6 @@ spec:
       from:
         - podSelector:
             matchLabels:
-              app.kubernetes.io/instance: observe-agent
               app.kubernetes.io/name: forwarder
   egress:
     - {}

--- a/charts/agent/examples/recommended-config/rendered/gateway/networkpolicy.yaml
+++ b/charts/agent/examples/recommended-config/rendered/gateway/networkpolicy.yaml
@@ -38,7 +38,6 @@ spec:
       from:
         - podSelector:
             matchLabels:
-              app.kubernetes.io/instance: observe-agent
               app.kubernetes.io/name: forwarder
   egress:
     - {}

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -1384,11 +1384,15 @@ gateway:
   networkPolicy:
     enabled: true
     egressRules: [{}]
+    # Do not add app.kubernetes.io/instance here — the subchart renders
+    # allowIngressFrom via toYaml (no tpl), so template expressions are
+    # emitted as literals.  A hardcoded release name silently breaks
+    # ingress on policy-enforcing CNIs when the chart is installed under
+    # any other name.
     allowIngressFrom:
       - podSelector:
           matchLabels:
             app.kubernetes.io/name: forwarder
-            app.kubernetes.io/instance: observe-agent
 
   podAnnotations: {
     # This stops optional prometheus scrape config from picking up these pods


### PR DESCRIPTION
## Summary

- Remove hardcoded `app.kubernetes.io/instance: observe-agent` from the gateway NetworkPolicy's `allowIngressFrom` selector in `values.yaml`
- The gateway now selects forwarder pods by `app.kubernetes.io/name: forwarder` only, which works regardless of the Helm release name
- Add a comment explaining why `app.kubernetes.io/instance` must not be added back (subchart uses `toYaml`, not `tpl`)

## Context

On any CNI that enforces NetworkPolicy (Calico, Cilium, recent kindnetd), installing the chart under a release name other than `observe-agent` caused the gateway policy to match no pods, silently dropping all forwarder→gateway traffic. Symptoms: forwarder sees `i/o timeout` to gateway:4317, memory climbs until `memory_limiter` trips, and `ReceiverRefusedCount` spikes across all signal types.

## Test plan

- [x] `make generate-examples && git diff --exit-code` passes (rendered examples are up to date)
- [x] Deploy on a policy-enforcing CNI with a non-default release name and confirm forwarder→gateway connectivity

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)