### PR TITLE
fix: make pod-metrics scrape_timeout configurable

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent
 description: Chart to install K8s collection stack based on Observe Agent
 type: application
-version: 0.94.2
+version: 0.94.3
 appVersion: "2.18.0"
 dependencies:
   - name: opentelemetry-collector

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -1,6 +1,6 @@
 # agent
 
-![Version: 0.94.2](https://img.shields.io/badge/Version-0.94.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.18.0](https://img.shields.io/badge/AppVersion-2.18.0-informational?style=flat-square)
+![Version: 0.94.3](https://img.shields.io/badge/Version-0.94.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.18.0](https://img.shields.io/badge/AppVersion-2.18.0-informational?style=flat-square)
 
 Chart to install K8s collection stack based on Observe Agent
 
@@ -115,6 +115,7 @@ This service is an *OpenTelemetryCollector*, a custom resource that is managed b
 | application.prometheusScrape.targetAllocator.prometheusCR.scrapeInterval | string | `""` | Default scrape interval for SMs/PMs that don't declare their own `interval`. Empty (default) leaves the field unrendered, so TA falls back to its built-in 30s default. |
 | application.prometheusScrape.targetAllocator.prometheusCR.serviceMonitorNamespaceSelector | object | `{}` | ServiceMonitor namespace selector. Empty (default) matches all namespaces. |
 | application.prometheusScrape.targetAllocator.prometheusCR.serviceMonitorSelector | object | `{}` | ServiceMonitor label selector. Empty (default) matches all SMs. Always rendered; TA treats omitted selectors as "match nothing". |
+| application.prometheusScrape.timeout | string | `"10s"` | Per-target scrape timeout. Must be <= interval. Raise this for exporters that take longer than the default to render a response, such as jmx-exporter on a broker with many topics. |
 | cluster-events.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key | string | `"observeinc.com/unschedulable"` |  |
 | cluster-events.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].operator | string | `"DoesNotExist"` |  |
 | cluster-events.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[1].key | string | `"kubernetes.io/os"` |  |

--- a/charts/agent/examples/aws-eks-fargate/rendered/prometheus-scraper-configmap.yaml
+++ b/charts/agent/examples/aws-eks-fargate/rendered/prometheus-scraper-configmap.yaml
@@ -278,6 +278,7 @@ data:
                 - __meta_kubernetes_pod_name
                 target_label: kubernetes_pod_name
               scrape_interval: 60s
+              scrape_timeout: 10s
       service:
         pipelines:
           logs/heartbeat:

--- a/charts/agent/examples/internal-red-metrics/rendered/prometheus-scraper-configmap.yaml
+++ b/charts/agent/examples/internal-red-metrics/rendered/prometheus-scraper-configmap.yaml
@@ -278,6 +278,7 @@ data:
                 - __meta_kubernetes_pod_name
                 target_label: kubernetes_pod_name
               scrape_interval: 60s
+              scrape_timeout: 10s
       service:
         pipelines:
           logs/heartbeat:

--- a/charts/agent/examples/prometheus-ta-enabled/rendered/prometheus-ta-configmap.yaml
+++ b/charts/agent/examples/prometheus-ta-enabled/rendered/prometheus-ta-configmap.yaml
@@ -19,6 +19,7 @@ data:
 
         - job_name: pod-metrics
           scrape_interval: 60s
+          scrape_timeout: 10s
           honor_labels: true
           kubernetes_sd_configs:
           - role: pod

--- a/charts/agent/examples/recommended-config/rendered/prometheus-scraper-configmap.yaml
+++ b/charts/agent/examples/recommended-config/rendered/prometheus-scraper-configmap.yaml
@@ -278,6 +278,7 @@ data:
                 - __meta_kubernetes_pod_name
                 target_label: kubernetes_pod_name
               scrape_interval: 60s
+              scrape_timeout: 10s
       service:
         pipelines:
           logs/heartbeat:

--- a/charts/agent/templates/_config-receivers.tpl
+++ b/charts/agent/templates/_config-receivers.tpl
@@ -5,6 +5,7 @@
 {{- define "observe.prometheus.pod_metrics.scrape_job" -}}
 - job_name: pod-metrics
   scrape_interval: {{.Values.application.prometheusScrape.interval}}
+  scrape_timeout: {{.Values.application.prometheusScrape.timeout}}
   honor_labels: true
   kubernetes_sd_configs:
   - role: pod

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -154,6 +154,10 @@ application:
     independentDeployment: false
     # scrape interval
     interval: 60s
+    # -- Per-target scrape timeout. Must be <= interval. Raise this for
+    # exporters that take longer than the default to render a response, such as
+    # jmx-exporter on a broker with many topics.
+    timeout: 10s
     # namespaces to exclude from scraping
     # drop is processed first so all namespaces that match regex will be dropped
     namespaceDropRegex: (.*istio.*|.*ingress.*|kube-system)


### PR DESCRIPTION
The `pod-metrics` scrape job sets `scrape_interval` but never `scrape_timeout`, so
every target falls back to Prometheus' 10s default, and no chart value can raise it.
An exporter that needs longer than 10s to answer loses the whole scrape.

That failure is easy to miss. A scrape which runs past its deadline fails the same
way an unreachable target does, so the metrics stop arriving and an operator sees
absence rather than an error.

## What this changes

Adds `application.prometheusScrape.timeout`, rendered as `scrape_timeout` on the
`pod-metrics` job beside the existing `interval`.

**The default is `10s`, the value targets already get today.** The rendered job now
states that default instead of leaving it to Prometheus, so scrape behaviour is
unchanged for every existing consumer. Only someone who sets the field gets
something different.

Prometheus requires `scrape_timeout <= scrape_interval`, which caps how high a
consumer can take this. At the chart's default 60s interval there is room to spare.

## How we ran into it

A `jmx-exporter` sidecar on our own Kafka brokers needs roughly 9-11s to render a
response once a broker carries enough topics. That sits right on the 10s line, so
some scrapes land, some do not, and the broker's JMX metrics go missing with nothing
reporting a failure.

One caveat on those numbers: the scrape durations we can observe are cut off by the
very timeout being measured, so they understate the real distribution rather than
describe it.

## Ancillary edits

The `Chart.yaml` bump (0.94.2 to 0.94.3), the regenerated helm-docs `README.md`, and
the regenerated `make generate-examples` output are all required by this repo's CI
checks rather than changes in their own right.

## Checks run

- `make lint` (`ct lint --all`): all 8 charts pass, including the chart-version bump check
- `make generate-examples`: 4 rendered examples pick up the new line
- `pre-commit` (helm-docs, whitespace, EOF): pass
- This chart carries no `values.schema.json` and no `charts/agent/tests/`, so nothing
  else needed regenerating
