### PR TITLE
fix: Change hardcoded ClusterRoleBinding name

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent
 description: Chart to install K8s collection stack based on Observe Agent
 type: application
-version: 0.94.1
+version: 0.94.2
 appVersion: "2.18.0"
 dependencies:
   - name: opentelemetry-collector

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -1,6 +1,6 @@
 # agent
 
-![Version: 0.94.1](https://img.shields.io/badge/Version-0.94.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.18.0](https://img.shields.io/badge/AppVersion-2.18.0-informational?style=flat-square)
+![Version: 0.94.2](https://img.shields.io/badge/Version-0.94.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.18.0](https://img.shields.io/badge/AppVersion-2.18.0-informational?style=flat-square)
 
 Chart to install K8s collection stack based on Observe Agent
 

--- a/charts/agent/examples/aws-eks-fargate/rendered/cluster-role.yaml
+++ b/charts/agent/examples/aws-eks-fargate/rendered/cluster-role.yaml
@@ -39,7 +39,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: observe-agent-cluster-role-binding
+  name: observe-agent-cluster-role-binding-observe
   labels:
     app.kubernetes.io/name: observe-agent-cluster-role-binding-observe
     app.kubernetes.io/instance: observe-agent

--- a/charts/agent/examples/internal-red-metrics/rendered/cluster-role.yaml
+++ b/charts/agent/examples/internal-red-metrics/rendered/cluster-role.yaml
@@ -39,7 +39,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: observe-agent-cluster-role-binding
+  name: observe-agent-cluster-role-binding-observe
   labels:
     app.kubernetes.io/name: observe-agent-cluster-role-binding-observe
     app.kubernetes.io/instance: observe-agent

--- a/charts/agent/examples/prometheus-ta-cr-discovery/rendered/cluster-role.yaml
+++ b/charts/agent/examples/prometheus-ta-cr-discovery/rendered/cluster-role.yaml
@@ -39,7 +39,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: observe-agent-cluster-role-binding
+  name: observe-agent-cluster-role-binding-observe
   labels:
     app.kubernetes.io/name: observe-agent-cluster-role-binding-observe
     app.kubernetes.io/instance: observe-agent

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/cluster-role.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/cluster-role.yaml
@@ -39,7 +39,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: observe-agent-cluster-role-binding
+  name: observe-agent-cluster-role-binding-observe
   labels:
     app.kubernetes.io/name: observe-agent-cluster-role-binding-observe
     app.kubernetes.io/instance: observe-agent

--- a/charts/agent/examples/recommended-config/rendered/cluster-role.yaml
+++ b/charts/agent/examples/recommended-config/rendered/cluster-role.yaml
@@ -39,7 +39,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: observe-agent-cluster-role-binding
+  name: observe-agent-cluster-role-binding-observe
   labels:
     app.kubernetes.io/name: observe-agent-cluster-role-binding-observe
     app.kubernetes.io/instance: observe-agent

--- a/charts/agent/templates/cluster-role.yaml
+++ b/charts/agent/templates/cluster-role.yaml
@@ -36,7 +36,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: observe-agent-cluster-role-binding
+  name: observe-agent-cluster-role-binding-{{ template "observe-agent.namespace" . }}
   labels:
     app.kubernetes.io/name: observe-agent-cluster-role-binding-{{ template "observe-agent.namespace" . }}
     app.kubernetes.io/instance: observe-agent


### PR DESCRIPTION
Since ClusterRoleBinding is cluster-scoped, the previous hard-coded name meant two installs of the chart in different namespaces would both try to create/own a binding named observe-agent-cluster-role-binding, colliding with each other. Suffixing with the namespace makes the name unique per install and keeps it consistent with the ClusterRole name and the binding's own label.