### PR TITLE
feat(agent): add hash processors for external-write Iceberg tables

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent
 description: Chart to install K8s collection stack based on Observe Agent
 type: application
-version: 0.94.3
+version: 0.94.4
 appVersion: "2.18.0"
 dependencies:
   - name: opentelemetry-collector

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -75,6 +75,7 @@ This service is an *OpenTelemetryCollector*, a custom resource that is managed b
 | agent.config.global.exporters.sendingQueue.batch.sizer | string | `"bytes"` |  |
 | agent.config.global.exporters.sendingQueue.enabled | bool | `true` |  |
 | agent.config.global.exporters.timeout | string | `"10s"` |  |
+| agent.config.global.externalWriteHashes | object | `{"enabled":false}` | Compute hash columns in the collector for external-write Iceberg source tables. When true, appends transform/identifiers_hash to the K8s objects pipeline and transform/metric_hashes to every pipeline that exports to prometheusremotewrite/observe. Only needed when a downstream writer appends to an Observe-schema Iceberg table directly (bypassing ingest). Leave false on the standard ingest path. |
 | agent.config.global.fleet.configInterval | string | `"24h"` |  |
 | agent.config.global.fleet.enabled | bool | `false` |  |
 | agent.config.global.fleet.interval | string | `"10m"` |  |

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -1,6 +1,6 @@
 # agent
 
-![Version: 0.94.3](https://img.shields.io/badge/Version-0.94.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.18.0](https://img.shields.io/badge/AppVersion-2.18.0-informational?style=flat-square)
+![Version: 0.94.4](https://img.shields.io/badge/Version-0.94.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.18.0](https://img.shields.io/badge/AppVersion-2.18.0-informational?style=flat-square)
 
 Chart to install K8s collection stack based on Observe Agent
 

--- a/charts/agent/examples/external-write-hashes/rendered/agent-monitor-configmap.yaml
+++ b/charts/agent/examples/external-write-hashes/rendered/agent-monitor-configmap.yaml
@@ -1,0 +1,165 @@
+---
+# Source: agent/templates/agent-monitor-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: monitor
+  namespace: observe
+data:
+  relay: |
+      exporters:
+        debug/override:
+          sampling_initial: 2
+          sampling_thereafter: 1
+          verbosity: basic
+        prometheusremotewrite/observe:
+          endpoint: ${env:OBSERVE_PROMETHEUS_ENDPOINT}
+          headers:
+            authorization: ${env:OBSERVE_AUTHORIZATION_HEADER}
+            x-observe-target-package: Kubernetes Explorer
+          max_batch_request_parallelism: 5
+          remote_write_queue:
+            num_consumers: 5
+          resource_to_telemetry_conversion:
+            enabled: true
+          retry_on_failure:
+            enabled: true
+            initial_interval: 1s
+            max_elapsed_time: 5m
+            max_interval: 30s
+          send_metadata: true
+          target_info:
+            enabled: false
+          timeout: 10s
+      processors:
+        attributes/debug_source_agent_monitor:
+          actions:
+          - action: insert
+            key: debug_source
+            value: agent_monitor
+        batch:
+          send_batch_max_size: 4096
+          send_batch_size: 4096
+          timeout: 5s
+        k8sattributes:
+          extract:
+            labels:
+            - from: pod
+              key_regex: (app\.kubernetes\.io/.+)
+              tag_name: $1
+            metadata:
+            - k8s.namespace.name
+            - k8s.deployment.name
+            - k8s.replicaset.name
+            - k8s.statefulset.name
+            - k8s.daemonset.name
+            - k8s.cronjob.name
+            - k8s.job.name
+            - k8s.node.name
+            - k8s.node.uid
+            - k8s.pod.name
+            - k8s.pod.uid
+            - k8s.cluster.uid
+            - k8s.container.name
+            - container.id
+            - service.namespace
+            - service.name
+            - service.version
+            - service.instance.id
+            otel_annotations: true
+          passthrough: false
+          pod_association:
+          - sources:
+            - from: resource_attribute
+              name: k8s.pod.ip
+          - sources:
+            - from: resource_attribute
+              name: k8s.pod.uid
+          - sources:
+            - from: connection
+          wait_for_metadata: false
+          wait_for_metadata_timeout: 10s
+        memory_limiter:
+          check_interval: 5s
+          limit_percentage: 80
+          spike_limit_percentage: 15
+        resource/drop_service_name:
+          attributes:
+          - action: delete
+            key: service.name
+        resource/observe_common:
+          attributes:
+          - action: upsert
+            key: k8s.cluster.name
+            value: ${env:OBSERVE_CLUSTER_NAME}
+          - action: upsert
+            key: k8s.cluster.uid
+            value: ${env:OBSERVE_CLUSTER_UID}
+        transform/metric_hashes:
+          error_mode: ignore
+          metric_statements:
+          - context: datapoint
+            statements:
+            - set(attributes["observe_labels_hash"], Substring(XXH128(Concat([ToKeyValueString(resource.attributes,
+              "=", ",", true), ToKeyValueString(attributes, "=", ",", true)], "|")), 0,
+              31))
+      receivers:
+        prometheus/collector:
+          config:
+            scrape_configs:
+            - job_name: opentelemetry-collector-self
+              scrape_interval: 60s
+              static_configs:
+              - targets:
+                - ${env:MY_POD_IP}:8888
+            - honor_labels: true
+              job_name: opentelemetry-collector-other
+              kubernetes_sd_configs:
+              - role: pod
+              relabel_configs:
+              - action: keep
+                regex: observecollection
+                source_labels:
+                - __meta_kubernetes_pod_annotation_observe_monitor_purpose
+              - action: keep
+                regex: true
+                source_labels:
+                - __meta_kubernetes_pod_annotation_observe_monitor_scrape
+              - action: replace
+                regex: (.+)
+                source_labels:
+                - __meta_kubernetes_pod_annotation_observe_monitor_path
+                target_label: __metrics_path__
+              - action: replace
+                regex: ([^:]+)(?::\d+)?;(\d+)
+                replacement: $$1:$$2
+                source_labels:
+                - __address__
+                - __meta_kubernetes_pod_annotation_observe_monitor_port
+                target_label: __address__
+              - action: labelmap
+                regex: __meta_kubernetes_pod_label_(.+)
+              - action: replace
+                source_labels:
+                - __meta_kubernetes_namespace
+                target_label: kubernetes_namespace
+              - action: replace
+                source_labels:
+                - __meta_kubernetes_pod_name
+                target_label: kubernetes_pod_name
+              scrape_interval: 60s
+      service:
+        pipelines:
+          metrics:
+            exporters:
+            - prometheusremotewrite/observe
+            processors:
+            - memory_limiter
+            - resource/drop_service_name
+            - k8sattributes
+            - batch
+            - resource/observe_common
+            - attributes/debug_source_agent_monitor
+            - transform/metric_hashes
+            receivers:
+            - prometheus/collector

--- a/charts/agent/examples/external-write-hashes/rendered/agent-monitor-configmap.yaml
+++ b/charts/agent/examples/external-write-hashes/rendered/agent-monitor-configmap.yaml
@@ -100,9 +100,10 @@ data:
           metric_statements:
           - context: datapoint
             statements:
-            - set(attributes["observe_labels_hash"], Substring(XXH128(Concat([ToKeyValueString(resource.attributes,
-              "=", ",", true), ToKeyValueString(attributes, "=", ",", true)], "|")), 0,
-              31))
+            - merge_maps(cache, attributes, "upsert")
+            - merge_maps(cache, resource.attributes, "upsert")
+            - set(attributes["observe_labels_hash"], Substring(XXH128(ToKeyValueString(cache,
+              "=", ",", true)), 0, 31))
       receivers:
         prometheus/collector:
           config:

--- a/charts/agent/examples/external-write-hashes/rendered/cluster-events-configmap.yaml
+++ b/charts/agent/examples/external-write-hashes/rendered/cluster-events-configmap.yaml
@@ -1,0 +1,555 @@
+---
+# Source: agent/templates/cluster-events-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-events
+  namespace: observe
+data:
+  relay: |
+      exporters:
+        debug/override:
+          sampling_initial: 2
+          sampling_thereafter: 1
+          verbosity: basic
+        otlphttp/observe/entity:
+          compression: zstd
+          headers:
+            authorization: ${env:OBSERVE_AUTHORIZATION_HEADER}
+            x-observe-target-package: Kubernetes Explorer
+          logs_endpoint: ${env:OBSERVE_COLLECTOR_URL}/v1/kubernetes/v1/entity
+          retry_on_failure:
+            enabled: true
+            initial_interval: 1s
+            max_elapsed_time: 5m
+            max_interval: 30s
+          sending_queue:
+            enabled: true
+          timeout: 10s
+      processors:
+        batch:
+          send_batch_max_size: 1024
+          send_batch_size: 1024
+          timeout: 5s
+        filter/cluster:
+          error_mode: ignore
+          logs:
+            log_record:
+            - body["metadata"]["name"] != "kube-system" and body["object"]["metadata"]["name"]
+              != "kube-system"
+        memory_limiter:
+          check_interval: 5s
+          limit_percentage: 80
+          spike_limit_percentage: 15
+        observek8sattributes: null
+        resource/observe_common:
+          attributes:
+          - action: upsert
+            key: k8s.cluster.name
+            value: ${env:OBSERVE_CLUSTER_NAME}
+          - action: upsert
+            key: k8s.cluster.uid
+            value: ${env:OBSERVE_CLUSTER_UID}
+        transform/cluster:
+          error_mode: ignore
+          log_statements:
+          - context: log
+            statements:
+            - set(attributes["observe_filter"], "objects_pull_watch")
+            - set(attributes["observe_transform"]["control"]["isDelete"], true) where body["object"]
+              != nil and body["type"] == "DELETED"
+            - set(attributes["observe_transform"]["control"]["debug_source"], "watch") where
+              body["object"] != nil and body["type"] != nil
+            - set(attributes["observe_transform"]["control"]["debug_source"], "pull") where
+              body["object"] == nil or body["type"] == nil
+            - set(body, body["object"]) where body["object"] != nil and body["type"] !=
+              nil
+            - set(attributes["observe_transform"]["valid_from"], observed_time_unix_nano)
+            - set(attributes["observe_transform"]["valid_to"], Int(observed_time_unix_nano)
+              + 5400000000000)
+            - set(attributes["observe_transform"]["kind"], "Cluster")
+            - set(attributes["observe_transform"]["control"]["isDelete"], false) where attributes["observe_transform"]["control"]["isDelete"]
+              == nil
+            - set(attributes["observe_transform"]["control"]["version"], body["metadata"]["resourceVersion"])
+            - set(attributes["observe_transform"]["identifiers"]["clusterName"], resource.attributes["k8s.cluster.name"])
+            - set(attributes["observe_transform"]["identifiers"]["clusterUid"], resource.attributes["k8s.cluster.uid"])
+            - set(attributes["observe_transform"]["identifiers"]["uid"], resource.attributes["k8s.cluster.uid"])
+            - set(attributes["observe_transform"]["identifiers"]["kind"], "Cluster")
+            - set(attributes["observe_transform"]["identifiers"]["name"], resource.attributes["k8s.cluster.name"])
+            - set(attributes["observe_transform"]["facets"]["creationTimestamp"], body["metadata"]["creationTimestamp"])
+            - set(attributes["observe_transform"]["facets"]["labels"], body["metadata"]["labels"])
+            - set(attributes["observe_transform"]["facets"]["annotations"], body["metadata"]["annotations"])
+            - set(body, "")
+        transform/identifiers_hash:
+          error_mode: ignore
+          log_statements:
+          - context: log
+            statements:
+            - set(attributes["observe_identifiers_hash"], Substring(XXH128(ToKeyValueString(attributes["observe_transform"]["identifiers"],
+              "=", ",", true)), 0, 31))
+        transform/object:
+          error_mode: ignore
+          log_statements:
+          - context: log
+            statements:
+            - set(attributes["observe_filter"], "objects_pull_watch")
+            - set(attributes["observe_transform"]["valid_from"], observed_time_unix_nano)
+            - set(attributes["observe_transform"]["valid_to"], Int(observed_time_unix_nano)
+              + 5400000000000)
+            - set(attributes["observe_transform"]["kind"], body["kind"])
+            - set(attributes["observe_transform"]["control"]["isDelete"], false) where attributes["observe_transform"]["control"]["isDelete"]
+              == nil
+            - set(attributes["observe_transform"]["control"]["version"], body["metadata"]["resourceVersion"])
+            - set(attributes["observe_transform"]["control"]["agentVersion"], "2.16.0")
+            - set(attributes["observe_transform"]["identifiers"]["clusterName"], resource.attributes["k8s.cluster.name"])
+            - set(attributes["observe_transform"]["identifiers"]["clusterUid"], resource.attributes["k8s.cluster.uid"])
+            - set(attributes["observe_transform"]["identifiers"]["kind"], body["kind"])
+            - set(attributes["observe_transform"]["identifiers"]["name"], body["metadata"]["name"])
+            - set(attributes["observe_transform"]["identifiers"]["namespaceName"], body["metadata"]["namespace"])
+            - set(attributes["observe_transform"]["identifiers"]["uid"], body["metadata"]["uid"])
+            - set(attributes["observe_transform"]["facets"]["creationTimestamp"], body["metadata"]["creationTimestamp"])
+            - set(attributes["observe_transform"]["facets"]["deletionTimestamp"], body["metadata"]["deletionTimestamp"])
+            - set(attributes["observe_transform"]["facets"]["ownerRefKind"], body["metadata"]["ownerReferences"][0]["kind"])
+            - set(attributes["observe_transform"]["facets"]["ownerRefName"], body["metadata"]["ownerReferences"][0]["name"])
+            - set(attributes["observe_transform"]["facets"]["labels"], body["metadata"]["labels"])
+            - set(attributes["observe_transform"]["facets"]["annotations"], body["metadata"]["annotations"])
+            - set(attributes["observe_transform"]["facets"]["replicaSetName"], body["metadata"]["ownerReferences"][0]["name"])
+              where body["metadata"]["ownerReferences"][0]["kind"] == "ReplicaSet"
+            - set(attributes["observe_transform"]["facets"]["daemonSetName"], body["metadata"]["ownerReferences"][0]["name"])
+              where body["metadata"]["ownerReferences"][0]["kind"] == "DaemonSet"
+            - set(attributes["observe_transform"]["facets"]["jobName"], body["metadata"]["ownerReferences"][0]["name"])
+              where body["metadata"]["ownerReferences"][0]["kind"] == "Job"
+            - set(attributes["observe_transform"]["facets"]["cronJobName"], attributes["observe_transform"]["facets"]["jobName"])
+              where IsMatch(attributes["observe_transform"]["facets"]["jobName"], ".*-\\d{8}$")
+            - replace_pattern(attributes["observe_transform"]["facets"]["cronJobName"],
+              "-\\d{8}$$", "")
+            - set(attributes["observe_transform"]["facets"]["statefulSetName"], body["metadata"]["ownerReferences"][0]["name"])
+              where body["metadata"]["ownerReferences"][0]["kind"] == "StatefulSet"
+            - set(attributes["observe_transform"]["facets"]["deploymentName"], body["metadata"]["ownerReferences"][0]["name"])
+              where body["metadata"]["ownerReferences"][0]["kind"] == "ReplicaSet"
+            - replace_pattern(attributes["observe_transform"]["facets"]["deploymentName"],
+              "^(.*)-[0-9a-f]+$$", "$$1")
+            - set(attributes["observe_transform"]["facets"]["deploymentName"], body["metadata"]["ownerReferences"][0]["name"])
+              where body["metadata"]["ownerReferences"][0]["kind"] == "Deployment"
+          - conditions:
+            - body["kind"] == "Pod"
+            context: log
+            statements:
+            - set(attributes["observe_transform"]["identifiers"]["podName"], body["metadata"]["name"])
+            - set(attributes["observe_transform"]["identifiers"]["podUid"], body["metadata"]["uid"])
+            - set(attributes["observe_transform"]["facets"]["phase"], body["status"]["phase"])
+            - set(attributes["observe_transform"]["facets"]["podIP"], body["status"]["podIP"])
+            - set(attributes["observe_transform"]["facets"]["qosClass"], body["status"]["qosClass"])
+            - set(attributes["observe_transform"]["facets"]["startTime"], body["status"]["startTime"])
+            - set(attributes["observe_transform"]["facets"]["readinessGates"], body["object"]["spec"]["readinessGates"])
+            - set(attributes["observe_transform"]["facets"]["nodeName"], body["spec"]["nodeName"])
+          - conditions:
+            - body["kind"] == "Namespace"
+            context: log
+            statements:
+            - set(attributes["observe_transform"]["facets"]["status"], body["status"]["phase"])
+            - set(attributes["observe_transform"]["identifiers"]["namespaceName"], body["metadata"]["name"])
+            - set(attributes["observe_transform"]["identifiers"]["namespaceUid"], body["metadata"]["uid"])
+          - conditions:
+            - body["kind"] == "Node"
+            context: log
+            statements:
+            - set(attributes["observe_transform"]["identifiers"]["nodeName"], body["metadata"]["name"])
+            - set(attributes["observe_transform"]["identifiers"]["nodeUid"], body["metadata"]["uid"])
+            - set(attributes["observe_transform"]["facets"]["kernelVersion"], body["status"]["nodeInfo"]["kernelVersion"])
+            - set(attributes["observe_transform"]["facets"]["kubeProxyVersion"], body["status"]["nodeInfo"]["kubeProxyVersion"])
+            - set(attributes["observe_transform"]["facets"]["kubeletVersion"], body["status"]["nodeInfo"]["kubeletVersion"])
+            - set(attributes["observe_transform"]["facets"]["osImage"], body["status"]["nodeInfo"]["osImage"])
+            - set(attributes["observe_transform"]["facets"]["taints"], body["spec"]["taints"])
+          - conditions:
+            - body["kind"] == "Deployment"
+            context: log
+            statements:
+            - set(attributes["observe_transform"]["identifiers"]["deploymentName"], body["metadata"]["name"])
+            - set(attributes["observe_transform"]["identifiers"]["deploymentUid"], body["metadata"]["uid"])
+            - set(attributes["observe_transform"]["facets"]["updatedReplicas"], body["status"]["updatedReplicas"])
+            - set(attributes["observe_transform"]["facets"]["availableReplicas"], body["status"]["availableReplicas"])
+            - set(attributes["observe_transform"]["facets"]["readyReplicas"], body["status"]["readyReplicas"])
+            - set(attributes["observe_transform"]["facets"]["readyReplicas"], 0) where attributes["observe_transform"]["facets"]["readyReplicas"]
+              == nil
+            - set(attributes["observe_transform"]["facets"]["unavailableReplicas"], body["status"]["unavailableReplicas"])
+            - set(attributes["observe_transform"]["facets"]["selector"], body["spec"]["selector"]["matchLabels"])
+            - set(attributes["observe_transform"]["facets"]["desiredReplicas"], body["spec"]["replicas"])
+            - set(attributes["observe_transform"]["facets"]["status"], "Healthy")
+            - set(attributes["observe_transform"]["facets"]["status"], "Unhealthy") where
+              attributes["observe_transform"]["facets"]["desiredReplicas"] != nil and attributes["observe_transform"]["facets"]["readyReplicas"]
+              != attributes["observe_transform"]["facets"]["desiredReplicas"]
+          - conditions:
+            - body["kind"] == "ReplicaSet"
+            context: log
+            statements:
+            - set(attributes["observe_transform"]["identifiers"]["replicaSetName"], body["metadata"]["name"])
+            - set(attributes["observe_transform"]["identifiers"]["replicaSetUid"], body["metadata"]["uid"])
+            - set(attributes["observe_transform"]["facets"]["desiredReplicas"], body["spec"]["replicas"])
+            - set(attributes["observe_transform"]["facets"]["currentReplicas"], body["status"]["replicas"])
+            - set(attributes["observe_transform"]["facets"]["availableReplicas"], body["status"]["availableReplicas"])
+            - set(attributes["observe_transform"]["facets"]["readyReplicas"], body["status"]["readyReplicas"])
+            - set(attributes["observe_transform"]["facets"]["readyReplicas"], 0) where attributes["observe_transform"]["facets"]["readyReplicas"]
+              == nil
+            - set(attributes["observe_transform"]["facets"]["status"], "Healthy")
+            - set(attributes["observe_transform"]["facets"]["status"], "Unhealthy") where
+              attributes["observe_transform"]["facets"]["desiredReplicas"] != nil and attributes["observe_transform"]["facets"]["readyReplicas"]
+              != attributes["observe_transform"]["facets"]["desiredReplicas"]
+          - conditions:
+            - body["kind"] == "Event"
+            context: log
+            statements:
+            - set(attributes["observe_transform"]["identifiers"]["involvedObjectKind"],
+              body["involvedObject"]["kind"])
+            - set(attributes["observe_transform"]["identifiers"]["involvedObjectName"],
+              body["involvedObject"]["name"])
+            - set(attributes["observe_transform"]["identifiers"]["involvedObjectUid"], body["involvedObject"]["uid"])
+            - set(attributes["observe_transform"]["facets"]["firstTimestamp"], body["firstTimestamp"])
+            - set(attributes["observe_transform"]["facets"]["lastTimestamp"], body["lastTimestamp"])
+            - set(attributes["observe_transform"]["facets"]["message"], body["message"])
+            - set(attributes["observe_transform"]["facets"]["reason"], body["reason"])
+            - set(attributes["observe_transform"]["facets"]["count"], body["count"])
+            - set(attributes["observe_transform"]["facets"]["type"], body["type"])
+            - set(attributes["observe_transform"]["facets"]["sourceComponent"], body["source"]["component"])
+          - conditions:
+            - body["kind"] == "Job"
+            context: log
+            statements:
+            - set(attributes["observe_transform"]["identifiers"]["jobName"], body["metadata"]["name"])
+            - set(attributes["observe_transform"]["identifiers"]["jobUid"], body["metadata"]["uid"])
+            - set(attributes["observe_transform"]["facets"]["cronJobName"], body["metadata"]["ownerReferences"][0]["name"])
+              where body["metadata"]["ownerReferences"][0]["kind"] == "CronJob"
+            - set(attributes["observe_transform"]["facets"]["cronJobUid"], body["metadata"]["ownerReferences"][0]["uid"])
+              where body["metadata"]["ownerReferences"][0]["kind"] == "CronJob"
+            - set(attributes["observe_transform"]["facets"]["completions"], body["spec"]["completions"])
+            - set(attributes["observe_transform"]["facets"]["parallelism"], body["spec"]["parallelism"])
+            - set(attributes["observe_transform"]["facets"]["activeDeadlineSeconds"], body["spec"]["activeDeadlineSeconds"])
+            - set(attributes["observe_transform"]["facets"]["backoffLimit"], body["spec"]["backoffLimit"])
+            - set(attributes["observe_transform"]["facets"]["startTime"], body["status"]["startTime"])
+            - set(attributes["observe_transform"]["facets"]["activePods"], body["status"]["active"])
+            - set(attributes["observe_transform"]["facets"]["failedPods"], body["status"]["falied"])
+            - set(attributes["observe_transform"]["facets"]["succeededPods"], body["status"]["succeeded"])
+            - set(attributes["observe_transform"]["facets"]["readyPods"], body["status"]["ready"])
+          - conditions:
+            - body["kind"] == "CronJob"
+            context: log
+            statements:
+            - set(attributes["observe_transform"]["identifiers"]["cronJobName"], body["metadata"]["name"])
+            - set(attributes["observe_transform"]["identifiers"]["cronJobUid"], body["metadata"]["uid"])
+            - set(attributes["observe_transform"]["facets"]["schedule"], body["spec"]["schedule"])
+            - set(attributes["observe_transform"]["facets"]["suspend"], "Active") where
+              body["spec"]["suspend"] == false
+            - set(attributes["observe_transform"]["facets"]["suspend"], "Suspend") where
+              body["spec"]["suspend"] == true
+          - conditions:
+            - body["kind"] == "DaemonSet"
+            context: log
+            statements:
+            - set(attributes["observe_transform"]["identifiers"]["daemonSetName"], body["metadata"]["name"])
+            - set(attributes["observe_transform"]["identifiers"]["daemonSetUid"], body["metadata"]["uid"])
+            - set(attributes["observe_transform"]["facets"]["updateStrategy"], body["spec"]["updateStrategy"]["type"])
+            - set(attributes["observe_transform"]["facets"]["maxUnavailable"], body["spec"]["updateStrategy"]["rollingUpdate"]["maxUnavailable"])
+            - set(attributes["observe_transform"]["facets"]["maxSurge"], body["spec"]["updateStrategy"]["rollingUpdate"]["maxSurge"])
+            - set(attributes["observe_transform"]["facets"]["numberReady"], body["status"]["numberReady"])
+            - set(attributes["observe_transform"]["facets"]["desiredNumberScheduled"], body["status"]["desiredNumberScheduled"])
+            - set(attributes["observe_transform"]["facets"]["currentNumberScheduled"], body["status"]["currentNumberScheduled"])
+            - set(attributes["observe_transform"]["facets"]["updatedNumberScheduled"], body["status"]["updatedNumberScheduled"])
+            - set(attributes["observe_transform"]["facets"]["numberAvailable"], body["status"]["numberAvailable"])
+            - set(attributes["observe_transform"]["facets"]["numberUnavailable"], body["status"]["numberUnavailable"])
+            - set(attributes["observe_transform"]["facets"]["numberMisscheduled"], body["status"]["numberMisscheduled"])
+            - set(attributes["observe_transform"]["facets"]["status"], "Healthy")
+            - set(attributes["observe_transform"]["facets"]["status"], "Unhealthy") where
+              attributes["observe_transform"]["facets"]["desiredNumberScheduled"] != nil
+              and attributes["observe_transform"]["facets"]["numberReady"] != attributes["observe_transform"]["facets"]["desiredNumberScheduled"]
+          - conditions:
+            - body["kind"] == "StatefulSet"
+            context: log
+            statements:
+            - set(attributes["observe_transform"]["identifiers"]["statefulSetName"], body["metadata"]["name"])
+            - set(attributes["observe_transform"]["identifiers"]["statefulSetUid"], body["metadata"]["uid"])
+            - set(attributes["observe_transform"]["facets"]["serviceName"], body["spec"]["serviceName"])
+            - set(attributes["observe_transform"]["facets"]["podManagementPolicy"], body["spec"]["podManagementPolicy"])
+            - set(attributes["observe_transform"]["facets"]["desiredReplicas"], body["spec"]["replicas"])
+            - set(attributes["observe_transform"]["facets"]["updateStrategy"], body["spec"]["updateStrategy"]["type"])
+            - set(attributes["observe_transform"]["facets"]["partition"], body["spec"]["updateStrategy"]["rollingUpdate"]["partition"])
+            - set(attributes["observe_transform"]["facets"]["currentReplicas"], body["status"]["currentReplicas"])
+            - set(attributes["observe_transform"]["facets"]["readyReplicas"], body["status"]["readyReplicas"])
+            - set(attributes["observe_transform"]["facets"]["status"], "Healthy")
+            - set(attributes["observe_transform"]["facets"]["status"], "Unhealthy") where
+              attributes["observe_transform"]["facets"]["desiredReplicas"] != nil and attributes["observe_transform"]["facets"]["readyReplicas"]
+              != attributes["observe_transform"]["facets"]["desiredReplicas"]
+          - conditions:
+            - body["kind"] == "ConfigMap"
+            context: log
+            statements:
+            - set(attributes["observe_transform"]["identifiers"]["configMapName"], body["metadata"]["name"])
+            - set(attributes["observe_transform"]["identifiers"]["configMapUid"], body["metadata"]["uid"])
+            - set(attributes["observe_transform"]["facets"]["immutable"], body["immutable"])
+          - conditions:
+            - body["kind"] == "Secret"
+            context: log
+            statements:
+            - set(attributes["observe_transform"]["identifiers"]["secretName"], body["metadata"]["name"])
+            - set(attributes["observe_transform"]["identifiers"]["secretUid"], body["metadata"]["uid"])
+            - set(attributes["observe_transform"]["facets"]["immutable"], body["immutable"])
+            - set(attributes["observe_transform"]["facets"]["data"], body["data"])
+            - set(attributes["observe_transform"]["facets"]["type"], body["type"])
+          - conditions:
+            - body["kind"] == "PersistentVolume"
+            context: log
+            statements:
+            - set(attributes["observe_transform"]["identifiers"]["persistentVolumeName"],
+              body["metadata"]["name"])
+            - set(attributes["observe_transform"]["identifiers"]["persistentVolumeUid"],
+              body["metadata"]["uid"])
+            - set(attributes["observe_transform"]["facets"]["capacity"], body["spec"]["capacity"]["storage"])
+            - set(attributes["observe_transform"]["facets"]["reclaimPolicy"], body["spec"]["persistentVolumeReclaimPolicy"])
+            - set(attributes["observe_transform"]["facets"]["class"], body["spec"]["storageClassName"])
+            - set(attributes["observe_transform"]["facets"]["accessModes"], body["spec"]["accessModes"])
+            - set(attributes["observe_transform"]["facets"]["volumeMode"], body["spec"]["volumeMode"])
+            - set(attributes["observe_transform"]["facets"]["phase"], body["status"]["phase"])
+          - conditions:
+            - body["kind"] == "PersistentVolumeClaim"
+            context: log
+            statements:
+            - set(attributes["observe_transform"]["identifiers"]["persistentVolumeClaimName"],
+              body["metadata"]["name"])
+            - set(attributes["observe_transform"]["identifiers"]["persistentVolumeClaimUid"],
+              body["metadata"]["uid"])
+            - set(attributes["observe_transform"]["facets"]["capacityRequests"], body["spec"]["resources"]["requests"]["storage"])
+            - set(attributes["observe_transform"]["facets"]["capacityLimits"], body["spec"]["resources"]["limits"]["storage"])
+            - set(attributes["observe_transform"]["facets"]["class"], body["spec"]["storageClassName"])
+            - set(attributes["observe_transform"]["facets"]["volumeName"], body["spec"]["volumeName"])
+            - set(attributes["observe_transform"]["facets"]["desiredAccessModes"], body["spec"]["accessModes"])
+            - set(attributes["observe_transform"]["facets"]["volumeMode"], body["spec"]["volumeMode"])
+            - set(attributes["observe_transform"]["facets"]["capacity"], body["status"]["capacity"]["storage"])
+            - set(attributes["observe_transform"]["facets"]["phase"], body["status"]["phase"])
+            - set(attributes["observe_transform"]["facets"]["currentAccessModes"], body["spec"]["accessModes"])
+          - conditions:
+            - body["kind"] == "Service"
+            context: log
+            statements:
+            - set(attributes["observe_transform"]["identifiers"]["serviceName"], body["metadata"]["name"])
+            - set(attributes["observe_transform"]["identifiers"]["serviceUid"], body["metadata"]["uid"])
+            - set(attributes["observe_transform"]["facets"]["serviceType"], body["spec"]["type"])
+            - set(attributes["observe_transform"]["facets"]["clusterIP"], body["spec"]["clusterIP"])
+            - set(attributes["observe_transform"]["facets"]["externalIPs"], body["spec"]["externalIPs"])
+            - set(attributes["observe_transform"]["facets"]["sessionAffinity"], body["spec"]["sessionAffinity"])
+            - set(attributes["observe_transform"]["facets"]["externalName"], body["spec"]["externalName"])
+            - set(attributes["observe_transform"]["facets"]["externalTrafficPolicy"], body["spec"]["externalTrafficPolicy"])
+            - set(attributes["observe_transform"]["facets"]["ipFamilies"], "IPv4,IPv6")
+              where Len(body["spec"]["ipFamilies"]) == 2
+            - set(attributes["observe_transform"]["facets"]["ipFamilies"], body["spec"]["ipFamilies"][0])
+              where Len(body["spec"]["ipFamilies"]) == 1
+          - conditions:
+            - body["kind"] == "Ingress"
+            context: log
+            statements:
+            - set(attributes["observe_transform"]["identifiers"]["ingressName"], body["metadata"]["name"])
+            - set(attributes["observe_transform"]["identifiers"]["ingressUid"], body["metadata"]["uid"])
+            - set(attributes["observe_transform"]["facets"]["class"], body["spec"]["ingressClassName"])
+            - set(attributes["observe_transform"]["facets"]["class"], body["metadata"]["annotations"]["kubernetes.io/ingress.class"])
+              where attributes["observe_transform"]["facets"]["class"] == nil
+          - conditions:
+            - body["kind"] == "RoleBinding"
+            context: log
+            statements:
+            - set(attributes["observe_transform"]["identifiers"]["roleBindingName"], body["metadata"]["name"])
+            - set(attributes["observe_transform"]["identifiers"]["roleBindingUid"], body["metadata"]["uid"])
+            - set(attributes["observe_transform"]["facets"]["subjects"], body["subjects"])
+            - set(attributes["observe_transform"]["facets"]["role"], body["roleRef"]["name"])
+          - conditions:
+            - body["kind"] == "Role"
+            context: log
+            statements:
+            - set(attributes["observe_transform"]["identifiers"]["roleName"], body["metadata"]["name"])
+            - set(attributes["observe_transform"]["identifiers"]["roleUid"], body["metadata"]["uid"])
+            - set(attributes["observe_transform"]["facets"]["rules"], body["rules"])
+            - set(attributes["observe_transform"]["facets"]["role"], body["roleRef"]["name"])
+          - conditions:
+            - body["kind"] == "ClusterRoleBinding"
+            context: log
+            statements:
+            - set(attributes["observe_transform"]["identifiers"]["clusterRoleBindingName"],
+              body["metadata"]["name"])
+            - set(attributes["observe_transform"]["identifiers"]["clusterRoleBindingUid"],
+              body["metadata"]["uid"])
+            - set(attributes["observe_transform"]["facets"]["subjects"], body["subjects"])
+            - set(attributes["observe_transform"]["facets"]["role"], body["roleRef"]["name"])
+          - conditions:
+            - body["kind"] == "ServiceAccount"
+            context: log
+            statements:
+            - set(attributes["observe_transform"]["identifiers"]["serviceAccountName"],
+              body["metadata"]["name"])
+            - set(attributes["observe_transform"]["identifiers"]["serviceAccountUid"], body["metadata"]["uid"])
+            - set(attributes["observe_transform"]["facets"]["automountToken"], body["automountServiceAccountToken"])
+        transform/unify:
+          error_mode: ignore
+          log_statements:
+          - context: log
+            statements:
+            - set(attributes["observe_transform"]["control"]["isDelete"], true) where body["object"]
+              != nil and body["type"] == "DELETED"
+            - set(attributes["observe_transform"]["control"]["debug_source"], "watch") where
+              body["object"] != nil and body["type"] != nil
+            - set(attributes["observe_transform"]["control"]["debug_source"], "pull") where
+              body["object"] == nil or body["type"] == nil
+            - set(body, body["object"]) where body["object"] != nil and body["type"] !=
+              nil
+      receivers:
+        k8sobjects/cluster:
+          auth_type: serviceAccount
+          objects:
+          - interval: 20m
+            mode: pull
+            name: namespaces
+        k8sobjects/objects:
+          auth_type: serviceAccount
+          objects:
+          - interval: 15m
+            mode: pull
+            name: events
+          - mode: watch
+            name: events
+          - interval: 15m
+            mode: pull
+            name: pods
+          - mode: watch
+            name: pods
+          - interval: 15m
+            mode: pull
+            name: namespaces
+          - mode: watch
+            name: namespaces
+          - interval: 15m
+            mode: pull
+            name: nodes
+          - mode: watch
+            name: nodes
+          - interval: 15m
+            mode: pull
+            name: deployments
+          - mode: watch
+            name: deployments
+          - interval: 15m
+            mode: pull
+            name: replicasets
+          - mode: watch
+            name: replicasets
+          - interval: 15m
+            mode: pull
+            name: configmaps
+          - mode: watch
+            name: configmaps
+          - interval: 15m
+            mode: pull
+            name: endpoints
+          - mode: watch
+            name: endpoints
+          - interval: 15m
+            mode: pull
+            name: jobs
+          - mode: watch
+            name: jobs
+          - interval: 15m
+            mode: pull
+            name: cronjobs
+          - mode: watch
+            name: cronjobs
+          - interval: 15m
+            mode: pull
+            name: daemonsets
+          - mode: watch
+            name: daemonsets
+          - interval: 15m
+            mode: pull
+            name: statefulsets
+          - mode: watch
+            name: statefulsets
+          - interval: 15m
+            mode: pull
+            name: services
+          - mode: watch
+            name: services
+          - interval: 15m
+            mode: pull
+            name: ingresses
+          - mode: watch
+            name: ingresses
+          - interval: 15m
+            mode: pull
+            name: secrets
+          - mode: watch
+            name: secrets
+          - interval: 15m
+            mode: pull
+            name: persistentvolumeclaims
+          - mode: watch
+            name: persistentvolumeclaims
+          - interval: 15m
+            mode: pull
+            name: persistentvolumes
+          - mode: watch
+            name: persistentvolumes
+          - interval: 15m
+            mode: pull
+            name: storageclasses
+          - mode: watch
+            name: storageclasses
+          - interval: 15m
+            mode: pull
+            name: roles
+          - mode: watch
+            name: roles
+          - interval: 15m
+            mode: pull
+            name: rolebindings
+          - mode: watch
+            name: rolebindings
+          - interval: 15m
+            mode: pull
+            name: clusterroles
+          - mode: watch
+            name: clusterroles
+          - interval: 15m
+            mode: pull
+            name: clusterrolebindings
+          - mode: watch
+            name: clusterrolebindings
+          - interval: 15m
+            mode: pull
+            name: serviceaccounts
+          - mode: watch
+            name: serviceaccounts
+          - interval: 15m
+            mode: pull
+            name: customresourcedefinitions
+          - mode: watch
+            name: customresourcedefinitions
+      service:
+        pipelines:
+          logs/cluster:
+            exporters:
+            - otlphttp/observe/entity
+            processors:
+            - memory_limiter
+            - batch
+            - resource/observe_common
+            - filter/cluster
+            - transform/cluster
+            receivers:
+            - k8sobjects/cluster
+          logs/objects:
+            exporters:
+            - otlphttp/observe/entity
+            processors:
+            - memory_limiter
+            - batch
+            - resource/observe_common
+            - transform/unify
+            - observek8sattributes
+            - transform/object
+            - transform/identifiers_hash
+            receivers:
+            - k8sobjects/objects

--- a/charts/agent/examples/external-write-hashes/rendered/cluster-events-configmap.yaml
+++ b/charts/agent/examples/external-write-hashes/rendered/cluster-events-configmap.yaml
@@ -100,7 +100,7 @@ data:
             - set(attributes["observe_transform"]["control"]["isDelete"], false) where attributes["observe_transform"]["control"]["isDelete"]
               == nil
             - set(attributes["observe_transform"]["control"]["version"], body["metadata"]["resourceVersion"])
-            - set(attributes["observe_transform"]["control"]["agentVersion"], "2.16.0")
+            - set(attributes["observe_transform"]["control"]["agentVersion"], "2.18.0")
             - set(attributes["observe_transform"]["identifiers"]["clusterName"], resource.attributes["k8s.cluster.name"])
             - set(attributes["observe_transform"]["identifiers"]["clusterUid"], resource.attributes["k8s.cluster.uid"])
             - set(attributes["observe_transform"]["identifiers"]["kind"], body["kind"])

--- a/charts/agent/examples/external-write-hashes/rendered/cluster-events/deployment.yaml
+++ b/charts/agent/examples/external-write-hashes/rendered/cluster-events/deployment.yaml
@@ -1,0 +1,192 @@
+---
+# Source: agent/charts/cluster-events/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-cluster-events
+  namespace: observe
+  labels:
+    helm.sh/chart: cluster-events-0.159.0
+    app.kubernetes.io/name: cluster-events
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.154.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-collector
+    app.kubernetes.io/component: standalone-collector
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: cluster-events
+      app.kubernetes.io/instance: example
+      component: standalone-collector
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+        observe_monitor_path: /metrics
+        observe_monitor_port: "8888"
+        observe_monitor_purpose: observecollection
+        observe_monitor_scrape: "true"
+        observeinc_com_scrape: "false"
+      labels:
+        app.kubernetes.io/name: cluster-events
+        app.kubernetes.io/instance: example
+        component: standalone-collector
+
+    spec:
+
+      serviceAccountName: observe-agent-service-account
+      automountServiceAccountToken: true
+      securityContext:
+        {}
+      containers:
+        - name: cluster-events
+          command:
+            - /observe-agent
+          args:
+            - --config=/conf/relay.yaml
+            - start
+            - --observe-config=/observe-agent-conf/observe-agent.yaml
+            - --config=/conf/relay.yaml
+          securityContext:
+            {}
+          image: "observeinc/observe-agent:2.16.0"
+          imagePullPolicy: IfNotPresent
+          ports:
+
+            - name: jaeger-compact
+              containerPort: 6831
+              protocol: UDP
+            - name: jaeger-grpc
+              containerPort: 14250
+              protocol: TCP
+            - name: jaeger-thrift
+              containerPort: 14268
+              protocol: TCP
+            - name: metrics
+              containerPort: 8888
+              protocol: TCP
+            - name: otlp
+              containerPort: 4317
+              protocol: TCP
+            - name: otlp-http
+              containerPort: 4318
+              protocol: TCP
+            - name: zipkin
+              containerPort: 9411
+              protocol: TCP
+          env:
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: OTEL_K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: OTEL_K8S_NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: OTEL_K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: OTEL_K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: OTEL_K8S_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: GOMEMLIMIT
+              value: "204MiB"
+            - name: OTEL_K8S_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+            - name: OBSERVE_CLUSTER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  key: name
+                  name: cluster-name
+            - name: OBSERVE_CLUSTER_UID
+              valueFrom:
+                configMapKeyRef:
+                  key: id
+                  name: cluster-info
+            - name: TOKEN
+              valueFrom:
+                secretKeyRef:
+                  key: OBSERVE_TOKEN
+                  name: agent-credentials
+                  optional: true
+          livenessProbe:
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            httpGet:
+              path: /status
+              port: 13133
+          readinessProbe:
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            httpGet:
+              path: /status
+              port: 13133
+          resources:
+            limits:
+              memory: 256Mi
+            requests:
+              cpu: 150m
+              memory: 256Mi
+          volumeMounts:
+            - mountPath: /conf
+              name: cluster-events-configmap
+            - mountPath: /observe-agent-conf
+              name: observe-agent-deployment-config
+      initContainers:
+        - env:
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          image: observeinc/kube-cluster-info:v0.11.6
+          imagePullPolicy: Always
+          name: kube-cluster-info
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - name: cluster-events-configmap
+          configMap:
+            name: cluster-events
+            items:
+              - key: relay
+                path: relay.yaml
+        - configMap:
+            defaultMode: 420
+            items:
+            - key: relay
+              path: observe-agent.yaml
+            name: observe-agent
+          name: observe-agent-deployment-config
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: observeinc.com/unschedulable
+                operator: DoesNotExist
+              - key: kubernetes.io/os
+                operator: NotIn
+                values:
+                - windows
+      hostNetwork: false
+      hostPID: false

--- a/charts/agent/examples/external-write-hashes/rendered/cluster-events/deployment.yaml
+++ b/charts/agent/examples/external-write-hashes/rendered/cluster-events/deployment.yaml
@@ -54,7 +54,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "observeinc/observe-agent:2.16.0"
+          image: "observeinc/observe-agent:2.18.0"
           imagePullPolicy: IfNotPresent
           ports:
 

--- a/charts/agent/examples/external-write-hashes/rendered/cluster-events/networkpolicy.yaml
+++ b/charts/agent/examples/external-write-hashes/rendered/cluster-events/networkpolicy.yaml
@@ -1,0 +1,39 @@
+---
+# Source: agent/charts/cluster-events/templates/networkpolicy.yaml
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: example-cluster-events
+  namespace: observe
+  labels:
+    helm.sh/chart: cluster-events-0.159.0
+    app.kubernetes.io/name: cluster-events
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.154.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-collector
+    app.kubernetes.io/component: standalone-collector
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: cluster-events
+      app.kubernetes.io/instance: example
+      component: standalone-collector
+  ingress:
+    - ports:
+        - port: 6831
+          protocol: UDP
+        - port: 14250
+          protocol: TCP
+        - port: 14268
+          protocol: TCP
+        - port: 8888
+          protocol: TCP
+        - port: 4317
+          protocol: TCP
+        - port: 4318
+          protocol: TCP
+        - port: 9411
+          protocol: TCP
+  egress:
+    - {}

--- a/charts/agent/examples/external-write-hashes/rendered/cluster-events/service.yaml
+++ b/charts/agent/examples/external-write-hashes/rendered/cluster-events/service.yaml
@@ -1,0 +1,54 @@
+---
+# Source: agent/charts/cluster-events/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-cluster-events
+  namespace: observe
+  labels:
+    helm.sh/chart: cluster-events-0.159.0
+    app.kubernetes.io/name: cluster-events
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.154.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-collector
+    app.kubernetes.io/component: standalone-collector
+    component: standalone-collector
+spec:
+  type: ClusterIP
+  ports:
+
+    - name: jaeger-compact
+      port: 6831
+      targetPort: 6831
+      protocol: UDP
+    - name: jaeger-grpc
+      port: 14250
+      targetPort: 14250
+      protocol: TCP
+    - name: jaeger-thrift
+      port: 14268
+      targetPort: 14268
+      protocol: TCP
+    - name: metrics
+      port: 8888
+      targetPort: 8888
+      protocol: TCP
+    - name: otlp
+      port: 4317
+      targetPort: 4317
+      protocol: TCP
+      appProtocol: grpc
+    - name: otlp-http
+      port: 4318
+      targetPort: 4318
+      protocol: TCP
+    - name: zipkin
+      port: 9411
+      targetPort: 9411
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: cluster-events
+    app.kubernetes.io/instance: example
+    component: standalone-collector
+  internalTrafficPolicy: Cluster

--- a/charts/agent/examples/external-write-hashes/rendered/cluster-metrics-configmap.yaml
+++ b/charts/agent/examples/external-write-hashes/rendered/cluster-metrics-configmap.yaml
@@ -1,0 +1,140 @@
+---
+# Source: agent/templates/cluster-metrics-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-metrics
+  namespace: observe
+data:
+  relay: |
+      exporters:
+        debug/override:
+          sampling_initial: 2
+          sampling_thereafter: 1
+          verbosity: basic
+        prometheusremotewrite/observe:
+          endpoint: ${env:OBSERVE_PROMETHEUS_ENDPOINT}
+          headers:
+            authorization: ${env:OBSERVE_AUTHORIZATION_HEADER}
+            x-observe-target-package: Kubernetes Explorer
+          max_batch_request_parallelism: 5
+          remote_write_queue:
+            num_consumers: 5
+          resource_to_telemetry_conversion:
+            enabled: true
+          retry_on_failure:
+            enabled: true
+            initial_interval: 1s
+            max_elapsed_time: 5m
+            max_interval: 30s
+          send_metadata: true
+          target_info:
+            enabled: false
+          timeout: 10s
+      processors:
+        attributes/debug_source_cluster_metrics:
+          actions:
+          - action: insert
+            key: debug_source
+            value: cluster_metrics
+        batch:
+          send_batch_max_size: 4096
+          send_batch_size: 4096
+          timeout: 5s
+        k8sattributes:
+          extract:
+            labels:
+            - from: pod
+              key_regex: (app\.kubernetes\.io/.+)
+              tag_name: $1
+            metadata:
+            - k8s.namespace.name
+            - k8s.deployment.name
+            - k8s.replicaset.name
+            - k8s.statefulset.name
+            - k8s.daemonset.name
+            - k8s.cronjob.name
+            - k8s.job.name
+            - k8s.node.name
+            - k8s.node.uid
+            - k8s.pod.name
+            - k8s.pod.uid
+            - k8s.cluster.uid
+            - k8s.container.name
+            - service.namespace
+            - service.name
+            - service.version
+            - service.instance.id
+            otel_annotations: true
+          passthrough: false
+          pod_association:
+          - sources:
+            - from: resource_attribute
+              name: k8s.pod.ip
+          - sources:
+            - from: resource_attribute
+              name: k8s.pod.uid
+          - sources:
+            - from: connection
+          wait_for_metadata: false
+          wait_for_metadata_timeout: 10s
+        memory_limiter:
+          check_interval: 5s
+          limit_percentage: 80
+          spike_limit_percentage: 15
+        resource/drop_container_info:
+          attributes:
+          - action: delete
+            key: container.id
+        resource/drop_service_name:
+          attributes:
+          - action: delete
+            key: service.name
+        resource/observe_common:
+          attributes:
+          - action: upsert
+            key: k8s.cluster.name
+            value: ${env:OBSERVE_CLUSTER_NAME}
+          - action: upsert
+            key: k8s.cluster.uid
+            value: ${env:OBSERVE_CLUSTER_UID}
+        transform/metric_hashes:
+          error_mode: ignore
+          metric_statements:
+          - context: datapoint
+            statements:
+            - set(attributes["observe_labels_hash"], Substring(XXH128(Concat([ToKeyValueString(resource.attributes,
+              "=", ",", true), ToKeyValueString(attributes, "=", ",", true)], "|")), 0,
+              31))
+      receivers:
+        k8s_cluster:
+          allocatable_types_to_report:
+          - cpu
+          - memory
+          - storage
+          - ephemeral-storage
+          auth_type: serviceAccount
+          collection_interval: 60s
+          metadata_collection_interval: 5m
+          metrics:
+            k8s.node.condition:
+              enabled: true
+          node_conditions_to_report:
+          - Ready
+          - MemoryPressure
+          - DiskPressure
+      service:
+        pipelines:
+          metrics:
+            exporters:
+            - prometheusremotewrite/observe
+            processors:
+            - memory_limiter
+            - k8sattributes
+            - batch
+            - resource/observe_common
+            - resource/drop_container_info
+            - attributes/debug_source_cluster_metrics
+            - transform/metric_hashes
+            receivers:
+            - k8s_cluster

--- a/charts/agent/examples/external-write-hashes/rendered/cluster-metrics-configmap.yaml
+++ b/charts/agent/examples/external-write-hashes/rendered/cluster-metrics-configmap.yaml
@@ -103,9 +103,10 @@ data:
           metric_statements:
           - context: datapoint
             statements:
-            - set(attributes["observe_labels_hash"], Substring(XXH128(Concat([ToKeyValueString(resource.attributes,
-              "=", ",", true), ToKeyValueString(attributes, "=", ",", true)], "|")), 0,
-              31))
+            - merge_maps(cache, attributes, "upsert")
+            - merge_maps(cache, resource.attributes, "upsert")
+            - set(attributes["observe_labels_hash"], Substring(XXH128(ToKeyValueString(cache,
+              "=", ",", true)), 0, 31))
       receivers:
         k8s_cluster:
           allocatable_types_to_report:

--- a/charts/agent/examples/external-write-hashes/rendered/cluster-metrics/deployment.yaml
+++ b/charts/agent/examples/external-write-hashes/rendered/cluster-metrics/deployment.yaml
@@ -55,7 +55,7 @@ spec:
             - --feature-gates=+exporter.prometheusremotewritexporter.EnableMultipleWorkers
           securityContext:
             {}
-          image: "observeinc/observe-agent:2.16.0"
+          image: "observeinc/observe-agent:2.18.0"
           imagePullPolicy: IfNotPresent
           ports:
 

--- a/charts/agent/examples/external-write-hashes/rendered/cluster-metrics/deployment.yaml
+++ b/charts/agent/examples/external-write-hashes/rendered/cluster-metrics/deployment.yaml
@@ -1,0 +1,193 @@
+---
+# Source: agent/charts/cluster-metrics/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-cluster-metrics
+  namespace: observe
+  labels:
+    helm.sh/chart: cluster-metrics-0.159.0
+    app.kubernetes.io/name: cluster-metrics
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.154.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-collector
+    app.kubernetes.io/component: standalone-collector
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: cluster-metrics
+      app.kubernetes.io/instance: example
+      component: standalone-collector
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+        observe_monitor_path: /metrics
+        observe_monitor_port: "8888"
+        observe_monitor_purpose: observecollection
+        observe_monitor_scrape: "true"
+        observeinc_com_scrape: "false"
+      labels:
+        app.kubernetes.io/name: cluster-metrics
+        app.kubernetes.io/instance: example
+        component: standalone-collector
+
+    spec:
+
+      serviceAccountName: observe-agent-service-account
+      automountServiceAccountToken: true
+      securityContext:
+        {}
+      containers:
+        - name: cluster-metrics
+          command:
+            - /observe-agent
+          args:
+            - --config=/conf/relay.yaml
+            - start
+            - --observe-config=/observe-agent-conf/observe-agent.yaml
+            - --config=/conf/relay.yaml
+            - --feature-gates=+exporter.prometheusremotewritexporter.EnableMultipleWorkers
+          securityContext:
+            {}
+          image: "observeinc/observe-agent:2.16.0"
+          imagePullPolicy: IfNotPresent
+          ports:
+
+            - name: jaeger-compact
+              containerPort: 6831
+              protocol: UDP
+            - name: jaeger-grpc
+              containerPort: 14250
+              protocol: TCP
+            - name: jaeger-thrift
+              containerPort: 14268
+              protocol: TCP
+            - name: metrics
+              containerPort: 8888
+              protocol: TCP
+            - name: otlp
+              containerPort: 4317
+              protocol: TCP
+            - name: otlp-http
+              containerPort: 4318
+              protocol: TCP
+            - name: zipkin
+              containerPort: 9411
+              protocol: TCP
+          env:
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: OTEL_K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: OTEL_K8S_NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: OTEL_K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: OTEL_K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: OTEL_K8S_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: GOMEMLIMIT
+              value: "409MiB"
+            - name: OTEL_K8S_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+            - name: OBSERVE_CLUSTER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  key: name
+                  name: cluster-name
+            - name: OBSERVE_CLUSTER_UID
+              valueFrom:
+                configMapKeyRef:
+                  key: id
+                  name: cluster-info
+            - name: TOKEN
+              valueFrom:
+                secretKeyRef:
+                  key: OBSERVE_TOKEN
+                  name: agent-credentials
+                  optional: true
+          livenessProbe:
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            httpGet:
+              path: /status
+              port: 13133
+          readinessProbe:
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            httpGet:
+              path: /status
+              port: 13133
+          resources:
+            limits:
+              memory: 512Mi
+            requests:
+              cpu: 250m
+              memory: 512Mi
+          volumeMounts:
+            - mountPath: /conf
+              name: cluster-metrics-configmap
+            - mountPath: /observe-agent-conf
+              name: observe-agent-deployment-config
+      initContainers:
+        - env:
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          image: observeinc/kube-cluster-info:v0.11.6
+          imagePullPolicy: Always
+          name: kube-cluster-info
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - name: cluster-metrics-configmap
+          configMap:
+            name: cluster-metrics
+            items:
+              - key: relay
+                path: relay.yaml
+        - configMap:
+            defaultMode: 420
+            items:
+            - key: relay
+              path: observe-agent.yaml
+            name: observe-agent
+          name: observe-agent-deployment-config
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: observeinc.com/unschedulable
+                operator: DoesNotExist
+              - key: kubernetes.io/os
+                operator: NotIn
+                values:
+                - windows
+      hostNetwork: false
+      hostPID: false

--- a/charts/agent/examples/external-write-hashes/rendered/cluster-metrics/networkpolicy.yaml
+++ b/charts/agent/examples/external-write-hashes/rendered/cluster-metrics/networkpolicy.yaml
@@ -1,0 +1,39 @@
+---
+# Source: agent/charts/cluster-metrics/templates/networkpolicy.yaml
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: example-cluster-metrics
+  namespace: observe
+  labels:
+    helm.sh/chart: cluster-metrics-0.159.0
+    app.kubernetes.io/name: cluster-metrics
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.154.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-collector
+    app.kubernetes.io/component: standalone-collector
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: cluster-metrics
+      app.kubernetes.io/instance: example
+      component: standalone-collector
+  ingress:
+    - ports:
+        - port: 6831
+          protocol: UDP
+        - port: 14250
+          protocol: TCP
+        - port: 14268
+          protocol: TCP
+        - port: 8888
+          protocol: TCP
+        - port: 4317
+          protocol: TCP
+        - port: 4318
+          protocol: TCP
+        - port: 9411
+          protocol: TCP
+  egress:
+    - {}

--- a/charts/agent/examples/external-write-hashes/rendered/cluster-metrics/service.yaml
+++ b/charts/agent/examples/external-write-hashes/rendered/cluster-metrics/service.yaml
@@ -1,0 +1,54 @@
+---
+# Source: agent/charts/cluster-metrics/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-cluster-metrics
+  namespace: observe
+  labels:
+    helm.sh/chart: cluster-metrics-0.159.0
+    app.kubernetes.io/name: cluster-metrics
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.154.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-collector
+    app.kubernetes.io/component: standalone-collector
+    component: standalone-collector
+spec:
+  type: ClusterIP
+  ports:
+
+    - name: jaeger-compact
+      port: 6831
+      targetPort: 6831
+      protocol: UDP
+    - name: jaeger-grpc
+      port: 14250
+      targetPort: 14250
+      protocol: TCP
+    - name: jaeger-thrift
+      port: 14268
+      targetPort: 14268
+      protocol: TCP
+    - name: metrics
+      port: 8888
+      targetPort: 8888
+      protocol: TCP
+    - name: otlp
+      port: 4317
+      targetPort: 4317
+      protocol: TCP
+      appProtocol: grpc
+    - name: otlp-http
+      port: 4318
+      targetPort: 4318
+      protocol: TCP
+    - name: zipkin
+      port: 9411
+      targetPort: 9411
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: cluster-metrics
+    app.kubernetes.io/instance: example
+    component: standalone-collector
+  internalTrafficPolicy: Cluster

--- a/charts/agent/examples/external-write-hashes/rendered/cluster-name-configmap.yaml
+++ b/charts/agent/examples/external-write-hashes/rendered/cluster-name-configmap.yaml
@@ -1,0 +1,9 @@
+---
+# Source: agent/templates/cluster-name-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-name
+  namespace: observe
+data:
+  name: observe-agent-monitored-cluster

--- a/charts/agent/examples/external-write-hashes/rendered/cluster-role.yaml
+++ b/charts/agent/examples/external-write-hashes/rendered/cluster-role.yaml
@@ -1,0 +1,53 @@
+---
+# Source: agent/templates/cluster-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: observe-agent-cluster-role-observe
+  labels:
+    app.kubernetes.io/name: observe-agent-cluster-role
+    app.kubernetes.io/instance: observe-agent
+
+rules:
+  - apiGroups:
+    - ""
+    resources:
+    - configmaps
+    verbs:
+    - create
+    - get
+  - apiGroups:
+    - ""
+    - '*'
+    - apps
+    - authorization.k8s.io
+    - autoscaling
+    - batch
+    - networking.k8s.io
+    - events.k8s.io
+    - rbac.authorization.k8s.io
+    - storage.k8s.io
+    - vpcresources.k8s.aws
+    resources:
+    - '*'
+    verbs:
+    - get
+    - list
+    - watch
+---
+# Source: agent/templates/cluster-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: observe-agent-cluster-role-binding
+  labels:
+    app.kubernetes.io/name: observe-agent-cluster-role-binding-observe
+    app.kubernetes.io/instance: observe-agent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: observe-agent-cluster-role-observe
+subjects:
+- kind: ServiceAccount
+  name: observe-agent-service-account
+  namespace: observe

--- a/charts/agent/examples/external-write-hashes/rendered/cluster-role.yaml
+++ b/charts/agent/examples/external-write-hashes/rendered/cluster-role.yaml
@@ -39,7 +39,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: observe-agent-cluster-role-binding
+  name: observe-agent-cluster-role-binding-observe
   labels:
     app.kubernetes.io/name: observe-agent-cluster-role-binding-observe
     app.kubernetes.io/instance: observe-agent

--- a/charts/agent/examples/external-write-hashes/rendered/forwarder-configmap.yaml
+++ b/charts/agent/examples/external-write-hashes/rendered/forwarder-configmap.yaml
@@ -1,0 +1,433 @@
+---
+# Source: agent/templates/forwarder-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: forwarder
+  namespace: observe
+data:
+  relay: |
+      connectors:
+        spanmetrics:
+          aggregation_temporality: AGGREGATION_TEMPORALITY_DELTA
+          dimensions:
+          - name: service.namespace
+          - name: service.version
+          - name: deployment.environment.name
+          - name: k8s.pod.name
+          - name: k8s.namespace.name
+          - name: peer.db.name
+          - name: peer.messaging.system
+          - name: otel.status_description
+          - name: observe.status_code
+          histogram:
+            exponential:
+              max_size: 100
+          resource_metrics_key_attributes:
+          - service.name
+          - service.namespace
+          - service.version
+          - deployment.environment.name
+          - k8s.pod.name
+          - k8s.namespace.name
+        spanmetrics/summary:
+          aggregation_temporality: AGGREGATION_TEMPORALITY_DELTA
+          dimensions:
+          - name: service.namespace
+          - name: service.version
+          - name: deployment.environment.name
+          - name: peer.db.name
+          - name: peer.messaging.system
+          - name: observe.status_code
+          histogram:
+            exponential:
+              max_size: 100
+          resource_metrics_key_attributes:
+          - service.name
+          - service.namespace
+          - service.version
+          - deployment.environment.name
+      exporters:
+        debug/override:
+          sampling_initial: 2
+          sampling_thereafter: 1
+          verbosity: basic
+        otlphttp/observe/base:
+          compression: zstd
+          endpoint: ${env:OBSERVE_OTEL_ENDPOINT}
+          headers:
+            authorization: ${env:OBSERVE_AUTHORIZATION_HEADER}
+            x-observe-target-package: Kubernetes Explorer
+          retry_on_failure:
+            enabled: true
+            initial_interval: 1s
+            max_elapsed_time: 5m
+            max_interval: 30s
+          sending_queue:
+            enabled: true
+          timeout: 10s
+        otlphttp/observe/forward/trace:
+          compression: zstd
+          endpoint: ${env:OBSERVE_OTEL_ENDPOINT}
+          headers:
+            authorization: Bearer ${env:TRACE_TOKEN}
+            x-observe-target-package: Tracing
+          retry_on_failure:
+            enabled: true
+            initial_interval: 1s
+            max_elapsed_time: 5m
+            max_interval: 30s
+          sending_queue:
+            enabled: true
+          timeout: 10s
+        otlphttp/observe/otel_metrics:
+          compression: zstd
+          endpoint: ${env:OBSERVE_OTEL_ENDPOINT}
+          headers:
+            authorization: ${env:OBSERVE_AUTHORIZATION_HEADER}
+            x-observe-target-package: Metrics
+          retry_on_failure:
+            enabled: true
+            initial_interval: 1s
+            max_elapsed_time: 5m
+            max_interval: 30s
+          sending_queue:
+            enabled: true
+          timeout: 10s
+        prometheusremotewrite/observe:
+          endpoint: ${env:OBSERVE_PROMETHEUS_ENDPOINT}
+          headers:
+            authorization: ${env:OBSERVE_AUTHORIZATION_HEADER}
+            x-observe-target-package: Kubernetes Explorer
+          max_batch_request_parallelism: 5
+          remote_write_queue:
+            num_consumers: 5
+          resource_to_telemetry_conversion:
+            enabled: true
+          retry_on_failure:
+            enabled: true
+            initial_interval: 1s
+            max_elapsed_time: 5m
+            max_interval: 30s
+          send_metadata: true
+          target_info:
+            enabled: false
+          timeout: 10s
+      processors:
+        attributes/debug_source_app_logs:
+          actions:
+          - action: insert
+            key: debug_source
+            value: app_logs
+        attributes/debug_source_app_metrics:
+          actions:
+          - action: insert
+            key: debug_source
+            value: app_metrics
+        attributes/debug_source_app_traces:
+          actions:
+          - action: insert
+            key: debug_source
+            value: app_traces
+        attributes/debug_source_span_metrics:
+          actions:
+          - action: insert
+            key: debug_source
+            value: span_metrics
+        batch:
+          send_batch_max_size: 4096
+          send_batch_size: 4096
+          timeout: 5s
+        deltatocumulative/observe:
+          max_stale: 5m
+        filter/drop_long_spans:
+          error_mode: ignore
+          traces:
+            span:
+            - (span.end_time - span.start_time) > Duration("1h")
+        filter/drop_non_apm_spans:
+          error_mode: ignore
+          traces:
+            span:
+            - span.kind == SPAN_KIND_CLIENT and span.attributes["peer.db.name"] == nil and
+              span.attributes["db.system.name"] == nil and span.attributes["db.system"]
+              == nil
+            - span.kind == SPAN_KIND_PRODUCER and span.attributes["peer.messaging.system"]
+              == nil and span.attributes["messaging.system"] == nil
+            - span.kind == SPAN_KIND_UNSPECIFIED
+            - span.kind == SPAN_KIND_INTERNAL
+        groupbyattrs/peers:
+          keys:
+          - peer.db.name
+          - peer.messaging.system
+        k8sattributes:
+          extract:
+            labels:
+            - from: pod
+              key_regex: (app\.kubernetes\.io/.+)
+              tag_name: $1
+            metadata:
+            - k8s.namespace.name
+            - k8s.deployment.name
+            - k8s.replicaset.name
+            - k8s.statefulset.name
+            - k8s.daemonset.name
+            - k8s.cronjob.name
+            - k8s.job.name
+            - k8s.node.name
+            - k8s.node.uid
+            - k8s.pod.name
+            - k8s.pod.uid
+            - k8s.cluster.uid
+            - k8s.container.name
+            - container.id
+            - service.namespace
+            - service.name
+            - service.version
+            - service.instance.id
+            otel_annotations: true
+          passthrough: false
+          pod_association:
+          - sources:
+            - from: resource_attribute
+              name: k8s.pod.ip
+          - sources:
+            - from: resource_attribute
+              name: k8s.pod.uid
+          - sources:
+            - from: connection
+          wait_for_metadata: false
+          wait_for_metadata_timeout: 10s
+        memory_limiter:
+          check_interval: 5s
+          limit_percentage: 80
+          spike_limit_percentage: 15
+        metricstransform/rename_summary_metrics:
+          transforms:
+          - action: update
+            include: traces.span.metrics.calls
+            new_name: traces.span.metrics.calls.summary
+          - action: update
+            include: traces.span.metrics.duration
+            new_name: traces.span.metrics.duration.summary
+        resource/observe_common:
+          attributes:
+          - action: upsert
+            key: k8s.cluster.name
+            value: ${env:OBSERVE_CLUSTER_NAME}
+          - action: upsert
+            key: k8s.cluster.uid
+            value: ${env:OBSERVE_CLUSTER_UID}
+        resourcedetection/cloud:
+          detectors:
+          - gcp
+          - ecs
+          - ec2
+          - azure
+          override: false
+          timeout: 2s
+        transform/add_empty_service_attributes:
+          error_mode: ignore
+          trace_statements:
+          - set(resource.attributes["deployment.environment.name"], Coalesce([resource.attributes["deployment.environment.name"],
+            resource.attributes["deployment.environment"]]))
+          - set(resource.attributes["deployment.environment"], Coalesce([resource.attributes["deployment.environment"],
+            resource.attributes["deployment.environment.name"]]))
+          - set(resource.attributes["service.name"], "") where resource.attributes["service.name"]
+            == nil
+          - set(resource.attributes["service.namespace"], "") where resource.attributes["service.namespace"]
+            == nil
+          - set(resource.attributes["deployment.environment.name"], "") where resource.attributes["deployment.environment.name"]
+            == nil
+          - set(resource.attributes["deployment.environment"], "") where resource.attributes["deployment.environment"]
+            == nil
+        transform/add_span_status_code:
+          error_mode: ignore
+          trace_statements:
+          - set(span.attributes["observe.status_code"], Int(span.attributes["rpc.grpc.status_code"]))
+            where span.attributes["observe.status_code"] == nil and span.attributes["rpc.grpc.status_code"]
+            != nil
+          - set(span.attributes["observe.status_code"], Int(span.attributes["grpc.status_code"]))
+            where span.attributes["observe.status_code"] == nil and span.attributes["grpc.status_code"]
+            != nil
+          - set(span.attributes["observe.status_code"], Int(span.attributes["rpc.status_code"]))
+            where span.attributes["observe.status_code"] == nil and span.attributes["rpc.status_code"]
+            != nil
+          - set(span.attributes["observe.status_code"], Int(span.attributes["http.status_code"]))
+            where span.attributes["observe.status_code"] == nil and span.attributes["http.status_code"]
+            != nil
+          - set(span.attributes["observe.status_code"], Int(span.attributes["http.response.status_code"]))
+            where span.attributes["observe.status_code"] == nil and span.attributes["http.response.status_code"]
+            != nil
+        transform/deployment_environment_compatability:
+          error_mode: ignore
+          log_statements:
+          - set(resource.attributes["deployment.environment.name"], Coalesce([resource.attributes["deployment.environment.name"],
+            resource.attributes["deployment.environment"]]))
+          - set(resource.attributes["deployment.environment"], Coalesce([resource.attributes["deployment.environment"],
+            resource.attributes["deployment.environment.name"]]))
+          metric_statements:
+          - set(resource.attributes["deployment.environment.name"], Coalesce([resource.attributes["deployment.environment.name"],
+            resource.attributes["deployment.environment"]]))
+          - set(resource.attributes["deployment.environment"], Coalesce([resource.attributes["deployment.environment"],
+            resource.attributes["deployment.environment.name"]]))
+          trace_statements:
+          - set(resource.attributes["deployment.environment.name"], Coalesce([resource.attributes["deployment.environment.name"],
+            resource.attributes["deployment.environment"]]))
+          - set(resource.attributes["deployment.environment"], Coalesce([resource.attributes["deployment.environment"],
+            resource.attributes["deployment.environment.name"]]))
+        transform/fix_red_metrics_resource_attributes:
+          error_mode: ignore
+          metric_statements:
+          - keep_matching_keys(resource.attributes, "^(service.name|service.namespace|service.version|deployment.environment.name|k8s.pod.name|k8s.namespace.name)")
+          - delete_matching_keys(datapoint.attributes, "^(service.name|service.namespace|service.version|deployment.environment.name|k8s.pod.name|k8s.namespace.name)")
+          - set(datapoint.attributes["otel.status_code"], "OK") where datapoint.attributes["status.code"]
+            == "STATUS_CODE_OK"
+          - set(datapoint.attributes["otel.status_code"], "ERROR") where datapoint.attributes["status.code"]
+            == "STATUS_CODE_ERROR"
+          - delete_key(datapoint.attributes, "status.code")
+        transform/fix_red_metrics_resource_attributes/summary:
+          error_mode: ignore
+          metric_statements:
+          - keep_matching_keys(resource.attributes, "^(service.name|service.namespace|service.version|deployment.environment.name)")
+          - delete_matching_keys(datapoint.attributes, "^(service.name|service.namespace|service.version|deployment.environment.name)")
+          - set(datapoint.attributes["otel.status_code"], "OK") where datapoint.attributes["status.code"]
+            == "STATUS_CODE_OK"
+          - set(datapoint.attributes["otel.status_code"], "ERROR") where datapoint.attributes["status.code"]
+            == "STATUS_CODE_ERROR"
+          - delete_key(datapoint.attributes, "status.code")
+        transform/metric_hashes:
+          error_mode: ignore
+          metric_statements:
+          - context: datapoint
+            statements:
+            - set(attributes["observe_labels_hash"], Substring(XXH128(Concat([ToKeyValueString(resource.attributes,
+              "=", ",", true), ToKeyValueString(attributes, "=", ",", true)], "|")), 0,
+              31))
+        transform/promote_peer_to_service:
+          error_mode: ignore
+          trace_statements:
+          - context: resource
+            statements:
+            - set(attributes["service.name"], attributes["peer.db.name"]) where attributes["peer.db.name"]
+              != nil
+            - set(attributes["service.name"], attributes["peer.messaging.system"]) where
+              attributes["peer.messaging.system"] != nil and attributes["peer.db.name"]
+              == nil
+          - context: span
+            statements:
+            - set(attributes["peer.db.name"], resource.attributes["peer.db.name"]) where
+              resource.attributes["peer.db.name"] != nil
+            - set(attributes["peer.messaging.system"], resource.attributes["peer.messaging.system"])
+              where resource.attributes["peer.messaging.system"] != nil
+          - context: resource
+            statements:
+            - delete_key(attributes, "peer.db.name")
+            - delete_key(attributes, "peer.messaging.system")
+        transform/remove_service_name_for_peer_metrics:
+          error_mode: ignore
+          metric_statements:
+          - delete_key(resource.attributes, "service.name") where datapoint.attributes["peer.db.name"]
+            != nil or datapoint.attributes["peer.messaging.system"] != nil
+        transform/shape_spans_for_red_metrics:
+          error_mode: ignore
+          trace_statements:
+          - set(span.attributes["peer.db.name"], Coalesce([span.attributes["peer.db.name"],
+            span.attributes["db.system.name"], span.attributes["db.system"]]))
+          - set(span.attributes["peer.messaging.system"], Coalesce([span.attributes["peer.messaging.system"],
+            span.attributes["messaging.system"]]))
+          - set(span.attributes["otel.status_description"], span.status.message) where span.status.message
+            != ""
+      receivers:
+        otlp/app-telemetry:
+          protocols:
+            grpc:
+              endpoint: ${env:MY_POD_IP}:4317
+            http:
+              endpoint: ${env:MY_POD_IP}:4318
+      service:
+        pipelines:
+          logs/observe-forward:
+            exporters:
+            - otlphttp/observe/base
+            processors:
+            - memory_limiter
+            - k8sattributes
+            - batch
+            - resourcedetection/cloud
+            - resource/observe_common
+            - transform/deployment_environment_compatability
+            - attributes/debug_source_app_logs
+            receivers:
+            - otlp/app-telemetry
+          metrics/observe-forward:
+            exporters:
+            - prometheusremotewrite/observe
+            processors:
+            - memory_limiter
+            - k8sattributes
+            - deltatocumulative/observe
+            - batch
+            - resourcedetection/cloud
+            - resource/observe_common
+            - transform/deployment_environment_compatability
+            - attributes/debug_source_app_metrics
+            - transform/metric_hashes
+            receivers:
+            - otlp/app-telemetry
+          metrics/spanmetrics:
+            exporters:
+            - otlphttp/observe/otel_metrics
+            processors:
+            - memory_limiter
+            - transform/remove_service_name_for_peer_metrics
+            - transform/fix_red_metrics_resource_attributes
+            - batch
+            - resource/observe_common
+            - attributes/debug_source_span_metrics
+            receivers:
+            - spanmetrics
+          metrics/spanmetrics/summary:
+            exporters:
+            - otlphttp/observe/otel_metrics
+            processors:
+            - memory_limiter
+            - transform/remove_service_name_for_peer_metrics
+            - transform/fix_red_metrics_resource_attributes/summary
+            - metricstransform/rename_summary_metrics
+            - batch
+            - resource/observe_common
+            receivers:
+            - spanmetrics/summary
+          traces/observe-forward:
+            exporters:
+            - otlphttp/observe/forward/trace
+            processors:
+            - filter/drop_long_spans
+            - memory_limiter
+            - k8sattributes
+            - transform/add_span_status_code
+            - transform/add_empty_service_attributes
+            - batch
+            - resourcedetection/cloud
+            - resource/observe_common
+            - transform/deployment_environment_compatability
+            - attributes/debug_source_app_traces
+            receivers:
+            - otlp/app-telemetry
+          traces/spanmetrics:
+            exporters:
+            - spanmetrics
+            - spanmetrics/summary
+            processors:
+            - memory_limiter
+            - filter/drop_long_spans
+            - filter/drop_non_apm_spans
+            - k8sattributes
+            - transform/shape_spans_for_red_metrics
+            - transform/add_span_status_code
+            - groupbyattrs/peers
+            - transform/promote_peer_to_service
+            - transform/add_empty_service_attributes
+            receivers:
+            - otlp/app-telemetry

--- a/charts/agent/examples/external-write-hashes/rendered/forwarder-configmap.yaml
+++ b/charts/agent/examples/external-write-hashes/rendered/forwarder-configmap.yaml
@@ -301,9 +301,10 @@ data:
           metric_statements:
           - context: datapoint
             statements:
-            - set(attributes["observe_labels_hash"], Substring(XXH128(Concat([ToKeyValueString(resource.attributes,
-              "=", ",", true), ToKeyValueString(attributes, "=", ",", true)], "|")), 0,
-              31))
+            - merge_maps(cache, attributes, "upsert")
+            - merge_maps(cache, resource.attributes, "upsert")
+            - set(attributes["observe_labels_hash"], Substring(XXH128(ToKeyValueString(cache,
+              "=", ",", true)), 0, 31))
         transform/promote_peer_to_service:
           error_mode: ignore
           trace_statements:

--- a/charts/agent/examples/external-write-hashes/rendered/forwarder/daemonset.yaml
+++ b/charts/agent/examples/external-write-hashes/rendered/forwarder/daemonset.yaml
@@ -1,0 +1,208 @@
+---
+# Source: agent/charts/forwarder/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: example-forwarder-agent
+  namespace: observe
+  labels:
+    helm.sh/chart: forwarder-0.159.0
+    app.kubernetes.io/name: forwarder
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.154.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-collector
+    app.kubernetes.io/component: agent-collector
+spec:
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: forwarder
+      app.kubernetes.io/instance: example
+      component: agent-collector
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+        observe_monitor_path: /metrics
+        observe_monitor_port: "8888"
+        observe_monitor_purpose: observecollection
+        observe_monitor_scrape: "true"
+        observeinc_com_scrape: "false"
+      labels:
+        app.kubernetes.io/name: forwarder
+        app.kubernetes.io/instance: example
+        component: agent-collector
+
+    spec:
+
+      serviceAccountName: observe-agent-service-account
+      automountServiceAccountToken: true
+      securityContext:
+        {}
+      containers:
+        - name: forwarder
+          command:
+            - /observe-agent
+          args:
+            - --config=/conf/relay.yaml
+            - start
+            - --observe-config=/observe-agent-conf/observe-agent.yaml
+            - --config=/conf/relay.yaml
+            - --feature-gates=+connector.spanmetrics.includeCollectorInstanceID
+          securityContext:
+            {}
+          image: "observeinc/observe-agent:2.16.0"
+          imagePullPolicy: IfNotPresent
+          ports:
+
+            - name: jaeger-compact
+              containerPort: 6831
+              protocol: UDP
+              hostPort: 6831
+            - name: jaeger-grpc
+              containerPort: 14250
+              protocol: TCP
+              hostPort: 14250
+            - name: jaeger-thrift
+              containerPort: 14268
+              protocol: TCP
+              hostPort: 14268
+            - name: metrics
+              containerPort: 8888
+              protocol: TCP
+            - name: otlp
+              containerPort: 4317
+              protocol: TCP
+              hostPort: 4317
+            - name: otlp-http
+              containerPort: 4318
+              protocol: TCP
+              hostPort: 4318
+            - name: zipkin
+              containerPort: 9411
+              protocol: TCP
+              hostPort: 9411
+          env:
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: OTEL_K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: OTEL_K8S_NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: OTEL_K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: OTEL_K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: OTEL_K8S_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: GOMEMLIMIT
+              value: "409MiB"
+            - name: OTEL_K8S_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+            - name: OBSERVE_CLUSTER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  key: name
+                  name: cluster-name
+            - name: OBSERVE_CLUSTER_UID
+              valueFrom:
+                configMapKeyRef:
+                  key: id
+                  name: cluster-info
+            - name: K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: TOKEN
+              valueFrom:
+                secretKeyRef:
+                  key: OBSERVE_TOKEN
+                  name: agent-credentials
+                  optional: true
+            - name: TRACE_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  key: TRACE_TOKEN
+                  name: agent-credentials
+                  optional: true
+          livenessProbe:
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            httpGet:
+              path: /status
+              port: 13133
+          readinessProbe:
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            httpGet:
+              path: /status
+              port: 13133
+          resources:
+            limits:
+              memory: 512Mi
+            requests:
+              cpu: 300m
+              memory: 512Mi
+          volumeMounts:
+            - mountPath: /conf
+              name: forwarder-configmap
+            - mountPath: /observe-agent-conf
+              name: observe-agent-deployment-config
+      initContainers:
+        - env:
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          image: observeinc/kube-cluster-info:v0.11.6
+          imagePullPolicy: Always
+          name: kube-cluster-info
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - name: forwarder-configmap
+          configMap:
+            name: forwarder
+            items:
+              - key: relay
+                path: relay.yaml
+        - configMap:
+            defaultMode: 420
+            items:
+            - key: relay
+              path: observe-agent.yaml
+            name: observe-agent
+          name: observe-agent-deployment-config
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: observeinc.com/unschedulable
+                operator: DoesNotExist
+              - key: kubernetes.io/os
+                operator: NotIn
+                values:
+                - windows
+      hostNetwork: false
+      hostPID: false

--- a/charts/agent/examples/external-write-hashes/rendered/forwarder/daemonset.yaml
+++ b/charts/agent/examples/external-write-hashes/rendered/forwarder/daemonset.yaml
@@ -54,7 +54,7 @@ spec:
             - --feature-gates=+connector.spanmetrics.includeCollectorInstanceID
           securityContext:
             {}
-          image: "observeinc/observe-agent:2.16.0"
+          image: "observeinc/observe-agent:2.18.0"
           imagePullPolicy: IfNotPresent
           ports:
 

--- a/charts/agent/examples/external-write-hashes/rendered/forwarder/networkpolicy.yaml
+++ b/charts/agent/examples/external-write-hashes/rendered/forwarder/networkpolicy.yaml
@@ -1,0 +1,39 @@
+---
+# Source: agent/charts/forwarder/templates/networkpolicy.yaml
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: example-forwarder
+  namespace: observe
+  labels:
+    helm.sh/chart: forwarder-0.159.0
+    app.kubernetes.io/name: forwarder
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.154.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-collector
+    app.kubernetes.io/component: agent-collector
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: forwarder
+      app.kubernetes.io/instance: example
+      component: agent-collector
+  ingress:
+    - ports:
+        - port: 6831
+          protocol: UDP
+        - port: 14250
+          protocol: TCP
+        - port: 14268
+          protocol: TCP
+        - port: 8888
+          protocol: TCP
+        - port: 4317
+          protocol: TCP
+        - port: 4318
+          protocol: TCP
+        - port: 9411
+          protocol: TCP
+  egress:
+    - {}

--- a/charts/agent/examples/external-write-hashes/rendered/forwarder/service.yaml
+++ b/charts/agent/examples/external-write-hashes/rendered/forwarder/service.yaml
@@ -1,0 +1,54 @@
+---
+# Source: agent/charts/forwarder/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-forwarder
+  namespace: observe
+  labels:
+    helm.sh/chart: forwarder-0.159.0
+    app.kubernetes.io/name: forwarder
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.154.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-collector
+    app.kubernetes.io/component: agent-collector
+    component: agent-collector
+spec:
+  type: ClusterIP
+  ports:
+
+    - name: jaeger-compact
+      port: 6831
+      targetPort: 6831
+      protocol: UDP
+    - name: jaeger-grpc
+      port: 14250
+      targetPort: 14250
+      protocol: TCP
+    - name: jaeger-thrift
+      port: 14268
+      targetPort: 14268
+      protocol: TCP
+    - name: metrics
+      port: 8888
+      targetPort: 8888
+      protocol: TCP
+    - name: otlp
+      port: 4317
+      targetPort: 4317
+      protocol: TCP
+      appProtocol: grpc
+    - name: otlp-http
+      port: 4318
+      targetPort: 4318
+      protocol: TCP
+    - name: zipkin
+      port: 9411
+      targetPort: 9411
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: forwarder
+    app.kubernetes.io/instance: example
+    component: agent-collector
+  internalTrafficPolicy: Local

--- a/charts/agent/examples/external-write-hashes/rendered/monitor/deployment.yaml
+++ b/charts/agent/examples/external-write-hashes/rendered/monitor/deployment.yaml
@@ -1,0 +1,193 @@
+---
+# Source: agent/charts/monitor/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-monitor
+  namespace: observe
+  labels:
+    helm.sh/chart: monitor-0.159.0
+    app.kubernetes.io/name: monitor
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.154.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-collector
+    app.kubernetes.io/component: standalone-collector
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: monitor
+      app.kubernetes.io/instance: example
+      component: standalone-collector
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+        observe_monitor_path: /metrics
+        observe_monitor_port: "8888"
+        observe_monitor_purpose: observecollection
+        observe_monitor_scrape: "false"
+        observeinc_com_scrape: "false"
+      labels:
+        app.kubernetes.io/name: monitor
+        app.kubernetes.io/instance: example
+        component: standalone-collector
+
+    spec:
+
+      serviceAccountName: observe-agent-service-account
+      automountServiceAccountToken: true
+      securityContext:
+        {}
+      containers:
+        - name: monitor
+          command:
+            - /observe-agent
+          args:
+            - --config=/conf/relay.yaml
+            - start
+            - --observe-config=/observe-agent-conf/observe-agent.yaml
+            - --config=/conf/relay.yaml
+            - --feature-gates=+exporter.prometheusremotewritexporter.EnableMultipleWorkers
+          securityContext:
+            {}
+          image: "observeinc/observe-agent:2.16.0"
+          imagePullPolicy: IfNotPresent
+          ports:
+
+            - name: jaeger-compact
+              containerPort: 6831
+              protocol: UDP
+            - name: jaeger-grpc
+              containerPort: 14250
+              protocol: TCP
+            - name: jaeger-thrift
+              containerPort: 14268
+              protocol: TCP
+            - name: metrics
+              containerPort: 8888
+              protocol: TCP
+            - name: otlp
+              containerPort: 4317
+              protocol: TCP
+            - name: otlp-http
+              containerPort: 4318
+              protocol: TCP
+            - name: zipkin
+              containerPort: 9411
+              protocol: TCP
+          env:
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: OTEL_K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: OTEL_K8S_NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: OTEL_K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: OTEL_K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: OTEL_K8S_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: GOMEMLIMIT
+              value: "204MiB"
+            - name: OTEL_K8S_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+            - name: OBSERVE_CLUSTER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  key: name
+                  name: cluster-name
+            - name: OBSERVE_CLUSTER_UID
+              valueFrom:
+                configMapKeyRef:
+                  key: id
+                  name: cluster-info
+            - name: TOKEN
+              valueFrom:
+                secretKeyRef:
+                  key: OBSERVE_TOKEN
+                  name: agent-credentials
+                  optional: true
+          livenessProbe:
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            httpGet:
+              path: /status
+              port: 13133
+          readinessProbe:
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            httpGet:
+              path: /status
+              port: 13133
+          resources:
+            limits:
+              memory: 256Mi
+            requests:
+              cpu: 150m
+              memory: 256Mi
+          volumeMounts:
+            - mountPath: /conf
+              name: monitor-configmap
+            - mountPath: /observe-agent-conf
+              name: observe-agent-deployment-config
+      initContainers:
+        - env:
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          image: observeinc/kube-cluster-info:v0.11.6
+          imagePullPolicy: Always
+          name: kube-cluster-info
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - name: monitor-configmap
+          configMap:
+            name: monitor
+            items:
+              - key: relay
+                path: relay.yaml
+        - configMap:
+            defaultMode: 420
+            items:
+            - key: relay
+              path: observe-agent.yaml
+            name: observe-agent
+          name: observe-agent-deployment-config
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: observeinc.com/unschedulable
+                operator: DoesNotExist
+              - key: kubernetes.io/os
+                operator: NotIn
+                values:
+                - windows
+      hostNetwork: false
+      hostPID: false

--- a/charts/agent/examples/external-write-hashes/rendered/monitor/deployment.yaml
+++ b/charts/agent/examples/external-write-hashes/rendered/monitor/deployment.yaml
@@ -55,7 +55,7 @@ spec:
             - --feature-gates=+exporter.prometheusremotewritexporter.EnableMultipleWorkers
           securityContext:
             {}
-          image: "observeinc/observe-agent:2.16.0"
+          image: "observeinc/observe-agent:2.18.0"
           imagePullPolicy: IfNotPresent
           ports:
 

--- a/charts/agent/examples/external-write-hashes/rendered/monitor/networkpolicy.yaml
+++ b/charts/agent/examples/external-write-hashes/rendered/monitor/networkpolicy.yaml
@@ -1,0 +1,39 @@
+---
+# Source: agent/charts/monitor/templates/networkpolicy.yaml
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: example-monitor
+  namespace: observe
+  labels:
+    helm.sh/chart: monitor-0.159.0
+    app.kubernetes.io/name: monitor
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.154.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-collector
+    app.kubernetes.io/component: standalone-collector
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: monitor
+      app.kubernetes.io/instance: example
+      component: standalone-collector
+  ingress:
+    - ports:
+        - port: 6831
+          protocol: UDP
+        - port: 14250
+          protocol: TCP
+        - port: 14268
+          protocol: TCP
+        - port: 8888
+          protocol: TCP
+        - port: 4317
+          protocol: TCP
+        - port: 4318
+          protocol: TCP
+        - port: 9411
+          protocol: TCP
+  egress:
+    - {}

--- a/charts/agent/examples/external-write-hashes/rendered/monitor/service.yaml
+++ b/charts/agent/examples/external-write-hashes/rendered/monitor/service.yaml
@@ -1,0 +1,54 @@
+---
+# Source: agent/charts/monitor/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-monitor
+  namespace: observe
+  labels:
+    helm.sh/chart: monitor-0.159.0
+    app.kubernetes.io/name: monitor
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.154.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-collector
+    app.kubernetes.io/component: standalone-collector
+    component: standalone-collector
+spec:
+  type: ClusterIP
+  ports:
+
+    - name: jaeger-compact
+      port: 6831
+      targetPort: 6831
+      protocol: UDP
+    - name: jaeger-grpc
+      port: 14250
+      targetPort: 14250
+      protocol: TCP
+    - name: jaeger-thrift
+      port: 14268
+      targetPort: 14268
+      protocol: TCP
+    - name: metrics
+      port: 8888
+      targetPort: 8888
+      protocol: TCP
+    - name: otlp
+      port: 4317
+      targetPort: 4317
+      protocol: TCP
+      appProtocol: grpc
+    - name: otlp-http
+      port: 4318
+      targetPort: 4318
+      protocol: TCP
+    - name: zipkin
+      port: 9411
+      targetPort: 9411
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: monitor
+    app.kubernetes.io/instance: example
+    component: standalone-collector
+  internalTrafficPolicy: Cluster

--- a/charts/agent/examples/external-write-hashes/rendered/node-logs-metrics-configmap.yaml
+++ b/charts/agent/examples/external-write-hashes/rendered/node-logs-metrics-configmap.yaml
@@ -1,0 +1,315 @@
+---
+# Source: agent/templates/node-logs-metrics-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: node-logs-metrics
+  namespace: observe
+data:
+  relay: |
+      exporters:
+        debug/override:
+          sampling_initial: 2
+          sampling_thereafter: 1
+          verbosity: basic
+        otlphttp/observe/base:
+          compression: zstd
+          endpoint: ${env:OBSERVE_OTEL_ENDPOINT}
+          headers:
+            authorization: ${env:OBSERVE_AUTHORIZATION_HEADER}
+            x-observe-target-package: Kubernetes Explorer
+          retry_on_failure:
+            enabled: true
+            initial_interval: 1s
+            max_elapsed_time: 5m
+            max_interval: 30s
+          sending_queue:
+            enabled: true
+          timeout: 10s
+        prometheusremotewrite/observe:
+          endpoint: ${env:OBSERVE_PROMETHEUS_ENDPOINT}
+          headers:
+            authorization: ${env:OBSERVE_AUTHORIZATION_HEADER}
+            x-observe-target-package: Kubernetes Explorer
+          max_batch_request_parallelism: 5
+          remote_write_queue:
+            num_consumers: 5
+          resource_to_telemetry_conversion:
+            enabled: true
+          retry_on_failure:
+            enabled: true
+            initial_interval: 1s
+            max_elapsed_time: 5m
+            max_interval: 30s
+          send_metadata: true
+          target_info:
+            enabled: false
+          timeout: 10s
+      extensions:
+        file_storage:
+          create_directory: true
+      processors:
+        attributes/debug_source_hostmetrics:
+          actions:
+          - action: insert
+            key: debug_source
+            value: hostmetrics
+        attributes/debug_source_kubeletstats_metrics:
+          actions:
+          - action: insert
+            key: debug_source
+            value: kubeletstats_metrics
+        attributes/debug_source_pod_logs:
+          actions:
+          - action: insert
+            key: debug_source
+            value: pod_logs
+        batch:
+          send_batch_max_size: 4096
+          send_batch_size: 4096
+          timeout: 5s
+        k8sattributes:
+          extract:
+            labels:
+            - from: pod
+              key_regex: (app\.kubernetes\.io/.+)
+              tag_name: $1
+            metadata:
+            - k8s.namespace.name
+            - k8s.deployment.name
+            - k8s.replicaset.name
+            - k8s.statefulset.name
+            - k8s.daemonset.name
+            - k8s.cronjob.name
+            - k8s.job.name
+            - k8s.node.name
+            - k8s.node.uid
+            - k8s.pod.name
+            - k8s.pod.uid
+            - k8s.cluster.uid
+            - k8s.container.name
+            - container.id
+            - service.namespace
+            - service.name
+            - service.version
+            - service.instance.id
+            otel_annotations: true
+          passthrough: false
+          pod_association:
+          - sources:
+            - from: resource_attribute
+              name: k8s.pod.ip
+          - sources:
+            - from: resource_attribute
+              name: k8s.pod.uid
+          - sources:
+            - from: connection
+          wait_for_metadata: false
+          wait_for_metadata_timeout: 10s
+        memory_limiter:
+          check_interval: 5s
+          limit_percentage: 80
+          spike_limit_percentage: 15
+        metricstransform/duplicate_k8s_cpu_metrics:
+          transforms:
+          - action: insert
+            include: container.cpu.usage
+            new_name: container.cpu.utilization
+          - action: insert
+            include: k8s.pod.cpu.usage
+            new_name: k8s.pod.cpu.utilization
+          - action: insert
+            include: k8s.node.cpu.usage
+            new_name: k8s.node.cpu.utilization
+        resource/node_name:
+          attributes:
+          - action: upsert
+            key: k8s.node.name
+            value: ${env:K8S_NODE_NAME}
+        resource/observe_common:
+          attributes:
+          - action: upsert
+            key: k8s.cluster.name
+            value: ${env:OBSERVE_CLUSTER_NAME}
+          - action: upsert
+            key: k8s.cluster.uid
+            value: ${env:OBSERVE_CLUSTER_UID}
+        resourcedetection/cloud:
+          detectors:
+          - gcp
+          - ecs
+          - ec2
+          - azure
+          override: false
+          timeout: 2s
+        transform/metric_hashes:
+          error_mode: ignore
+          metric_statements:
+          - context: datapoint
+            statements:
+            - set(attributes["observe_labels_hash"], Substring(XXH128(Concat([ToKeyValueString(resource.attributes,
+              "=", ",", true), ToKeyValueString(attributes, "=", ",", true)], "|")), 0,
+              31))
+      receivers:
+        filelog:
+          exclude:
+          - '**/*.gz'
+          - '**/*.tmp'
+          exclude_older_than: 24h
+          include:
+          - /var/log/pods/*/*/*.log
+          - /var/log/pods/*/*/*.log.*
+          include_file_name: false
+          include_file_path: true
+          max_log_size: 1024kb
+          operators:
+          - id: container-parser
+            max_log_size: 102400
+            type: container
+          poll_interval: 20ms
+          retry_on_failure:
+            enabled: true
+            initial_interval: 1s
+            max_elapsed_time: 5m
+            max_interval: 30s
+          start_at: end
+          storage: file_storage
+        hostmetrics:
+          collection_interval: 60s
+          root_path: /hostfs
+          scrapers:
+            cpu: null
+            disk: null
+            filesystem:
+              exclude_fs_types:
+                fs_types:
+                - autofs
+                - binfmt_misc
+                - bpf
+                - cgroup2
+                - configfs
+                - debugfs
+                - devpts
+                - devtmpfs
+                - fusectl
+                - hugetlbfs
+                - iso9660
+                - mqueue
+                - nsfs
+                - overlay
+                - proc
+                - procfs
+                - pstore
+                - rpc_pipefs
+                - securityfs
+                - selinuxfs
+                - squashfs
+                - sysfs
+                - tracefs
+                match_type: strict
+              exclude_mount_points:
+                match_type: regexp
+                mount_points:
+                - /dev/*
+                - /proc/*
+                - /sys/*
+                - /run/k3s/containerd/*
+                - /var/lib/docker/*
+                - /var/lib/kubelet/*
+                - /snap/*
+            load: null
+            memory: null
+            network: null
+        kubeletstats:
+          auth_type: serviceAccount
+          collection_interval: 60s
+          endpoint: ${env:K8S_NODE_NAME}:10250
+          extra_metadata_labels:
+          - container.id
+          insecure_skip_verify: true
+          k8s_api_config:
+            auth_type: serviceAccount
+          metric_groups:
+          - node
+          - pod
+          - container
+          metrics:
+            container.cpu.usage:
+              enabled: true
+            container.uptime:
+              enabled: true
+            k8s.container.cpu.node.utilization:
+              enabled: true
+            k8s.container.cpu_limit_utilization:
+              enabled: true
+            k8s.container.cpu_request_utilization:
+              enabled: true
+            k8s.container.memory.node.utilization:
+              enabled: true
+            k8s.container.memory_limit_utilization:
+              enabled: true
+            k8s.container.memory_request_utilization:
+              enabled: true
+            k8s.node.cpu.usage:
+              enabled: true
+            k8s.node.uptime:
+              enabled: true
+            k8s.pod.cpu.node.utilization:
+              enabled: true
+            k8s.pod.cpu.usage:
+              enabled: true
+            k8s.pod.cpu_limit_utilization:
+              enabled: true
+            k8s.pod.cpu_request_utilization:
+              enabled: true
+            k8s.pod.memory.node.utilization:
+              enabled: true
+            k8s.pod.memory_limit_utilization:
+              enabled: true
+            k8s.pod.memory_request_utilization:
+              enabled: true
+            k8s.pod.uptime:
+              enabled: true
+          node: ${env:K8S_NODE_NAME}
+      service:
+        pipelines:
+          logs:
+            exporters:
+            - otlphttp/observe/base
+            processors:
+            - memory_limiter
+            - k8sattributes
+            - batch
+            - resourcedetection/cloud
+            - resource/observe_common
+            - attributes/debug_source_pod_logs
+            receivers:
+            - filelog
+          metrics/hostmetrics:
+            exporters:
+            - prometheusremotewrite/observe
+            processors:
+            - memory_limiter
+            - k8sattributes
+            - batch
+            - resourcedetection/cloud
+            - resource/node_name
+            - resource/observe_common
+            - attributes/debug_source_hostmetrics
+            - transform/metric_hashes
+            receivers:
+            - hostmetrics
+          metrics/kubeletstats:
+            exporters:
+            - prometheusremotewrite/observe
+            processors:
+            - memory_limiter
+            - metricstransform/duplicate_k8s_cpu_metrics
+            - k8sattributes
+            - batch
+            - resourcedetection/cloud
+            - resource/observe_common
+            - attributes/debug_source_kubeletstats_metrics
+            - transform/metric_hashes
+            receivers:
+            - kubeletstats

--- a/charts/agent/examples/external-write-hashes/rendered/node-logs-metrics-configmap.yaml
+++ b/charts/agent/examples/external-write-hashes/rendered/node-logs-metrics-configmap.yaml
@@ -147,9 +147,10 @@ data:
           metric_statements:
           - context: datapoint
             statements:
-            - set(attributes["observe_labels_hash"], Substring(XXH128(Concat([ToKeyValueString(resource.attributes,
-              "=", ",", true), ToKeyValueString(attributes, "=", ",", true)], "|")), 0,
-              31))
+            - merge_maps(cache, attributes, "upsert")
+            - merge_maps(cache, resource.attributes, "upsert")
+            - set(attributes["observe_labels_hash"], Substring(XXH128(ToKeyValueString(cache,
+              "=", ",", true)), 0, 31))
       receivers:
         filelog:
           exclude:

--- a/charts/agent/examples/external-write-hashes/rendered/node-logs-metrics/daemonset.yaml
+++ b/charts/agent/examples/external-write-hashes/rendered/node-logs-metrics/daemonset.yaml
@@ -55,7 +55,7 @@ spec:
           securityContext:
             runAsGroup: 0
             runAsUser: 0
-          image: "observeinc/observe-agent:2.16.0"
+          image: "observeinc/observe-agent:2.18.0"
           imagePullPolicy: IfNotPresent
           ports:
 

--- a/charts/agent/examples/external-write-hashes/rendered/node-logs-metrics/daemonset.yaml
+++ b/charts/agent/examples/external-write-hashes/rendered/node-logs-metrics/daemonset.yaml
@@ -1,0 +1,214 @@
+---
+# Source: agent/charts/node-logs-metrics/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: example-node-logs-metrics-agent
+  namespace: observe
+  labels:
+    helm.sh/chart: node-logs-metrics-0.159.0
+    app.kubernetes.io/name: node-logs-metrics
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.154.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-collector
+    app.kubernetes.io/component: agent-collector
+spec:
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: node-logs-metrics
+      app.kubernetes.io/instance: example
+      component: agent-collector
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+        observe_monitor_path: /metrics
+        observe_monitor_port: "8888"
+        observe_monitor_purpose: observecollection
+        observe_monitor_scrape: "true"
+        observeinc_com_scrape: "false"
+      labels:
+        app.kubernetes.io/name: node-logs-metrics
+        app.kubernetes.io/instance: example
+        component: agent-collector
+
+    spec:
+
+      serviceAccountName: observe-agent-service-account
+      automountServiceAccountToken: true
+      securityContext:
+        {}
+      containers:
+        - name: node-logs-metrics
+          command:
+            - /observe-agent
+          args:
+            - --config=/conf/relay.yaml
+            - start
+            - --observe-config=/observe-agent-conf/observe-agent.yaml
+            - --config=/conf/relay.yaml
+            - --feature-gates=+exporter.prometheusremotewritexporter.EnableMultipleWorkers
+          securityContext:
+            runAsGroup: 0
+            runAsUser: 0
+          image: "observeinc/observe-agent:2.16.0"
+          imagePullPolicy: IfNotPresent
+          ports:
+
+            - name: metrics
+              containerPort: 8888
+              protocol: TCP
+          env:
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: OTEL_K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: OTEL_K8S_NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: OTEL_K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: OTEL_K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: OTEL_K8S_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: GOMEMLIMIT
+              value: "409MiB"
+            - name: OTEL_K8S_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+            - name: OBSERVE_CLUSTER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  key: name
+                  name: cluster-name
+            - name: OBSERVE_CLUSTER_UID
+              valueFrom:
+                configMapKeyRef:
+                  key: id
+                  name: cluster-info
+            - name: K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: K8S_NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: TOKEN
+              valueFrom:
+                secretKeyRef:
+                  key: OBSERVE_TOKEN
+                  name: agent-credentials
+                  optional: true
+            - name: TRACES_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  key: TRACES_TOKEN
+                  name: agent-credentials
+                  optional: true
+          livenessProbe:
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            httpGet:
+              path: /status
+              port: 13133
+          readinessProbe:
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            httpGet:
+              path: /status
+              port: 13133
+          resources:
+            limits:
+              memory: 512Mi
+            requests:
+              cpu: 250m
+              memory: 512Mi
+          volumeMounts:
+            - mountPath: /conf
+              name: node-logs-metrics-configmap
+            - mountPath: /observe-agent-conf
+              name: observe-agent-deployment-config
+            - mountPath: /var/log/pods
+              name: varlogpods
+              readOnly: true
+            - mountPath: /var/lib/docker/containers
+              name: varlibdockercontainers
+              readOnly: true
+            - mountPath: /var/lib/otelcol
+              name: varlibotelcol
+            - mountPath: /hostfs
+              mountPropagation: HostToContainer
+              name: hostfs
+              readOnly: true
+      initContainers:
+        - env:
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          image: observeinc/kube-cluster-info:v0.11.6
+          imagePullPolicy: Always
+          name: kube-cluster-info
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - name: node-logs-metrics-configmap
+          configMap:
+            name: node-logs-metrics
+            items:
+              - key: relay
+                path: relay.yaml
+        - configMap:
+            defaultMode: 420
+            items:
+            - key: relay
+              path: observe-agent.yaml
+            name: observe-agent
+          name: observe-agent-deployment-config
+        - hostPath:
+            path: /var/log/pods
+          name: varlogpods
+        - hostPath:
+            path: /var/lib/docker/containers
+          name: varlibdockercontainers
+        - hostPath:
+            path: /var/lib/otelcol
+            type: DirectoryOrCreate
+          name: varlibotelcol
+        - hostPath:
+            path: /
+          name: hostfs
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: observeinc.com/unschedulable
+                operator: DoesNotExist
+              - key: kubernetes.io/os
+                operator: NotIn
+                values:
+                - windows
+      hostNetwork: false
+      hostPID: false

--- a/charts/agent/examples/external-write-hashes/rendered/observe-agent-configmap.yaml
+++ b/charts/agent/examples/external-write-hashes/rendered/observe-agent-configmap.yaml
@@ -1,0 +1,42 @@
+---
+# Source: agent/templates/observe-agent-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: observe-agent
+  namespace: observe
+data:
+  relay: |
+    observe_url:
+    token:
+
+    debug: false
+
+    health_check:
+      enabled: true
+      endpoint: "${env:MY_POD_IP}:13133"
+      path: "/status"
+
+    internal_telemetry:
+      enabled: true
+      metrics:
+        enabled: true
+        host: "${env:MY_POD_IP}"
+        port: 8888
+        level: normal
+      logs:
+        enabled: true
+        level: WARN
+        encoding: console
+
+
+    forwarding:
+      enabled: false
+
+    self_monitoring:
+      enabled: false
+      fleet:
+        enabled: false
+
+    host_monitoring:
+      enabled: false

--- a/charts/agent/examples/external-write-hashes/rendered/prometheus-scraper-configmap.yaml
+++ b/charts/agent/examples/external-write-hashes/rendered/prometheus-scraper-configmap.yaml
@@ -1,0 +1,220 @@
+---
+# Source: agent/templates/prometheus-scraper-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-scraper
+  namespace: observe
+data:
+  relay: |
+      exporters:
+        debug/override:
+          sampling_initial: 2
+          sampling_thereafter: 1
+          verbosity: basic
+        prometheusremotewrite/observe:
+          endpoint: ${env:OBSERVE_PROMETHEUS_ENDPOINT}
+          headers:
+            authorization: ${env:OBSERVE_AUTHORIZATION_HEADER}
+            x-observe-target-package: Kubernetes Explorer
+          max_batch_request_parallelism: 5
+          remote_write_queue:
+            num_consumers: 5
+          resource_to_telemetry_conversion:
+            enabled: true
+          retry_on_failure:
+            enabled: true
+            initial_interval: 1s
+            max_elapsed_time: 5m
+            max_interval: 30s
+          send_metadata: true
+          target_info:
+            enabled: false
+          timeout: 10s
+      processors:
+        attributes/debug_source_pod_metrics:
+          actions:
+          - action: insert
+            key: debug_source
+            value: pod_metrics
+        batch:
+          send_batch_max_size: 4096
+          send_batch_size: 4096
+          timeout: 5s
+        k8sattributes:
+          extract:
+            labels:
+            - from: pod
+              key_regex: (app\.kubernetes\.io/.+)
+              tag_name: $1
+            metadata:
+            - k8s.namespace.name
+            - k8s.deployment.name
+            - k8s.replicaset.name
+            - k8s.statefulset.name
+            - k8s.daemonset.name
+            - k8s.cronjob.name
+            - k8s.job.name
+            - k8s.node.name
+            - k8s.node.uid
+            - k8s.pod.name
+            - k8s.pod.uid
+            - k8s.cluster.uid
+            - k8s.container.name
+            - container.id
+            - service.namespace
+            - service.name
+            - service.version
+            - service.instance.id
+            otel_annotations: true
+          passthrough: false
+          pod_association:
+          - sources:
+            - from: resource_attribute
+              name: k8s.pod.ip
+          - sources:
+            - from: resource_attribute
+              name: k8s.pod.uid
+          - sources:
+            - from: connection
+          wait_for_metadata: false
+          wait_for_metadata_timeout: 10s
+        memory_limiter:
+          check_interval: 5s
+          limit_percentage: 80
+          spike_limit_percentage: 15
+        resource/drop_service_name:
+          attributes:
+          - action: delete
+            key: service.name
+        resource/observe_common:
+          attributes:
+          - action: upsert
+            key: k8s.cluster.name
+            value: ${env:OBSERVE_CLUSTER_NAME}
+          - action: upsert
+            key: k8s.cluster.uid
+            value: ${env:OBSERVE_CLUSTER_UID}
+        transform/deployment_environment_compatability:
+          error_mode: ignore
+          log_statements:
+          - set(resource.attributes["deployment.environment.name"], Coalesce([resource.attributes["deployment.environment.name"],
+            resource.attributes["deployment.environment"]]))
+          - set(resource.attributes["deployment.environment"], Coalesce([resource.attributes["deployment.environment"],
+            resource.attributes["deployment.environment.name"]]))
+          metric_statements:
+          - set(resource.attributes["deployment.environment.name"], Coalesce([resource.attributes["deployment.environment.name"],
+            resource.attributes["deployment.environment"]]))
+          - set(resource.attributes["deployment.environment"], Coalesce([resource.attributes["deployment.environment"],
+            resource.attributes["deployment.environment.name"]]))
+          trace_statements:
+          - set(resource.attributes["deployment.environment.name"], Coalesce([resource.attributes["deployment.environment.name"],
+            resource.attributes["deployment.environment"]]))
+          - set(resource.attributes["deployment.environment"], Coalesce([resource.attributes["deployment.environment"],
+            resource.attributes["deployment.environment.name"]]))
+        transform/metric_hashes:
+          error_mode: ignore
+          metric_statements:
+          - context: datapoint
+            statements:
+            - set(attributes["observe_labels_hash"], Substring(XXH128(Concat([ToKeyValueString(resource.attributes,
+              "=", ",", true), ToKeyValueString(attributes, "=", ",", true)], "|")), 0,
+              31))
+      receivers:
+        prometheus/pod_metrics:
+          config:
+            scrape_configs:
+            - honor_labels: true
+              job_name: pod-metrics
+              kubernetes_sd_configs:
+              - role: pod
+              metric_relabel_configs:
+              - action: keep
+                regex: (.*)
+                source_labels:
+                - __name__
+              relabel_configs:
+              - action: keep
+              - action: drop
+                regex: (.*istio.*|.*ingress.*|kube-system)
+                source_labels:
+                - __meta_kubernetes_namespace
+              - action: keep
+                regex: (.*)
+                source_labels:
+                - __meta_kubernetes_namespace
+              - action: keep
+                regex: (.*metrics;|.*;\d+)
+                source_labels:
+                - __meta_kubernetes_pod_container_port_name
+                - __meta_kubernetes_pod_annotation_prometheus_io_port
+              - action: drop
+                regex: Succeeded|Failed
+                source_labels:
+                - __meta_kubernetes_pod_phase
+              - action: drop
+                regex: "false"
+                source_labels:
+                - __meta_kubernetes_pod_annotation_observeinc_com_scrape
+              - action: drop
+                regex: "false"
+                source_labels:
+                - __meta_kubernetes_pod_annotation_prometheus_io_scrape
+              - action: replace
+                regex: (https?)
+                replacement: $1
+                source_labels:
+                - __meta_kubernetes_pod_annotation_prometheus_io_scheme
+                target_label: __scheme__
+              - action: replace
+                regex: (.+)
+                replacement: $1
+                source_labels:
+                - __meta_kubernetes_pod_annotation_prometheus_io_path
+                target_label: __metrics_path__
+              - action: replace
+                regex: (.+?)(\:\d+)?;(\d+)
+                replacement: $1:$3
+                source_labels:
+                - __address__
+                - __meta_kubernetes_pod_annotation_prometheus_io_port
+                target_label: __address__
+              - action: replace
+                regex: (.+)
+                source_labels:
+                - __meta_kubernetes_pod_annotation_observeinc_com_path
+                target_label: __metrics_path__
+              - action: replace
+                regex: ([^:]+)(?::\d+)?;(\d+)
+                replacement: $1:$2
+                source_labels:
+                - __address__
+                - __meta_kubernetes_pod_annotation_observeinc_com_port
+                target_label: __address__
+              - action: labelmap
+                regex: __meta_kubernetes_pod_label_(.+)
+              - action: replace
+                source_labels:
+                - __meta_kubernetes_namespace
+                target_label: kubernetes_namespace
+              - action: replace
+                source_labels:
+                - __meta_kubernetes_pod_name
+                target_label: kubernetes_pod_name
+              scrape_interval: 60s
+      service:
+        pipelines:
+          metrics/pod_metrics:
+            exporters:
+            - prometheusremotewrite/observe
+            processors:
+            - memory_limiter
+            - resource/drop_service_name
+            - k8sattributes
+            - batch
+            - resource/observe_common
+            - transform/deployment_environment_compatability
+            - attributes/debug_source_pod_metrics
+            - transform/metric_hashes
+            receivers:
+            - prometheus/pod_metrics

--- a/charts/agent/examples/external-write-hashes/rendered/prometheus-scraper-configmap.yaml
+++ b/charts/agent/examples/external-write-hashes/rendered/prometheus-scraper-configmap.yaml
@@ -117,9 +117,10 @@ data:
           metric_statements:
           - context: datapoint
             statements:
-            - set(attributes["observe_labels_hash"], Substring(XXH128(Concat([ToKeyValueString(resource.attributes,
-              "=", ",", true), ToKeyValueString(attributes, "=", ",", true)], "|")), 0,
-              31))
+            - merge_maps(cache, attributes, "upsert")
+            - merge_maps(cache, resource.attributes, "upsert")
+            - set(attributes["observe_labels_hash"], Substring(XXH128(ToKeyValueString(cache,
+              "=", ",", true)), 0, 31))
       receivers:
         prometheus/pod_metrics:
           config:

--- a/charts/agent/examples/external-write-hashes/rendered/prometheus-scraper-configmap.yaml
+++ b/charts/agent/examples/external-write-hashes/rendered/prometheus-scraper-configmap.yaml
@@ -202,6 +202,7 @@ data:
                 - __meta_kubernetes_pod_name
                 target_label: kubernetes_pod_name
               scrape_interval: 60s
+              scrape_timeout: 10s
       service:
         pipelines:
           metrics/pod_metrics:

--- a/charts/agent/examples/external-write-hashes/rendered/prometheus-scraper/deployment.yaml
+++ b/charts/agent/examples/external-write-hashes/rendered/prometheus-scraper/deployment.yaml
@@ -1,0 +1,193 @@
+---
+# Source: agent/charts/prometheus-scraper/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-prometheus-scraper
+  namespace: observe
+  labels:
+    helm.sh/chart: prometheus-scraper-0.159.0
+    app.kubernetes.io/name: prometheus-scraper
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.154.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-collector
+    app.kubernetes.io/component: standalone-collector
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus-scraper
+      app.kubernetes.io/instance: example
+      component: standalone-collector
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+        observe_monitor_path: /metrics
+        observe_monitor_port: "8888"
+        observe_monitor_purpose: observecollection
+        observe_monitor_scrape: "true"
+        observeinc_com_scrape: "false"
+      labels:
+        app.kubernetes.io/name: prometheus-scraper
+        app.kubernetes.io/instance: example
+        component: standalone-collector
+
+    spec:
+
+      serviceAccountName: observe-agent-service-account
+      automountServiceAccountToken: true
+      securityContext:
+        {}
+      containers:
+        - name: prometheus-scraper
+          command:
+            - /observe-agent
+          args:
+            - --config=/conf/relay.yaml
+            - start
+            - --observe-config=/observe-agent-conf/observe-agent.yaml
+            - --config=/conf/relay.yaml
+            - --feature-gates=+exporter.prometheusremotewritexporter.EnableMultipleWorkers
+          securityContext:
+            {}
+          image: "observeinc/observe-agent:2.16.0"
+          imagePullPolicy: IfNotPresent
+          ports:
+
+            - name: jaeger-compact
+              containerPort: 6831
+              protocol: UDP
+            - name: jaeger-grpc
+              containerPort: 14250
+              protocol: TCP
+            - name: jaeger-thrift
+              containerPort: 14268
+              protocol: TCP
+            - name: metrics
+              containerPort: 8888
+              protocol: TCP
+            - name: otlp
+              containerPort: 4317
+              protocol: TCP
+            - name: otlp-http
+              containerPort: 4318
+              protocol: TCP
+            - name: zipkin
+              containerPort: 9411
+              protocol: TCP
+          env:
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: OTEL_K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: OTEL_K8S_NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: OTEL_K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: OTEL_K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: OTEL_K8S_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: GOMEMLIMIT
+              value: "409MiB"
+            - name: OTEL_K8S_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+            - name: OBSERVE_CLUSTER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  key: name
+                  name: cluster-name
+            - name: OBSERVE_CLUSTER_UID
+              valueFrom:
+                configMapKeyRef:
+                  key: id
+                  name: cluster-info
+            - name: TOKEN
+              valueFrom:
+                secretKeyRef:
+                  key: OBSERVE_TOKEN
+                  name: agent-credentials
+                  optional: true
+          livenessProbe:
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            httpGet:
+              path: /status
+              port: 13133
+          readinessProbe:
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            httpGet:
+              path: /status
+              port: 13133
+          resources:
+            limits:
+              memory: 512Mi
+            requests:
+              cpu: 250m
+              memory: 512Mi
+          volumeMounts:
+            - mountPath: /conf
+              name: prometheus-scraper-configmap
+            - mountPath: /observe-agent-conf
+              name: observe-agent-deployment-config
+      initContainers:
+        - env:
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          image: observeinc/kube-cluster-info:v0.11.6
+          imagePullPolicy: Always
+          name: kube-cluster-info
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - name: prometheus-scraper-configmap
+          configMap:
+            name: prometheus-scraper
+            items:
+              - key: relay
+                path: relay.yaml
+        - configMap:
+            defaultMode: 420
+            items:
+            - key: relay
+              path: observe-agent.yaml
+            name: observe-agent
+          name: observe-agent-deployment-config
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: observeinc.com/unschedulable
+                operator: DoesNotExist
+              - key: kubernetes.io/os
+                operator: NotIn
+                values:
+                - windows
+      hostNetwork: false
+      hostPID: false

--- a/charts/agent/examples/external-write-hashes/rendered/prometheus-scraper/deployment.yaml
+++ b/charts/agent/examples/external-write-hashes/rendered/prometheus-scraper/deployment.yaml
@@ -55,7 +55,7 @@ spec:
             - --feature-gates=+exporter.prometheusremotewritexporter.EnableMultipleWorkers
           securityContext:
             {}
-          image: "observeinc/observe-agent:2.16.0"
+          image: "observeinc/observe-agent:2.18.0"
           imagePullPolicy: IfNotPresent
           ports:
 

--- a/charts/agent/examples/external-write-hashes/rendered/prometheus-scraper/networkpolicy.yaml
+++ b/charts/agent/examples/external-write-hashes/rendered/prometheus-scraper/networkpolicy.yaml
@@ -1,0 +1,39 @@
+---
+# Source: agent/charts/prometheus-scraper/templates/networkpolicy.yaml
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: example-prometheus-scraper
+  namespace: observe
+  labels:
+    helm.sh/chart: prometheus-scraper-0.159.0
+    app.kubernetes.io/name: prometheus-scraper
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.154.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-collector
+    app.kubernetes.io/component: standalone-collector
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus-scraper
+      app.kubernetes.io/instance: example
+      component: standalone-collector
+  ingress:
+    - ports:
+        - port: 6831
+          protocol: UDP
+        - port: 14250
+          protocol: TCP
+        - port: 14268
+          protocol: TCP
+        - port: 8888
+          protocol: TCP
+        - port: 4317
+          protocol: TCP
+        - port: 4318
+          protocol: TCP
+        - port: 9411
+          protocol: TCP
+  egress:
+    - {}

--- a/charts/agent/examples/external-write-hashes/rendered/prometheus-scraper/service.yaml
+++ b/charts/agent/examples/external-write-hashes/rendered/prometheus-scraper/service.yaml
@@ -1,0 +1,54 @@
+---
+# Source: agent/charts/prometheus-scraper/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-prometheus-scraper
+  namespace: observe
+  labels:
+    helm.sh/chart: prometheus-scraper-0.159.0
+    app.kubernetes.io/name: prometheus-scraper
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.154.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-collector
+    app.kubernetes.io/component: standalone-collector
+    component: standalone-collector
+spec:
+  type: ClusterIP
+  ports:
+
+    - name: jaeger-compact
+      port: 6831
+      targetPort: 6831
+      protocol: UDP
+    - name: jaeger-grpc
+      port: 14250
+      targetPort: 14250
+      protocol: TCP
+    - name: jaeger-thrift
+      port: 14268
+      targetPort: 14268
+      protocol: TCP
+    - name: metrics
+      port: 8888
+      targetPort: 8888
+      protocol: TCP
+    - name: otlp
+      port: 4317
+      targetPort: 4317
+      protocol: TCP
+      appProtocol: grpc
+    - name: otlp-http
+      port: 4318
+      targetPort: 4318
+      protocol: TCP
+    - name: zipkin
+      port: 9411
+      targetPort: 9411
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: prometheus-scraper
+    app.kubernetes.io/instance: example
+    component: standalone-collector
+  internalTrafficPolicy: Cluster

--- a/charts/agent/examples/external-write-hashes/rendered/secret.yaml
+++ b/charts/agent/examples/external-write-hashes/rendered/secret.yaml
@@ -1,0 +1,9 @@
+---
+# Source: agent/templates/secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: agent-credentials
+type: Opaque
+data:
+  OBSERVE_TOKEN: ""

--- a/charts/agent/examples/external-write-hashes/rendered/serviceaccount.yaml
+++ b/charts/agent/examples/external-write-hashes/rendered/serviceaccount.yaml
@@ -1,0 +1,7 @@
+---
+# Source: agent/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: observe-agent-service-account
+  namespace: observe

--- a/charts/agent/examples/external-write-hashes/values.yaml
+++ b/charts/agent/examples/external-write-hashes/values.yaml
@@ -1,0 +1,32 @@
+# Enable the hash processors for external-write Iceberg source tables.
+#
+# See charts/agent/templates/_config-processors.tpl for what these processors
+# compute and where they get wired.
+#
+# The flag appends `transform/identifiers_hash` to the K8s objects pipeline in
+# cluster-events, and `transform/metric_hashes` to every pipeline that exports
+# to `prometheusremotewrite/observe`.
+observe:
+  token:
+    create: true
+
+application:
+  prometheusScrape:
+    enabled: true
+    independentDeployment: true
+  REDMetrics:
+    enabled: true
+
+agent:
+  config:
+    global:
+      externalWriteHashes:
+        enabled: true
+
+node:
+  forwarder:
+    enabled: true
+    traces:
+      maxSpanDuration: 1h
+    metrics:
+      outputFormat: prometheus

--- a/charts/agent/templates/_cluster-events-config.tpl
+++ b/charts/agent/templates/_cluster-events-config.tpl
@@ -92,6 +92,10 @@ processors:
 
 {{- include "config.processors.attributes.observek8sattributes" . | nindent 2 }}
 
+{{- if .Values.agent.config.global.externalWriteHashes.enabled }}
+{{- include "config.processors.transform.observe_identifiers_hash" . | nindent 2 }}
+{{- end }}
+
 {{- if .Values.agent.config.global.fleet.enabled }}
 {{- include "config.processors.attributes.k8sattributes" . | nindent 2 }}
 {{- include "config.processors.resource_detection" . | nindent 2 }}
@@ -474,6 +478,9 @@ service:
           - transform/unify
           - observek8sattributes
           - transform/object
+          {{- if .Values.agent.config.global.externalWriteHashes.enabled }}
+          - transform/identifiers_hash
+          {{- end }}
         exporters: [{{ join ", " $objectsExporters }}]
       logs/cluster:
         receivers: [k8sobjects/cluster]

--- a/charts/agent/templates/_cluster-metrics-config.tpl
+++ b/charts/agent/templates/_cluster-metrics-config.tpl
@@ -68,6 +68,10 @@ processors:
 {{- include "config.processors.transform.k8sheartbeat" . | nindent 2 }}
 {{- end }}
 
+{{- if .Values.agent.config.global.externalWriteHashes.enabled }}
+{{- include "config.processors.transform.observe_metric_hashes" . | nindent 2 }}
+{{- end }}
+
   # attributes to append to objects
   attributes/debug_source_cluster_metrics:
     actions:
@@ -94,6 +98,9 @@ service:
         - resource/observe_common
         - resource/drop_container_info
         - attributes/debug_source_cluster_metrics
+        {{- if .Values.agent.config.global.externalWriteHashes.enabled }}
+        - transform/metric_hashes
+        {{- end }}
       exporters: [{{ join ", " $metricsExporters }}]
     {{- if $podMetrics }}
     {{- include "config.pipelines.prometheus_scrapers" . | nindent 4 }}

--- a/charts/agent/templates/_config-pipelines.tpl
+++ b/charts/agent/templates/_config-pipelines.tpl
@@ -125,6 +125,9 @@ metrics/k8s_metrics:
     - batch
     {{- end }}
     - resource/observe_common
+    {{- if .Values.agent.config.global.externalWriteHashes.enabled }}
+    - transform/metric_hashes
+    {{- end }}
   exporters:
     - prometheusremotewrite/observe
     {{- if eq .Values.agent.config.global.debug.enabled true }}
@@ -148,6 +151,9 @@ metrics/pod_metrics:
     - transform/deployment_environment_compatability
     {{- end }}
     - attributes/debug_source_pod_metrics
+    {{- if .Values.agent.config.global.externalWriteHashes.enabled }}
+    - transform/metric_hashes
+    {{- end }}
   exporters:
     - prometheusremotewrite/observe
     {{- if eq .Values.agent.config.global.debug.enabled true }}
@@ -165,6 +171,9 @@ metrics/cadvisor:
     {{- end }}
     - resource/observe_common
     - attributes/debug_source_cadvisor_metrics
+    {{- if .Values.agent.config.global.externalWriteHashes.enabled }}
+    - transform/metric_hashes
+    {{- end }}
   exporters:
     - prometheusremotewrite/observe
     {{- if eq .Values.agent.config.global.debug.enabled true }}

--- a/charts/agent/templates/_config-processors.tpl
+++ b/charts/agent/templates/_config-processors.tpl
@@ -509,5 +509,8 @@ transform/metric_hashes:
   metric_statements:
     - context: datapoint
       statements:
-        - set(attributes["observe_labels_hash"], Substring(XXH128(Concat([ToKeyValueString(resource.attributes, "=", ",", true), ToKeyValueString(attributes, "=", ",", true)], "|")), 0, 31))
+        # resource attrs override datapoint attrs due to ordering (matches prometheusremotewrite resource_to_telemetry_conversion)
+        - merge_maps(cache, attributes, "upsert")
+        - merge_maps(cache, resource.attributes, "upsert")
+        - set(attributes["observe_labels_hash"], Substring(XXH128(ToKeyValueString(cache, "=", ",", true)), 0, 31))
 {{- end -}}

--- a/charts/agent/templates/_config-processors.tpl
+++ b/charts/agent/templates/_config-processors.tpl
@@ -469,3 +469,92 @@ Parameters (passed via dict):
       action: update
       new_name: traces.span.metrics.duration.{{ $suffix }}
 {{- end -}}
+
+{{- /*
+Hash processors for EXTERNAL-WRITE Iceberg source tables.
+
+Observe's source tables carry hidden hash columns that the ingest transformer
+normally computes: _observe_hash126_11identifiers on a k8sEntity table and
+_observe_hash126_6labels on a prometheus table. The query optimizer SUBSTITUTES
+`group by <object>` with the stored hash rather than recomputing it, so the
+column must be populated for that optimization to be correct.
+
+A writer that appends to such a table directly -- bypassing ingest -- therefore
+has to supply those hashes itself, and the collector is the only place that sees
+the data before it is written. Neither processor is needed on the normal ingest
+path, where the transformer fills the columns.
+
+Neither is wired into any pipeline by this chart. Add the one you need to the
+relevant pipeline's `processors` list through an agent.config.<workload>
+override, and note the ordering constraints on each below.
+
+The hash need not match Observe's own algorithm; the optimizer trusts whatever
+is stored. It must only be a deterministic function of the same input, and the
+dataset must never mix external and internal writes -- two rows with equal
+identifiers would otherwise carry different hashes and silently fail to group.
+
+Values are 31 hex digits (124 bits) rather than the full 32. The column is
+decimal(38,0), max ~1.0e38, while a full XXH128 reaches ~3.4e38, so roughly
+two thirds of digests would overflow it. The consumer converts hex to decimal.
+*/ -}}
+
+{{- /*
+_observe_hash126_11identifiers, for a k8sEntity source table.
+
+MUST be placed LAST in the pipeline. observek8sattributes and transform/object
+are what populate observe_transform.identifiers, so hashing any earlier digests
+an empty or partial map.
+
+ToKeyValueString's 4th argument sorts the keys, which is what makes this
+deterministic: identifiers is a map and map order is not stable across records
+or agent versions. It serializes keys AND values, so two entities of the same
+kind hash differently -- hashing sorted keys alone would collapse every Pod onto
+one hash.
+
+Emitted as a sibling attribute, deliberately NOT inside
+observe_transform.identifiers: writing it there would mutate the very map being
+hashed, and would also leak the hash into the identifiers column.
+*/ -}}
+{{- define "config.processors.transform.observe_identifiers_hash" -}}
+transform/identifiers_hash:
+  error_mode: ignore
+  log_statements:
+    - context: log
+      statements:
+        - set(attributes["observe_identifiers_hash"], Substring(XXH128(ToKeyValueString(attributes["observe_transform"]["identifiers"], "=", ",", true)), 0, 31))
+{{- end -}}
+
+{{- /*
+_observe_hash126_6labels, for a prometheus source table.
+
+Ordering is load-bearing twice over:
+
+  1. This must be the ONLY datapoint attribute the pipeline sets after it. The
+     prometheusremotewrite exporter turns datapoint attributes into labels, so
+     any attribute set afterwards lands inside the very label map this hash
+     describes, desynchronizing the two.
+
+  2. It must cover resource attributes as well as datapoint attributes, because
+     the exporter's resource_to_telemetry_conversion folds resource attributes
+     into labels AFTER this processor runs. Hashing datapoint attributes alone
+     would give two series differing only by k8s.pod.name the same hash, and
+     `group by labels` would wrongly merge them.
+
+Concatenating two independently-sorted maps is not globally sorted, but it is
+deterministic and injective over the union -- which is what grouping correctness
+needs. The two key sets are disjoint: resource versus datapoint.
+
+Note this does NOT emit _observe_hash_metric, the metric-NAME hash. That one
+must be bit-identical to a literal the query compiler inlines at compile time,
+and the exporter normalizes metric names at export time -- after every processor
+runs -- so OTTL only ever sees the pre-normalization name. Compute it in the
+writer, over the metric string actually being written.
+*/ -}}
+{{- define "config.processors.transform.observe_metric_hashes" -}}
+transform/metric_hashes:
+  error_mode: ignore
+  metric_statements:
+    - context: datapoint
+      statements:
+        - set(attributes["observe_labels_hash"], Substring(XXH128(Concat([ToKeyValueString(resource.attributes, "=", ",", true), ToKeyValueString(attributes, "=", ",", true)], "|")), 0, 31))
+{{- end -}}

--- a/charts/agent/templates/_config-processors.tpl
+++ b/charts/agent/templates/_config-processors.tpl
@@ -474,46 +474,17 @@ Parameters (passed via dict):
 Hash processors for EXTERNAL-WRITE Iceberg source tables.
 
 Observe's source tables carry hidden hash columns that the ingest transformer
-normally computes: _observe_hash126_11identifiers on a k8sEntity table and
-_observe_hash126_6labels on a prometheus table. The query optimizer SUBSTITUTES
-`group by <object>` with the stored hash rather than recomputing it, so the
-column must be populated for that optimization to be correct.
+normally computes. A writer using external write (bypassing ingest) has to supply those hashes itself.
 
-A writer that appends to such a table directly -- bypassing ingest -- therefore
-has to supply those hashes itself, and the collector is the only place that sees
-the data before it is written. Neither processor is needed on the normal ingest
-path, where the transformer fills the columns.
+These hash need not match Observe's own algorithm, so long as the two algorithms do not mix in the same dataset.
+Values are 31 hex digits (124 bits) rather than the full 32 because the underlying dataset column is
+decimal(38,0), i.e. non-negative integers, max ~1.0e38.
 
-Neither is wired into any pipeline by this chart. Add the one you need to the
-relevant pipeline's `processors` list through an agent.config.<workload>
-override, and note the ordering constraints on each below.
-
-The hash need not match Observe's own algorithm; the optimizer trusts whatever
-is stored. It must only be a deterministic function of the same input, and the
-dataset must never mix external and internal writes -- two rows with equal
-identifiers would otherwise carry different hashes and silently fail to group.
-
-Values are 31 hex digits (124 bits) rather than the full 32. The column is
-decimal(38,0), max ~1.0e38, while a full XXH128 reaches ~3.4e38, so roughly
-two thirds of digests would overflow it. The consumer converts hex to decimal.
+These processors must be after any modifications to the fields they hash are made.
 */ -}}
 
 {{- /*
 _observe_hash126_11identifiers, for a k8sEntity source table.
-
-MUST be placed LAST in the pipeline. observek8sattributes and transform/object
-are what populate observe_transform.identifiers, so hashing any earlier digests
-an empty or partial map.
-
-ToKeyValueString's 4th argument sorts the keys, which is what makes this
-deterministic: identifiers is a map and map order is not stable across records
-or agent versions. It serializes keys AND values, so two entities of the same
-kind hash differently -- hashing sorted keys alone would collapse every Pod onto
-one hash.
-
-Emitted as a sibling attribute, deliberately NOT inside
-observe_transform.identifiers: writing it there would mutate the very map being
-hashed, and would also leak the hash into the identifiers column.
 */ -}}
 {{- define "config.processors.transform.observe_identifiers_hash" -}}
 transform/identifiers_hash:
@@ -527,28 +498,10 @@ transform/identifiers_hash:
 {{- /*
 _observe_hash126_6labels, for a prometheus source table.
 
-Ordering is load-bearing twice over:
-
-  1. This must be the ONLY datapoint attribute the pipeline sets after it. The
-     prometheusremotewrite exporter turns datapoint attributes into labels, so
-     any attribute set afterwards lands inside the very label map this hash
-     describes, desynchronizing the two.
-
-  2. It must cover resource attributes as well as datapoint attributes, because
-     the exporter's resource_to_telemetry_conversion folds resource attributes
-     into labels AFTER this processor runs. Hashing datapoint attributes alone
-     would give two series differing only by k8s.pod.name the same hash, and
-     `group by labels` would wrongly merge them.
-
-Concatenating two independently-sorted maps is not globally sorted, but it is
-deterministic and injective over the union -- which is what grouping correctness
-needs. The two key sets are disjoint: resource versus datapoint.
-
-Note this does NOT emit _observe_hash_metric, the metric-NAME hash. That one
+This does NOT emit _observe_hash_metric, the metric-NAME hash. That hash
 must be bit-identical to a literal the query compiler inlines at compile time,
-and the exporter normalizes metric names at export time -- after every processor
-runs -- so OTTL only ever sees the pre-normalization name. Compute it in the
-writer, over the metric string actually being written.
+and the exporter converts metric names to prometheus format, after every processor
+runs. That hash should be calculated in the ingest pipeline itself.
 */ -}}
 {{- define "config.processors.transform.observe_metric_hashes" -}}
 transform/metric_hashes:

--- a/charts/agent/templates/_fargate-sidecar-config.tpl
+++ b/charts/agent/templates/_fargate-sidecar-config.tpl
@@ -70,6 +70,10 @@ processors:
 {{- include "config.processors.metricstransform.duplicate_k8s_cpu_metrics" . | nindent 2 }}
 {{- include "config.processors.attributes.sidecar_kubeletstats_metrics" . | nindent 2 }}
 
+{{- if .Values.agent.config.global.externalWriteHashes.enabled }}
+{{- include "config.processors.transform.observe_metric_hashes" . | nindent 2 }}
+{{- end }}
+
 # logs specific processors
 {{- include "config.processors.resource.fargate_resource_attributes" . | nindent 2 }}
 {{- include "config.processors.attributes.fargate_pod_logs" . | nindent 2 }}
@@ -100,7 +104,7 @@ service:
     {{- if .Values.nodeless.metrics.enabled }}
     metrics/kubeletstats:
       receivers: [kubeletstats]
-      processors: [memory_limiter, metricstransform/duplicate_k8s_cpu_metrics, k8sattributes, deltatocumulative/observe, batch, resourcedetection/cloud, resource/observe_common, attributes/debug_source_sidecar_kubeletstats_metrics]
+      processors: [memory_limiter, metricstransform/duplicate_k8s_cpu_metrics, k8sattributes, deltatocumulative/observe, batch, resourcedetection/cloud, resource/observe_common, attributes/debug_source_sidecar_kubeletstats_metrics{{- if .Values.agent.config.global.externalWriteHashes.enabled -}}, transform/metric_hashes{{- end -}}]
       exporters: [{{ join ", " $kubeletstatsExporters }}]
 
     {{- end }}

--- a/charts/agent/templates/_forwarder-config.tpl
+++ b/charts/agent/templates/_forwarder-config.tpl
@@ -113,6 +113,10 @@ processors:
 {{- include "config.processors.transform.k8sheartbeat" . | nindent 2 }}
 {{- end }}
 
+{{- if and .Values.agent.config.global.externalWriteHashes.enabled (eq .Values.node.forwarder.metrics.outputFormat "prometheus") }}
+{{- include "config.processors.transform.observe_metric_hashes" . | nindent 2 }}
+{{- end }}
+
 {{- $traceExporters := (list) -}}
 {{- $logsExporters := (list) -}}
 {{- $metricsExporters := (list) -}}
@@ -172,6 +176,10 @@ processors:
     {{- $metricsProcessors = concat $metricsProcessors (list "transform/deployment_environment_compatability") }}
   {{- end }}
   {{- $metricsProcessors = concat $metricsProcessors (list "attributes/debug_source_app_metrics") }}
+{{- end }}
+
+{{- if and .Values.agent.config.global.externalWriteHashes.enabled (eq .Values.node.forwarder.metrics.outputFormat "prometheus") }}
+  {{- $metricsProcessors = concat $metricsProcessors (list "transform/metric_hashes") }}
 {{- end }}
 
 service:

--- a/charts/agent/templates/_gateway-config.tpl
+++ b/charts/agent/templates/_gateway-config.tpl
@@ -59,6 +59,10 @@ processors:
 {{- include "config.processors.transform.k8sheartbeat" . | nindent 2 }}
 {{- end }}
 
+{{- if and .Values.agent.config.global.externalWriteHashes.enabled (eq .Values.node.forwarder.metrics.outputFormat "prometheus") }}
+{{- include "config.processors.transform.observe_metric_hashes" . | nindent 2 }}
+{{- end }}
+
   attributes/debug_source_gateway:
     actions:
     - action: upsert
@@ -140,6 +144,9 @@ service:
         - transform/deployment_environment_compatability
         {{- end }}
         - attributes/debug_source_gateway
+        {{- if and .Values.agent.config.global.externalWriteHashes.enabled (eq .Values.node.forwarder.metrics.outputFormat "prometheus") }}
+        - transform/metric_hashes
+        {{- end }}
       exporters: [{{ join ", " $metricsExporters }}]
     {{- if .Values.application.REDMetrics.enabled }}
     {{- include "config.pipelines.RED_metrics" . | nindent 4 }}

--- a/charts/agent/templates/_monitor-config.tpl
+++ b/charts/agent/templates/_monitor-config.tpl
@@ -72,6 +72,10 @@ processors:
 {{- include "config.processors.transform.k8sheartbeat" . | nindent 2 }}
 {{- end }}
 
+{{- if .Values.agent.config.global.externalWriteHashes.enabled }}
+{{- include "config.processors.transform.observe_metric_hashes" . | nindent 2 }}
+{{- end }}
+
   # attributes to append to objects
   attributes/debug_source_agent_monitor:
     actions:
@@ -99,6 +103,9 @@ service:
           {{- end }}
           - resource/observe_common
           - attributes/debug_source_agent_monitor
+          {{- if .Values.agent.config.global.externalWriteHashes.enabled }}
+          - transform/metric_hashes
+          {{- end }}
         exporters: [{{ join ", " $metricsExporters }}]
 
       {{- if .Values.agent.config.global.fleet.enabled }}

--- a/charts/agent/templates/_node-logs-metrics-config.tpl
+++ b/charts/agent/templates/_node-logs-metrics-config.tpl
@@ -129,6 +129,10 @@ processors:
 {{- include "config.processors.transform.k8sheartbeat" . | nindent 2 }}
 {{- end }}
 
+{{- if .Values.agent.config.global.externalWriteHashes.enabled }}
+{{- include "config.processors.transform.observe_metric_hashes" . | nindent 2 }}
+{{- end }}
+
   # attributes to append to objects
   attributes/debug_source_pod_logs:
     actions:
@@ -187,6 +191,9 @@ service:
           - resource/node_name
           - resource/observe_common
           - attributes/debug_source_hostmetrics
+          {{- if .Values.agent.config.global.externalWriteHashes.enabled }}
+          - transform/metric_hashes
+          {{- end }}
         exporters: [{{ join ", " $hostmetricsExporters }}]
       {{- end -}}
       {{- if .Values.node.containers.metrics.enabled }}
@@ -202,6 +209,9 @@ service:
           - resourcedetection/cloud
           - resource/observe_common
           - attributes/debug_source_kubeletstats_metrics
+          {{- if .Values.agent.config.global.externalWriteHashes.enabled }}
+          - transform/metric_hashes
+          {{- end }}
         exporters: [{{ join ", " $kubeletstatsExporters }}]
       {{- end -}}
 

--- a/charts/agent/templates/_prometheus-scraper-config.tpl
+++ b/charts/agent/templates/_prometheus-scraper-config.tpl
@@ -54,6 +54,10 @@ processors:
 {{- include "config.processors.transform.k8sheartbeat" . | nindent 2 }}
 {{- end }}
 
+{{- if and .Values.agent.config.global.externalWriteHashes.enabled (eq .Values.application.prometheusScrape.enabled true) }}
+{{- include "config.processors.transform.observe_metric_hashes" . | nindent 2 }}
+{{- end }}
+
 service:
   pipelines:
     {{- if eq .Values.application.prometheusScrape.enabled true }}

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -349,6 +349,13 @@ agent:
         enabled: false
         interval: 10m
         configInterval: 24h
+      # -- Compute hash columns in the collector for external-write Iceberg source tables.
+      # When true, appends transform/identifiers_hash to the K8s objects pipeline and
+      # transform/metric_hashes to every pipeline that exports to prometheusremotewrite/observe.
+      # Only needed when a downstream writer appends to an Observe-schema Iceberg table
+      # directly (bypassing ingest). Leave false on the standard ingest path.
+      externalWriteHashes:
+        enabled: false
       # -- Additional OTel collector config for all agent deployments/daemonsets
       overrides:
 


### PR DESCRIPTION
Observe source tables carry hidden hash columns that the ingest transformer normally computes: `_observe_hash126_11identifiers` on a k8sEntity table and `_observe_hash126_6labels` on a prometheus table. The query optimizer substitutes `group by <object>` with the stored hash rather than recomputing it, so a writer that appends to such a table directly -- bypassing ingest -- must supply the hashes itself, and the collector is the only place that sees the data first.

## Processor definitions

Adds two processors in `charts/agent/templates/_config-processors.tpl`:

- `transform/identifiers_hash` — hashes `attributes["observe_transform"]["identifiers"]` for K8sEntity rows. Must run last in the pipeline (after `observek8sattributes` + `transform/object` populate the map).
- `transform/metric_hashes` — hashes the union of datapoint attributes and resource attributes for Prometheus rows. Must be the last datapoint-attribute-setting processor before the exporter, and must include resource attributes because `resource_to_telemetry_conversion` promotes them to labels after this processor runs.

Both use `XXH128` truncated to 31 hex chars (124 bits) because the underlying storage column is `decimal(38,0)` (max ~1.0e38); a full 128-bit digest would overflow ~2/3 of the time. The consumer converts hex to decimal at write time.

The hashes need not be bit-identical to Observe's own algorithm — the optimizer trusts whatever is stored — but the algorithm must be deterministic and the dataset must never mix external and internal writes.

## Wiring

Adds `agent.config.global.externalWriteHashes.enabled` (default `false`). When enabled:

- **`transform/identifiers_hash`** appended to the `logs/objects` pipeline in `_cluster-events-config.tpl`.
- **`transform/metric_hashes`** appended to every pipeline that exports to `prometheusremotewrite/observe`:
  - `_cluster-metrics-config.tpl` (metrics pipeline)
  - `_config-pipelines.tpl` (k8s_metrics / pod_metrics / cadvisor)
  - `_node-logs-metrics-config.tpl` (hostmetrics, kubeletstats)
  - `_gateway-config.tpl` (metrics/observe-forward, gated on `outputFormat == prometheus`)
  - `_forwarder-config.tpl` (metrics/observe-forward, gated on `outputFormat == prometheus`)
  - `_monitor-config.tpl` (metrics pipeline)
  - `_prometheus-scraper-config.tpl` (gated on `prometheusScrape.enabled`)
  - `_fargate-sidecar-config.tpl` (metrics/kubeletstats)

Default `false` means rendered output is unchanged on the standard ingest path; users on external-write Iceberg flip the flag once and both hashes are wired everywhere they need to be.

## Example + render-diff coverage

New example `charts/agent/examples/external-write-hashes/` turns the flag on. Its rendered output is checked in, so any future PR that breaks the wiring will surface as a diff in `make generate-examples`.

Note: does not emit `_observe_hash_metric` (the metric-name hash). That one has to be bit-identical to a literal the query compiler inlines at compile time, and the exporter normalizes metric names after every processor runs, so OTTL only ever sees the pre-normalization name. Compute it in the writer, over the metric string actually being written.

Refs: OB-62148